### PR TITLE
UntrackedCache: enable based on platform

### DIFF
--- a/Scalar.Common/FileSystem/IPlatformFileSystem.cs
+++ b/Scalar.Common/FileSystem/IPlatformFileSystem.cs
@@ -5,6 +5,7 @@ namespace Scalar.Common.FileSystem
     public interface IPlatformFileSystem
     {
         bool SupportsFileMode { get; }
+        bool SupportsUntrackedCache { get; }
         void FlushFileBuffers(string path);
         void MoveAndOverwriteFile(string sourceFileName, string destinationFilename);
         bool TryGetNormalizedPath(string path, out string normalizedPath, out string errorMessage);

--- a/Scalar.Platform.POSIX/POSIXFileSystem.cs
+++ b/Scalar.Platform.POSIX/POSIXFileSystem.cs
@@ -28,6 +28,8 @@ namespace Scalar.Platform.POSIX
 
         public bool SupportsFileMode { get; } = true;
 
+        public bool SupportsUntrackedCache { get; } = true;
+
         public void FlushFileBuffers(string path)
         {
             // TODO(#1057): Use native API to flush file

--- a/Scalar.Platform.Windows/WindowsFileSystem.cs
+++ b/Scalar.Platform.Windows/WindowsFileSystem.cs
@@ -14,6 +14,8 @@ namespace Scalar.Platform.Windows
     {
         public bool SupportsFileMode { get; } = false;
 
+        public bool SupportsUntrackedCache { get; } = false;
+
         /// <summary>
         /// Adds a new FileSystemAccessRule granting read (and optionally modify) access for all users.
         /// </summary>

--- a/Scalar.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
+++ b/Scalar.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
@@ -8,6 +8,8 @@ namespace Scalar.UnitTests.Mock.FileSystem
     {
         public bool SupportsFileMode { get; } = true;
 
+        public bool SupportsUntrackedCache { get; } = true;
+
         public void FlushFileBuffers(string path)
         {
             throw new NotSupportedException();

--- a/Scalar/CommandLine/ScalarVerb.cs
+++ b/Scalar/CommandLine/ScalarVerb.cs
@@ -117,7 +117,7 @@ namespace Scalar.CommandLine
                 { "core.multiPackIndex", "true" },
                 { "core.preloadIndex", "true" },
                 { "core.safecrlf", "false" },
-                { "core.untrackedCache", "false" },
+                { "core.untrackedCache", ScalarPlatform.Instance.FileSystem.SupportsUntrackedCache ? "true" : "false" },
                 { "core.repositoryformatversion", "0" },
                 { "core.filemode", ScalarPlatform.Instance.FileSystem.SupportsFileMode ? "true" : "false" },
                 { GitConfigSetting.CoreVirtualizeObjectsName, "true" },


### PR DESCRIPTION
While adding functional tests in #77, I noticed that functional tests on Windows were failing due to the untracked cache. I was unable to repro them when paused in the debugger, so it must be something wrong with however Git detects changes to the filesystem using timestamps.

For now, re-enable the untracked cache on non-Windows platforms. Since it is related to the filesystem, I put the constant there.