### PR TITLE
Add SparseVerb --add

### DIFF
--- a/Scalar.Common/Git/GitProcess.cs
+++ b/Scalar.Common/Git/GitProcess.cs
@@ -421,6 +421,21 @@ namespace Scalar.Common.Git
             return this.InvokeGitInWorkingDirectoryRoot("checkout HEAD -- .", useReadObjectHook: true);
         }
 
+        public Result SparseCheckout(List<string> foldersToAdd)
+        {
+            return this.InvokeGitInWorkingDirectoryRoot(
+                $"sparse-checkout add",
+                useReadObjectHook: true,
+                writeStdIn: writer =>
+                {
+                    foreach (string path in foldersToAdd)
+                    {
+                        string normalizedPath = path.Replace(Path.DirectorySeparatorChar, ScalarConstants.GitPathSeparator).TrimEnd(ScalarConstants.GitPathSeparator);
+                        writer.Write(normalizedPath + "\n");
+                    }
+                });
+        }
+
         public Result Status(bool allowObjectDownloads, bool useStatusCache, bool showUntracked = false)
         {
             string command = "status";

--- a/Scalar/CommandLine/PrefetchVerb.cs
+++ b/Scalar/CommandLine/PrefetchVerb.cs
@@ -27,6 +27,8 @@ namespace Scalar.CommandLine
         private static readonly int DownloadThreadCount = Environment.ProcessorCount;
         private static readonly int IndexThreadCount = Environment.ProcessorCount;
 
+        private List<string> parsedFoldersList;
+
         [Option(
             "files",
             Required = false,
@@ -94,6 +96,11 @@ namespace Scalar.CommandLine
         public bool SkipVersionCheck { get; set; }
         public CacheServerInfo ResolvedCacheServer { get; set; }
         public ServerScalarConfig ServerScalarConfig { get; set; }
+
+        public List<string> ParsedFoldersList
+        {
+            get { return this.parsedFoldersList; }
+        }
 
         protected override string VerbName
         {
@@ -164,12 +171,11 @@ namespace Scalar.CommandLine
                     {
                         string headCommitId;
                         List<string> filesList;
-                        List<string> foldersList;
                         FileBasedDictionary<string, string> lastPrefetchArgs;
 
-                        this.LoadBlobPrefetchArgs(tracer, enlistment, out headCommitId, out filesList, out foldersList, out lastPrefetchArgs);
+                        this.LoadBlobPrefetchArgs(tracer, enlistment, out headCommitId, out filesList, out this.parsedFoldersList, out lastPrefetchArgs);
 
-                        if (BlobPrefetcher.IsNoopPrefetch(tracer, lastPrefetchArgs, headCommitId, filesList, foldersList, this.HydrateFiles))
+                        if (BlobPrefetcher.IsNoopPrefetch(tracer, lastPrefetchArgs, headCommitId, filesList, this.parsedFoldersList, this.HydrateFiles))
                         {
                             Console.WriteLine("All requested files are already available. Nothing new to prefetch.");
                         }
@@ -183,7 +189,7 @@ namespace Scalar.CommandLine
                                 cacheServerUrl,
                                 out objectRequestor,
                                 out cacheServer);
-                            this.PrefetchBlobs(tracer, enlistment, headCommitId, filesList, foldersList, lastPrefetchArgs, objectRequestor, cacheServer);
+                            this.PrefetchBlobs(tracer, enlistment, headCommitId, filesList, this.parsedFoldersList, lastPrefetchArgs, objectRequestor, cacheServer);
                         }
                     }
                 }

--- a/Scalar/CommandLine/ScalarVerb.cs
+++ b/Scalar/CommandLine/ScalarVerb.cs
@@ -199,7 +199,8 @@ namespace Scalar.CommandLine
 
         protected ReturnCode Execute<TVerb>(
             ScalarEnlistment enlistment,
-            Action<TVerb> configureVerb = null)
+            Action<TVerb> configureVerb = null,
+            Action<TVerb> postExecuteVerb = null)
             where TVerb : ScalarVerb.ForExistingEnlistment, new()
         {
             TVerb verb = new TVerb();
@@ -218,6 +219,11 @@ namespace Scalar.CommandLine
             }
             catch (VerbAbortedException)
             {
+            }
+
+            if (postExecuteVerb != null)
+            {
+                postExecuteVerb(verb);
             }
 
             return verb.ReturnCode;

