### PR TITLE
CloneVerb: remove --no-mount option

### DIFF
--- a/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
+++ b/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
@@ -57,7 +57,7 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
             string newEnlistmentRoot = ScalarFunctionalTestEnlistment.GetUniqueEnlistmentRoot();
 
             ProcessStartInfo processInfo = new ProcessStartInfo(ScalarTestConfig.PathToScalar);
-            processInfo.Arguments = $"clone {Properties.Settings.Default.RepoToClone} {newEnlistmentRoot} --no-mount --no-prefetch";
+            processInfo.Arguments = $"clone {Properties.Settings.Default.RepoToClone} {newEnlistmentRoot} --no-prefetch";
             processInfo.WindowStyle = ProcessWindowStyle.Hidden;
             processInfo.CreateNoWindow = true;
             processInfo.UseShellExecute = false;

--- a/Scalar/CommandLine/CloneVerb.cs
+++ b/Scalar/CommandLine/CloneVerb.cs
@@ -55,13 +55,6 @@ namespace Scalar.CommandLine
         public bool SingleBranch { get; set; }
 
         [Option(
-            "no-mount",
-            Required = false,
-            Default = false,
-            HelpText = "Use this option to only clone, but not mount the repo")]
-        public bool NoMount { get; set; }
-
-        [Option(
             "no-prefetch",
             Required = false,
             Default = false,
@@ -137,7 +130,6 @@ namespace Scalar.CommandLine
                                 { "Branch", this.Branch },
                                 { "LocalCacheRoot", this.LocalCacheRoot },
                                 { "SingleBranch", this.SingleBranch },
-                                { "NoMount", this.NoMount },
                                 { "NoPrefetch", this.NoPrefetch },
                                 { "Unattended", this.Unattended },
                                 { "IsElevated", ScalarPlatform.Instance.IsElevated() },
@@ -223,23 +215,15 @@ namespace Scalar.CommandLine
                         }
                     }
 
-                    if (this.NoMount)
-                    {
-                        this.Output.WriteLine("\r\nIn order to mount, first cd to within your enlistment, then call: ");
-                        this.Output.WriteLine("scalar mount");
-                    }
-                    else
-                    {
-                        this.Execute<MountVerb>(
-                            enlistment,
-                            verb =>
-                            {
-                                verb.SkipMountedCheck = true;
-                                verb.SkipVersionCheck = true;
-                                verb.ResolvedCacheServer = cacheServer;
-                                verb.DownloadedScalarConfig = serverScalarConfig;
-                            });
-                    }
+                    this.Execute<MountVerb>(
+                        enlistment,
+                        verb =>
+                        {
+                            verb.SkipMountedCheck = true;
+                            verb.SkipVersionCheck = true;
+                            verb.ResolvedCacheServer = cacheServer;
+                            verb.DownloadedScalarConfig = serverScalarConfig;
+                        });
 
                     GitProcess git = new GitProcess(enlistment);
                     git.ForceCheckoutAllFiles();


### PR DESCRIPTION
Long term, we will not have a mount, so this feature will
eventually be meaningless. In the meantime, it is only causing
possible problems with hydrating files.

Resolves #26 permanently. In a normal clone, we already resolved
it in #56 by prefetching all files on clone. However, we still
dynamically prefetch on a sparse clone (#54).