### PR TITLE
Add a global setup when using a --test= option

### DIFF
--- a/Scalar.FunctionalTests/Program.cs
+++ b/Scalar.FunctionalTests/Program.cs
@@ -15,6 +15,7 @@ namespace Scalar.FunctionalTests
         {
             Properties.Settings.Default.Initialize();
             NUnitRunner runner = new NUnitRunner(args);
+            runner.AddGlobalSetupIfNeeded("Scalar.FunctionalTests.GlobalSetup");
 
             if (runner.HasCustomArg("--no-shared-scalar-cache"))
             {

--- a/Scalar.Tests/NUnitRunner.cs
+++ b/Scalar.Tests/NUnitRunner.cs
@@ -33,6 +33,15 @@ namespace Scalar.Tests
             return this.args.Remove(arg);
         }
 
+        public void AddGlobalSetupIfNeeded(string globalSetup)
+        {
+            // If there are any test filters, the GlobalSetup still needs to run so add it.
+            if (this.args.Any(x => x.StartsWith("--test=")))
+            {
+                this.args.Add($"--test={globalSetup}");
+            }
+        }
+
         public int RunTests(ICollection<string> includeCategories, ICollection<string> excludeCategories)
         {
             string filters = GetFiltersArgument(includeCategories, excludeCategories);

--- a/Scalar.UnitTests/Program.cs
+++ b/Scalar.UnitTests/Program.cs
@@ -11,6 +11,7 @@ namespace Scalar.UnitTests
         public static void Main(string[] args)
         {
             NUnitRunner runner = new NUnitRunner(args);
+            runner.AddGlobalSetupIfNeeded("Scalar.UnitTests.Setup");
 
             List<string> excludeCategories = new List<string>();
 


### PR DESCRIPTION
When using the `--test=` option for filtering the tests that run, any global setup class also gets filtered out and does not run.

This change will add a global setup class to the tests if there is a `--test=` option passed.