--- a/Scalar/CommandLine/SparseVerb.cs
+++ b/Scalar/CommandLine/SparseVerb.cs
@@ -1,0 +1,128 @@
+﻿using CommandLine;
+using Scalar.Common;
+using Scalar.Common.Git;
+using Scalar.Common.Http;
+using Scalar.Common.Tracing;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Scalar.CommandLine
+{
+    [Verb(
+        SparseVerb.SparseVerbName,
+        HelpText = @"Add to the list of folders that are included in git's sparse-checkout.
+Folders need to be relative to the repo's root directory.")
+    ]
+    public class SparseVerb : ScalarVerb.ForExistingEnlistment
+    {
+        private const string SparseVerbName = "sparse";
+        private const string FolderListSeparator = ";";
+
+        [Option(
+            'a',
+            "add",
+            Required = false,
+            Default = "",
+            HelpText = "A semicolon-delimited list of repo root relative folders to include in the sparse-checkout. Wildcards are not supported.")]
+        public string FoldersToAdd { get; set; }
+
+        [Option(
+            "add-stdin",
+            Required = false,
+            Default = false,
+            HelpText = "Specify this flag to load folder list from stdin. Folders must be line-delimited and wildcards are not supported.")]
+        public bool AddFromStdIn { get; set; }
+
+        protected override string VerbName => SparseVerbName;
+
+        protected override void Execute(ScalarEnlistment enlistment)
+        {
+            using (JsonTracer tracer = new JsonTracer(ScalarConstants.ScalarEtwProviderName, SparseVerbName))
+            {
+                try
+                {
+                    CacheServerInfo cacheServer = CacheServerResolver.GetCacheServerFromConfig(enlistment);
+
+                    tracer.AddLogFileEventListener(
+                        ScalarEnlistment.GetNewScalarLogFileName(enlistment.ScalarLogsRoot, ScalarConstants.LogFileTypes.Sparse),
+                        EventLevel.Informational,
+                        Keywords.Any);
+                    tracer.WriteStartEvent(
+                            enlistment.EnlistmentRoot,
+                            enlistment.RepoUrl,
+                            cacheServer.Url,
+                            new EventMetadata
+                            {
+                                { "Unattended", this.Unattended },
+                                { "IsElevated", ScalarPlatform.Instance.IsElevated() },
+                                { "NamedPipeName", enlistment.NamedPipeName },
+                                { "ProcessID", Process.GetCurrentProcess().Id },
+                                { nameof(this.EnlistmentRootPathParameter), this.EnlistmentRootPathParameter },
+                                { nameof(this.FoldersToAdd), this.FoldersToAdd },
+                                { nameof(this.AddFromStdIn), this.AddFromStdIn },
+                            });
+
+                    if (!this.AddFromStdIn && string.IsNullOrWhiteSpace(this.FoldersToAdd))
+                    {
+                        this.ReportErrorAndExit(tracer, "You must specify folders to add with --add or --add-stdin");
+                    }
+
+                    List<string> foldersToAdd = null;
+
+                    // Pre-fetch the blobs for the folders that will be added and
+                    // rely on PrefetchVerb for parsing the the list of folders
+                    ReturnCode result = this.Execute<PrefetchVerb>(
+                            enlistment,
+                            verb =>
+                            {
+                                verb.Commits = false;
+                                verb.ResolvedCacheServer = cacheServer;
+                                verb.SkipVersionCheck = false;
+                                verb.Files = string.Empty;
+                                verb.Folders = this.FoldersToAdd;
+                                verb.FoldersFromStdIn = this.AddFromStdIn;
+                            },
+                            verb =>
+                            {
+                                foldersToAdd = verb.ParsedFoldersList;
+                            });
+
+                    if (result != ReturnCode.Success)
+                    {
+                        this.ReportErrorAndExit(tracer, "\r\nError during prefetch @ {0}", enlistment.EnlistmentRoot);
+                    }
+
+                    this.SparseCheckoutAdd(tracer, enlistment, foldersToAdd);
+                }
+                catch (Exception e)
+                {
+                    this.ReportErrorAndExit(tracer, "Failed to add folders to sparse-checkout {0}", e.Message);
+                }
+            }
+        }
+
+        private void SparseCheckoutAdd(ITracer tracer, ScalarEnlistment enlistment, List<string> foldersToAdd)
+        {
+            GitProcess git = new GitProcess(enlistment);
+            GitProcess.Result sparseResult = git.SparseCheckout(foldersToAdd);
+
+            if (sparseResult.ExitCodeIsFailure)
+            {
+                this.WriteMessage(tracer, $"Failed to add folders to sparse-checkout: {sparseResult.Errors}");
+            }
+        }
+
+        private void WriteMessage(ITracer tracer, string message)
+        {
+            this.Output.WriteLine(message);
+            tracer.RelatedEvent(
+                EventLevel.Informational,
+                SparseVerbName,
+                new EventMetadata
+                {
+                    { TracingConstants.MessageKey.InfoMessage, message }
+                });
+        }
+    }
+}

--- a/Scalar/Program.cs
+++ b/Scalar/Program.cs
@@ -22,6 +22,7 @@ namespace Scalar
                 typeof(DehydrateVerb),
                 typeof(DiagnoseVerb),
                 typeof(LogVerb),
+                typeof(SparseVerb),
                 typeof(MountVerb),
                 typeof(PrefetchVerb),
                 typeof(RepairVerb),

--- a/Scalar/Scalar.Windows.csproj
+++ b/Scalar/Scalar.Windows.csproj
@@ -116,6 +116,7 @@
     <Compile Include="CommandLine\DehydrateVerb.cs" />
     <Compile Include="CommandLine\DiagnoseVerb.cs" />
     <Compile Include="CommandLine\ScalarVerb.cs" />
+    <Compile Include="CommandLine\SparseVerb.cs" />
     <Compile Include="CommandLine\LogVerb.cs" />
     <Compile Include="CommandLine\MountVerb.cs" />
     <Compile Include="CommandLine\PrefetchVerb.cs" />


### PR DESCRIPTION
Resolves #76 

- Added `SparseVerb` to Scalar
- `SparseVerb` supports adding folders to the sparse-checkout with `--add` and `--add-stdin`
- `SparseVerb` add prefetches the requested folders before calling `git sparse-checkout add` with the specified folders

**TODO**
- [X] Wire-up a call to `git sparse-checkout add`
- [X] Add support for providing folders over stdin