### PR TITLE
Fix Mac build script

### DIFF
--- a/GVFS/GVFS.Installer.Mac/vfsforgit_components.plist
+++ b/GVFS/GVFS.Installer.Mac/vfsforgit_components.plist
@@ -14,13 +14,5 @@
 		<key>RootRelativeBundlePath</key>
 		<string>Library/Application Support/VFS For Git/VFS For Git.app</string>
 	</dict>
-	<dict>
-		<key>BundleIsVersionChecked</key>
-		<true/>
-		<key>BundleOverwriteAction</key>
-		<string>upgrade</string>
-		<key>RootRelativeBundlePath</key>
-		<string>Library/Extensions/PrjFSKext.kext</string>
-	</dict>
 </array>
 </plist>

--- a/Scripts/Mac/BuildGVFSForMac.sh
+++ b/Scripts/Mac/BuildGVFSForMac.sh
@@ -78,8 +78,6 @@ fi
 
 echo 'Copying native binaries to Publish directory...'
 cp $VFS_OUTPUTDIR/GVFS.Native.Mac/Build/Products/$CONFIGURATION/GVFS.ReadObjectHook $VFS_PUBLISHDIR || exit 1
-cp $VFS_OUTPUTDIR/GVFS.Native.Mac/Build/Products/$CONFIGURATION/GVFS.VirtualFileSystemHook $VFS_PUBLISHDIR || exit 1
-cp $VFS_OUTPUTDIR/GVFS.Native.Mac/Build/Products/$CONFIGURATION/GVFS.PostIndexChangedHook $VFS_PUBLISHDIR || exit 1
 
 # Publish after native build, so installer package can include the native binaries.
 dotnet publish $VFS_SRCDIR/GVFS.sln /p:Configuration=$CONFIGURATION.Mac /p:Platform=x64 -p:CopyPrjFS=true --runtime osx-x64 --framework netcoreapp2.1 --self-contained --output $VFS_PUBLISHDIR /maxcpucount:1 /warnasmessage:MSB4011 || exit 1


### PR DESCRIPTION
With this change the Mac build succeeds and unit tests pass (using `./Scripts/Mac/BuildGVFSForMac.sh`)