### PR TITLE
Scalar Clone: configure watchman integration

### DIFF
--- a/Scalar.Common/ScalarConstants.cs
+++ b/Scalar.Common/ScalarConstants.cs
@@ -144,8 +144,13 @@ namespace Scalar.Common
             public static class Hooks
             {
                 public const string ReadObjectName = "read-object";
+                public const string QueryWatchmanName = "query-watchman";
+                public const string FsMonitorWatchmanSampleName = "fsmonitor-watchman.sample";
+
                 public static readonly string Root = Path.Combine(DotGit.Root, "hooks");
                 public static readonly string ReadObjectPath = Path.Combine(Hooks.Root, ReadObjectName);
+                public static readonly string QueryWatchmanPath = Path.Combine(Hooks.Root, QueryWatchmanName);
+                public static readonly string FsMonitorWatchmanSamplePath = Path.Combine(Hooks.Root, FsMonitorWatchmanSampleName);
             }
 
             public static class Info


### PR DESCRIPTION
If Watchman is installed, configure Watchman integration during Scalar clone.
If Watchman is not available, or there is an error configuring it, then notify
user but do not fail installation.

Example output - success:

```
Cloning...Succeeded
Fetching commits and trees from cache server...Succeeded
Configuring Watchman...Succeeded.
Validating repo...Succeeded
Mounting...Succeeded
Registering for automount...Succeeded
```

Example output - Watchman not installed:

```
Cloning...Succeeded
Fetching commits and trees from cache server...Succeeded
Configuring Watchman...Skipping: Watchman not installed.
Validating repo...Succeeded
Mounting...Succeeded
Registering for automount...Succeeded
```

Resolves #83 