### PR TITLE
Remove blobSizes / gitObjects subfolders

### DIFF
--- a/Scalar.Common/RepoMetadata.cs
+++ b/Scalar.Common/RepoMetadata.cs
@@ -132,7 +132,6 @@ namespace Scalar.Common
                     new KeyValuePair<string, string>(Keys.DiskLayoutMinorVersion, ScalarPlatform.Instance.DiskLayoutUpgrade.Version.CurrentMinorVersion.ToString()),
                     new KeyValuePair<string, string>(Keys.GitObjectsRoot, enlistment.GitObjectsRoot),
                     new KeyValuePair<string, string>(Keys.LocalCacheRoot, enlistment.LocalCacheRoot),
-                    new KeyValuePair<string, string>(Keys.BlobSizesRoot, enlistment.BlobSizesRoot),
                     new KeyValuePair<string, string>(Keys.EnlistmentId, CreateNewEnlistmentId(tracer)),
                 });
         }
@@ -186,33 +185,6 @@ namespace Scalar.Common
             return true;
         }
 
-        public bool TryGetBlobSizesRoot(out string blobSizesRoot, out string error)
-        {
-            blobSizesRoot = null;
-
-            try
-            {
-                if (!this.repoMetadata.TryGetValue(Keys.BlobSizesRoot, out blobSizesRoot))
-                {
-                    error = "Blob sizes root not found";
-                    return false;
-                }
-            }
-            catch (FileBasedCollectionException ex)
-            {
-                error = ex.Message;
-                return false;
-            }
-
-            error = null;
-            return true;
-        }
-
-        public void SetBlobSizesRoot(string blobSizesRoot)
-        {
-            this.repoMetadata.SetValueAndFlush(Keys.BlobSizesRoot, blobSizesRoot);
-        }
-
         public void SetEntry(string keyName, string valueName)
         {
             this.repoMetadata.SetValueAndFlush(keyName, valueName);
@@ -233,7 +205,6 @@ namespace Scalar.Common
             public const string DiskLayoutMinorVersion = "DiskLayoutMinorVersion";
             public const string GitObjectsRoot = "GitObjectsRoot";
             public const string LocalCacheRoot = "LocalCacheRoot";
-            public const string BlobSizesRoot = "BlobSizesRoot";
             public const string EnlistmentId = "EnlistmentId";
         }
     }

--- a/Scalar.Common/ScalarEnlistment.cs
+++ b/Scalar.Common/ScalarEnlistment.cs
@@ -11,10 +11,6 @@ namespace Scalar.Common
 {
     public partial class ScalarEnlistment : Enlistment
     {
-        public const string BlobSizesCacheName = "blobSizes";
-
-        private const string GitObjectCacheName = "gitObjects";
-
         private string gitVersion;
         private string scalarVersion;
 
@@ -54,8 +50,6 @@ namespace Scalar.Common
         public string ScalarLogsRoot { get; }
 
         public string LocalCacheRoot { get; private set; }
-
-        public string BlobSizesRoot { get; private set; }
 
         public override string GitObjectsRoot { get; protected set; }
         public override string LocalObjectsRoot { get; protected set; }
@@ -189,16 +183,14 @@ namespace Scalar.Common
         {
             this.InitializeCachePaths(
                 localCacheRoot,
-                Path.Combine(localCacheRoot, localCacheKey, GitObjectCacheName),
-                Path.Combine(localCacheRoot, localCacheKey, BlobSizesCacheName));
+                Path.Combine(localCacheRoot, localCacheKey));
         }
 
-        public void InitializeCachePaths(string localCacheRoot, string gitObjectsRoot, string blobSizesRoot)
+        public void InitializeCachePaths(string localCacheRoot, string gitObjectsRoot)
         {
             this.LocalCacheRoot = localCacheRoot;
             this.GitObjectsRoot = gitObjectsRoot;
             this.GitPackRoot = Path.Combine(this.GitObjectsRoot, ScalarConstants.DotGit.Objects.Pack.Name);
-            this.BlobSizesRoot = blobSizesRoot;
         }
 
         public bool TryCreateEnlistmentFolders()

--- a/Scalar.FunctionalTests/Tools/ScalarFunctionalTestEnlistment.cs
+++ b/Scalar.FunctionalTests/Tools/ScalarFunctionalTestEnlistment.cs
@@ -144,7 +144,7 @@ namespace Scalar.FunctionalTests.Tools
             objectRootFolder.ShouldNotBeNull();
             objectRootFolder.Length.ShouldBeAtLeast(1, $"Invalid object root folder: {objectRootFolder} for {this.RepoUrl} mapping file content: {mappingFileContents}");
 
-            return Path.Combine(this.LocalCacheRoot, objectRootFolder, "gitObjects");
+            return Path.Combine(this.LocalCacheRoot, objectRootFolder);
         }
 
         public string GetPackRoot(FileSystemRunner fileSystem)

--- a/Scalar.Mount/InProcessMount.cs
+++ b/Scalar.Mount/InProcessMount.cs
@@ -75,12 +75,6 @@ namespace Scalar.Mount
                 this.FailMountAndExit("Failed to determine local cache path from repo metadata: " + error);
             }
 
-            string blobSizesRoot;
-            if (!RepoMetadata.Instance.TryGetBlobSizesRoot(out blobSizesRoot, out error))
-            {
-                this.FailMountAndExit("Failed to determine blob sizes root from repo metadata: " + error);
-            }
-
             this.tracer.RelatedEvent(
                 EventLevel.Informational,
                 "CachePathsLoaded",
@@ -88,10 +82,9 @@ namespace Scalar.Mount
                 {
                     { "gitObjectsRoot", gitObjectsRoot },
                     { "localCacheRoot", localCacheRoot },
-                    { "blobSizesRoot", blobSizesRoot },
                 });
 
-            this.enlistment.InitializeCachePaths(localCacheRoot, gitObjectsRoot, blobSizesRoot);
+            this.enlistment.InitializeCachePaths(localCacheRoot, gitObjectsRoot);
 
             using (NamedPipeServer pipeServer = this.StartNamedPipe())
             {

--- a/Scalar/CommandLine/CloneVerb.cs
+++ b/Scalar/CommandLine/CloneVerb.cs
@@ -75,6 +75,7 @@ namespace Scalar.CommandLine
             HelpText = "Use this option to not prefetch commits after clone")]
         public bool NoPrefetch { get; set; }
 
+        // By default this is "Drive\.scalarCache"
         [Option(
             "local-cache-path",
             Required = false,
@@ -431,7 +432,6 @@ namespace Scalar.CommandLine
 
             Directory.CreateDirectory(this.enlistment.GitObjectsRoot);
             Directory.CreateDirectory(this.enlistment.GitPackRoot);
-            Directory.CreateDirectory(this.enlistment.BlobSizesRoot);
 
             return new Result(true);
         }


### PR DESCRIPTION
Previously per repository we had the directory structure
- .scalarCache\guid\blobSizes
- .scalarCache\guid\gitObjects

We don't need blobSizes, so this PR moves git objects up a level so we'll just have
- cache\guid

This allows us to remove a lot of unnecessary code and simplify the cache directories.
