### PR TITLE
[Ported from VFSForGit] Fix mac installer/upgrader failure

### DIFF
--- a/Scalar.Installer.Mac/scripts/postinstall
+++ b/Scalar.Installer.Mac/scripts/postinstall
@@ -30,7 +30,7 @@ declare -a launchAgents=(
     "org.scalar.usernotification"
     "org.scalar.service"
 )
-for uid in $(ps -Ac -o uid,command | grep -iw "loginwindow" | awk '{print $1}'); do
+for uid in $(ps -Ac -o uid,command | grep -iw "Finder" | awk '{print $1}'); do
     for nextLaunchAgent in "${launchAgents[@]}"; do
         startOrRestartService "gui/$uid" $nextLaunchAgent
     done

--- a/Scalar.Notifications/Scalar.Mac/org.scalar.usernotification.plist
+++ b/Scalar.Notifications/Scalar.Mac/org.scalar.usernotification.plist
@@ -24,6 +24,8 @@
         <string>/usr/local/scalar</string>
         <key>ProcessType</key>
         <string>Interactive</string>
+        <key>LimitLoadToSessionType</key>
+        <string>Aqua</string>
         <key>Disabled</key>
         <false/>
         <key>OnDemand</key>

--- a/Scalar.Service/Mac/org.scalar.service.plist
+++ b/Scalar.Service/Mac/org.scalar.service.plist
@@ -24,6 +24,8 @@
     <string>/usr/local/scalar</string>
     <key>ProcessType</key>
     <string>Interactive</string>
+    <key>LimitLoadToSessionType</key>
+    <string>Aqua</string>
     <key>Disabled</key>
     <false/>
     <key>OnDemand</key>


### PR DESCRIPTION
Ported from microsoft/vfsforgit#1466, [commit eae1d3289](https://github.com/microsoft/VFSForGit/pull/1466/commits/eae1d32898fb8c4b0490585f920ffb8b2cb95c6c).

VFSForGit installer fails in postinstall script while trying to launch Service and UserNotification agents in GUI context of logged in users. To determine users logged into the GUI context, postinstall script looks for loginwindow commands and the user running the command. When Fast User switching is enabled, then loginwindow can be running as root user, even though root user is Not logged in. In such cases, postinstall tries to launch Service and UserNotifcation agents in GUI context of root user (that does not exist) resulting in failure. This commit makes postinstall look for Finder command (which only runs after a user has successfully logged into GUI context and is therefore more reliably associated with GUI session) rather than loginwindow.

Also Updated launchd plist for Service and Notification agents, added LimitLoadToSessionType = Aqua, just to make sure the agents get launched into the GUI context only.

Fixes microsoft/vfsforgit#1444 