### PR TITLE
Update Git to include race condition fix in gvfs-helper

### DIFF
--- a/Scalar.Build/Scalar.props
+++ b/Scalar.Build/Scalar.props
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Parameters">
     <ScalarVersion>0.2.173.2</ScalarVersion>
-    <GitPackageVersion>2.20191003.3-sc</GitPackageVersion>
+    <GitPackageVersion>2.20191004.2-sc</GitPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="DefaultSettings">

--- a/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
+++ b/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
@@ -218,7 +218,7 @@ namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
         {
             // 'git rev-list --objects' will check for all objects' existence, which
             // triggers an object download on every missing blob.
-            ProcessResult result = GitHelpers.InvokeGitAgainstScalarRepo(enlistment.RepoRoot, "rev-list --objects HEAD^{tree}");
+            ProcessResult result = GitHelpers.InvokeGitAgainstScalarRepo(enlistment.RepoRoot, "rev-list --all --objects");
             result.ExitCode.ShouldEqual(0, result.Errors);
         }
     }


### PR DESCRIPTION
Resolves #156.

See microsoft/git#205 for the Git code change. One race condition still existed: who creates the loose object _directory_ first? The simple change is to check if the directory exists after the mkdir fails.