### PR TITLE
Use specific core.gvfs flags in git config

### DIFF
--- a/Scalar/CommandLine/ScalarVerb.cs
+++ b/Scalar/CommandLine/ScalarVerb.cs
@@ -151,7 +151,6 @@ namespace Scalar.CommandLine
             expectedHooksPath = Paths.ConvertPathToGitFormat(expectedHooksPath);
 
             string coreGVFSFlags = Convert.ToInt32(
-                GitCoreGVFSFlags.SkipShaOnIndex |
                 GitCoreGVFSFlags.BlockCommands |
                 GitCoreGVFSFlags.MissingOk |
                 GitCoreGVFSFlags.FetchSkipReachabilityAndUploadPack)


### PR DESCRIPTION
Resolves #64 

The `core.gvfs` setting in git can be specified as a bool or an int.

Rather than setting `core.gvfs` to `true`, which sets all flags in git, use the specific flags we're interested in for Scalar (currently all flags except `GVFS_BLOCK_FILTERS_AND_EOL_CONVERSIONS`).

Marking as **RFC** because I'm interested in hearing what people think of this approach.  

Some specific open questions:

- Is this approach okay (or okay in the short term)?  
- Should we have a follow up issue to make this cleaner in the config file (e.g. have specific config value entries that can be `true`/`false`)?  Or should that work be done now?
- Do any of the current flags need to be split apart to be more granular?
- Are the flags currently set in this PR the correct ones?