### PR TITLE
LooseObjectsStep: simplify code for getting directory paths

### DIFF
--- a/Scalar.Common/Maintenance/LooseObjectsStep.cs
+++ b/Scalar.Common/Maintenance/LooseObjectsStep.cs
@@ -52,8 +52,7 @@ namespace Scalar.Common.Maintenance
 
                 if (GitObjects.IsLooseObjectsDirectory(directoryName))
                 {
-                    string dirPath = Path.Combine(this.Context.Enlistment.GitObjectsRoot, directoryPath);
-                    List<DirectoryItemInfo> dirItems = this.Context.FileSystem.ItemsInDirectory(dirPath).ToList();
+                    List<DirectoryItemInfo> dirItems = this.Context.FileSystem.ItemsInDirectory(directoryPath).ToList();
                     count += dirItems.Count;
                     size += dirItems.Sum(item => item.Length);
                 }

--- a/Scalar.UnitTests/Mock/FileSystem/MockFileSystem.cs
+++ b/Scalar.UnitTests/Mock/FileSystem/MockFileSystem.cs
@@ -279,7 +279,7 @@ namespace Scalar.UnitTests.Mock.FileSystem
             {
                 foreach (MockDirectory subDirectory in directory.Directories.Values)
                 {
-                    yield return subDirectory.Name;
+                    yield return subDirectory.FullName;
                 }
             }
         }


### PR DESCRIPTION
The code in CountLooseObjects can be simplified by avoiding
an unnecessary Path.Combine.

Additionally, fix a bug in the MockFileSystem where EnumerateDirectories
was not returning the full paths of directories and it should.

I found this while updating the unit tests as part of #216, the port to VFS4G is here: https://github.com/microsoft/VFSForGit/pull/1570