### PR TITLE
Pipelines: Create build to run functional tests on a private repo

### DIFF
--- a/.azure-pipelines/pull-request.yml
+++ b/.azure-pipelines/pull-request.yml
@@ -71,3 +71,16 @@ jobs:
     steps:
     - checkout: none # We'll get the build drop from Windows_Build_and_UnitTests job
     - template: templates/windows-functional-test.yml
+
+  - job: macOS_FunctionalTests_with_cache
+    variables:
+      platformFriendlyName: macOS
+      configuration: Release
+    timeoutInMinutes: 30
+    pool:
+      name: 'GVFS'
+    dependsOn: macOS_Build_and_UnitTests
+    condition: succeeded()
+    steps:
+      - checkout: none # Use the drop from macOS_Build_and_UnitTests job
+      - template: templates/macos-functional-test-with-cache.yml

--- a/.azure-pipelines/templates/macos-functional-test-with-cache.yml
+++ b/.azure-pipelines/templates/macos-functional-test-with-cache.yml
@@ -1,0 +1,51 @@
+steps:
+
+  - task: DotNetCoreInstaller@0
+    displayName: Use .NET Core SDK 2.1.301
+    inputs:
+      packageType: sdk
+      version: '2.1.301'
+
+  - bash: rm -rf $(Build.BinariesDirectory)/FunctionalTests_$(platformFriendlyName)_$(configuration)/BuildOutput/Git/*
+    displayName: Clean previous Git installations
+
+  - task: DownloadBuildArtifacts@0
+    displayName: Download functional test drop
+    inputs:
+      buildType: current
+      downloadType: specific
+      artifactName: FunctionalTests_$(platformFriendlyName)_$(configuration)
+      downloadPath: $(Build.BinariesDirectory)
+
+  - bash: |
+      chmod +x $(Build.BinariesDirectory)/FunctionalTests_$(platformFriendlyName)_$(configuration)/src/Scripts/Mac/*.sh
+      chmod +x $(Build.BinariesDirectory)/FunctionalTests_$(platformFriendlyName)_$(configuration)/Publish/*
+    displayName: Ensure tests assets are executable
+
+  - bash: $(Build.BinariesDirectory)/FunctionalTests_$(platformFriendlyName)_$(configuration)/src/Scripts/Mac/CleanupFunctionalTests.sh
+    displayName: Clean environment
+
+  - bash: $(Build.BinariesDirectory)/FunctionalTests_$(platformFriendlyName)_$(configuration)/src/Scripts/Mac/PrepFunctionalTests.sh
+    displayName: Prep functional tests
+
+  - bash: $(Build.BinariesDirectory)/FunctionalTests_$(platformFriendlyName)_$(configuration)/src/Scripts/Mac/RunFunctionalTests.sh $(configuration) --repo-to-clone=https://dev.azure.com/mseng/AzureDevOps/_git/GVFS
+    displayName: Run functional tests
+
+  - task: PublishTestResults@2
+    displayName: Publish functional test results
+    inputs:
+      testRunner: NUnit
+      testResultsFiles: "**\\TestResult*.xml"
+      searchFolder: $(System.DefaultWorkingDirectory)
+      testRunTitle: macOS $(configuration) Functional Tests
+      publishRunAttachments: true
+    condition: succeededOrFailed()
+
+  - bash: $(Build.BinariesDirectory)/FunctionalTests_$(platformFriendlyName)_$(configuration)/src/Scripts/Mac/CleanupFunctionalTests.sh
+    displayName: Cleanup
+    condition: always()
+
+  - bash: sudo rm -rf $(Build.BinariesDirectory)/FunctionalTests_$(platformFriendlyName)_$(configuration)
+    displayName: Cleanup phase 2
+    condition: always()
+

--- a/Scripts/Mac/RunFunctionalTests.sh
+++ b/Scripts/Mac/RunFunctionalTests.sh
@@ -7,6 +7,9 @@ if [ -z $CONFIGURATION ]; then
   CONFIGURATION=Debug
 fi
 
+# consume $1 so the next "$@" is all arguments after it
+shift
+
 mkdir ~/Scalar.FT
 
-$Scalar_PUBLISHDIR/Scalar.FunctionalTests --full-suite $2
+$Scalar_PUBLISHDIR/Scalar.FunctionalTests --full-suite "$@"


### PR DESCRIPTION
We want to run functional tests with a cache server. Cache servers require authenticated endpoints, so we need to run functional tests against a private repo.

Create a new test run that is run on a private pool, targeting a private repo. I'm working to stand up a cache server against that repo.