### PR TITLE
Update Git to include read-tree progress

### DIFF
--- a/Scalar.Build/Scalar.props
+++ b/Scalar.Build/Scalar.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <ScalarVersion>0.2.173.2</ScalarVersion>
-    <GitPackageVersion>2.20190923.1-sc</GitPackageVersion>
+    <GitPackageVersion>2.20190925.2-sc</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">


### PR DESCRIPTION
See microsoft/git#200 for details. Resolves microsoft/git#181.

This will give users more ideas of how long a command will take when modifying the sparse-checkout definition. In particular, we will notice if `clear_ce_flags()` is suddenly slow.