### PR TITLE
Publish trace2 logs during functional tests

### DIFF
--- a/.azure-pipelines/templates/macos-functional-test.yml
+++ b/.azure-pipelines/templates/macos-functional-test.yml
@@ -28,7 +28,7 @@ steps:
   - bash: $(Build.BinariesDirectory)/FunctionalTests_$(platformFriendlyName)_$(configuration)/src/Scripts/Mac/PrepFunctionalTests.sh
     displayName: Prep functional tests
 
-  - bash: $(Build.BinariesDirectory)/FunctionalTests_$(platformFriendlyName)_$(configuration)/src/Scripts/Mac/RunFunctionalTests.sh $(configuration)
+  - bash: $(Build.BinariesDirectory)/FunctionalTests_$(platformFriendlyName)_$(configuration)/src/Scripts/Mac/RunFunctionalTests.sh $(configuration) --trace2-output=$(Build.ArtifactStagingDirectory)/trace2-event-mac.txt
     displayName: Run functional tests
 
   - task: PublishTestResults@2
@@ -40,6 +40,12 @@ steps:
       testRunTitle: macOS $(configuration) Functional Tests
       publishRunAttachments: true
     condition: succeededOrFailed()
+    
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Git trace2 log
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: trace2-event-mac.txt
 
   - bash: $(Build.BinariesDirectory)/FunctionalTests_$(platformFriendlyName)_$(configuration)/src/Scripts/Mac/CleanupFunctionalTests.sh
     displayName: Cleanup

--- a/.azure-pipelines/templates/windows-functional-test.yml
+++ b/.azure-pipelines/templates/windows-functional-test.yml
@@ -14,7 +14,7 @@ steps:
   - script: git config --global credential.interactive never
     displayName: Disable interactive auth
 
-  - script: $(Build.BinariesDirectory)/FunctionalTests_$(platformFriendlyName)_$(configuration)/src/Scripts/RunFunctionalTests.bat $(configuration) --test-scalar-on-path
+  - script: $(Build.BinariesDirectory)/FunctionalTests_$(platformFriendlyName)_$(configuration)/src/Scripts/RunFunctionalTests.bat $(configuration) --test-scalar-on-path "--trace2-output=$(Build.ArtifactStagingDirectory)\trace2-event-windows.txt"
     displayName: Run functional tests
 
   - task: PublishTestResults@2
@@ -26,3 +26,9 @@ steps:
       testRunTitle: Windows $(configuration) Functional Tests
       publishRunAttachments: true
     condition: succeededOrFailed()
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish Git trace2 log
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: trace2-event-windows.txt

--- a/Scalar.FunctionalTests/Program.cs
+++ b/Scalar.FunctionalTests/Program.cs
@@ -29,6 +29,13 @@ namespace Scalar.FunctionalTests
                 ScalarTestConfig.TestScalarOnPath = true;
             }
 
+            string trace2Output = runner.GetCustomArgWithParam("--trace2-output");
+            if (trace2Output != null)
+            {
+                Console.WriteLine($"Sending trace2 output to {trace2Output}");
+                Environment.SetEnvironmentVariable("GIT_TRACE2_EVENT", trace2Output);
+            }
+
             ScalarTestConfig.LocalCacheRoot = runner.GetCustomArgWithParam("--shared-scalar-cache-root");
 
             HashSet<string> includeCategories = new HashSet<string>();

--- a/Scripts/Mac/RunFunctionalTests.sh
+++ b/Scripts/Mac/RunFunctionalTests.sh
@@ -9,4 +9,7 @@ fi
 
 mkdir ~/Scalar.FT
 
-$Scalar_PUBLISHDIR/Scalar.FunctionalTests --full-suite $2
+# Consume the first argument
+shift
+
+$Scalar_PUBLISHDIR/Scalar.FunctionalTests --full-suite "$@"

--- a/Scripts/RunFunctionalTests.bat
+++ b/Scripts/RunFunctionalTests.bat
@@ -29,7 +29,7 @@ echo git location:
 where git
 
 :startFunctionalTests
-dotnet %Scalar_OUTPUTDIR%\Scalar.FunctionalTests\bin\x64\%Configuration%\netcoreapp2.1\Scalar.FunctionalTests.dll /result:TestResultNetCore.xml %2 %3 %4 %5 || goto :endFunctionalTests
+dotnet %Scalar_OUTPUTDIR%\Scalar.FunctionalTests\bin\x64\%Configuration%\netcoreapp2.1\Scalar.FunctionalTests.dll /result:TestResultNetCore.xml %2 %3 %4 %5 %6 %7 %8 || goto :endFunctionalTests
 
 :endFunctionalTests
 set error=%errorlevel%


### PR DESCRIPTION
Our functional tests have many moving parts, including a live service where we send many requests. Things go wrong.

It's important that we can diagnose failures effectively. The trace2 mechanism can give us the most amount of detail, but can be very noisy. Send all trace2 events to a log file, then publish that file as a build artifact (do NOT include it in the test output). When we need to dig deep on a failure, we should be able to find the relevant Git commands and filter to the lines sharing that SID.

This is my first time really digging into YAML. I used [this doc](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/publish-build-artifacts?view=azure-devops) as a guide.

Resolves #162.

---

In the Azure Pipelines report, you can get artifacts here:

![image](https://user-images.githubusercontent.com/570044/66419999-17e89300-e9d3-11e9-9803-b07ba1bd04a6.png)

![image](https://user-images.githubusercontent.com/570044/66420018-1fa83780-e9d3-11e9-8245-92275f512973.png)

Then open the log file and try to find the `git` command that had trouble. That will have a line starting with

```
"event":"version","sid":"<SID>","thread":"main","time":"<TIME>",
```

The time may be one way you find this event. You can then grep for the SID to isolate the events in that command. That will include any child processes.