### PR TITLE
Replace GVFS with Scalar in ReadObjectHook

### DIFF
--- a/Scalar.Build/GenerateVersionInfo.cs
+++ b/Scalar.Build/GenerateVersionInfo.cs
@@ -39,10 +39,10 @@ namespace Scalar.PreBuild
                 this.VersionHeader,
                 string.Format(
 @"
-#define GVFS_FILE_VERSION {0}
-#define GVFS_FILE_VERSION_STRING ""{1}""
-#define GVFS_PRODUCT_VERSION {0}
-#define GVFS_PRODUCT_VERSION_STRING ""{1}""
+#define SCALAR_FILE_VERSION {0}
+#define SCALAR_FILE_VERSION_STRING ""{1}""
+#define SCALAR_PRODUCT_VERSION {0}
+#define SCALAR_PRODUCT_VERSION_STRING ""{1}""
 ",
                     commaDelimetedVersion,
                     this.Version));

--- a/Scalar.ReadObjectHook/Version.rc
+++ b/Scalar.ReadObjectHook/Version.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION GVFS_FILE_VERSION
- PRODUCTVERSION GVFS_PRODUCT_VERSION
+ FILEVERSION SCALAR_FILE_VERSION
+ PRODUCTVERSION SCALAR_PRODUCT_VERSION
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -68,13 +68,13 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "CompanyName", "Microsoft"
-            VALUE "FileDescription", "GVFS.ReadObjectHook"
-            VALUE "FileVersion", GVFS_FILE_VERSION_STRING
-            VALUE "InternalName", "GVFS.ReadObjectHook.exe"
+            VALUE "FileDescription", "Scalar.ReadObjectHook"
+            VALUE "FileVersion", SCALAR_FILE_VERSION_STRING
+            VALUE "InternalName", "Scalar.ReadObjectHook.exe"
             VALUE "LegalCopyright", "Copyright (c) Microsoft 2019"
-            VALUE "OriginalFilename", "GVFS.ReadObjectHook.exe"
-            VALUE "ProductName", "GVFS.ReadObjectHook"
-            VALUE "ProductVersion", GVFS_PRODUCT_VERSION_STRING
+            VALUE "OriginalFilename", "Scalar.ReadObjectHook.exe"
+            VALUE "ProductName", "Scalar.ReadObjectHook"
+            VALUE "ProductVersion", SCALAR_PRODUCT_VERSION_STRING
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
More fallout from #22. The script to replace GVFS with Scalar didn't catch the `.rc` file, so it had trouble on these version strings. I found this is affecting how the read object hook appears in Task Manager.