### PR TITLE
Ensure only one BuildOutput directory is created

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,6 @@
   This file should not be parsed when building with .NET Framework.
   See https://github.com/Microsoft/msbuild/issues/1603#issuecomment-283104367 for more info .-->
   <PropertyGroup>
-    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)\..\..\BuildOutput\$(MSBuildProjectName)\obj</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)\..\BuildOutput\$(MSBuildProjectName)\obj</BaseIntermediateOutputPath>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
In the initial repo fork from VFS for Git, we moved all the projects from inside the "GVFS" directory to the root of the repository.

We failed to update this property however, which results in 'obj' directories being created for each project two levels up from the repository root, and not in the normal 'BuildOutput' directory which is only one level up from the repository root.