### PR TITLE
Remove --no-mount and --no-prefetch from GVFS_Clone.sh

### DIFF
--- a/Scripts/Mac/GVFS_Clone.sh
+++ b/Scripts/Mac/GVFS_Clone.sh
@@ -8,4 +8,4 @@ if [ -z $CONFIGURATION ]; then
   CONFIGURATION=Debug
 fi
 
-$VFS_PUBLISHDIR/gvfs clone $REPOURL ~/GVFSTest --local-cache-path ~/GVFSTest/.gvfsCache --no-mount --no-prefetch
+$VFS_PUBLISHDIR/gvfs clone $REPOURL ~/GVFSTest --local-cache-path ~/GVFSTest/.gvfsCache


### PR DESCRIPTION
If `--no-mount` is passed in the `clone` verb won't be able to download the objects it needs (see #26) 