### PR TITLE
Use untracked cache by default

### DIFF
--- a/Scalar/CommandLine/ScalarVerb.cs
+++ b/Scalar/CommandLine/ScalarVerb.cs
@@ -117,7 +117,7 @@ namespace Scalar.CommandLine
                 { "core.multiPackIndex", "true" },
                 { "core.preloadIndex", "true" },
                 { "core.safecrlf", "false" },
-                { "core.untrackedCache", "false" },
+                { "core.untrackedCache", "true" },
                 { "core.repositoryformatversion", "0" },
                 { "core.filemode", ScalarPlatform.Instance.FileSystem.SupportsFileMode ? "true" : "false" },
                 { GitConfigSetting.CoreVirtualizeObjectsName, "true" },


### PR DESCRIPTION
The untracked cache can help `git status` times by avoiding a directory crawl for untracked files. This can be upwards of 20 seconds in the target enlistment. With this enabled, 1.5s `git status` is possible. Maybe it won't happen every time, but it is possible.