### PR TITLE
[Port 1550] Removing git config - autoRefreshIndex

### DIFF
--- a/Scalar/CommandLine/ScalarVerb.cs
+++ b/Scalar/CommandLine/ScalarVerb.cs
@@ -167,7 +167,6 @@ namespace Scalar.CommandLine
                 { "core.hookspath", expectedHooksPath },
                 { GitConfigSetting.CredentialUseHttpPath, "true" },
                 { "credential.validate", "false" },
-                { "diff.autoRefreshIndex", "false" },
                 { "gc.auto", "0" },
                 { "gui.gcwarning", "false" },
                 { "index.threads", "true" },


### PR DESCRIPTION
#### Removing git config - autoRefreshIndex

This config is not needed anymore, because Scalar does not use
index.lock. (This change was introduced initially to prevent
`git diff` from acquiring index.lock file.)

Reference - [Original PR](https://github.com/microsoft/VFSForGit/pull/1550)