### PR TITLE
Move ReadObjectHook to target RS5 SDK

### DIFF
--- a/Scalar.ReadObjectHook/Scalar.ReadObjectHook.Windows.vcxproj
+++ b/Scalar.ReadObjectHook/Scalar.ReadObjectHook.Windows.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{5A6656D5-81C7-472C-9DC8-32D071CB2258}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>readobject</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.10240.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
     <ProjectName>Scalar.ReadObjectHook.Windows</ProjectName>
     <TargetName>Scalar.ReadObjectHook</TargetName>
   </PropertyGroup>


### PR DESCRIPTION
I don't think we need to target RS1 any more. Let's make setting up developer boxes easier.