### PR TITLE
InitializeLocalCacheAndObjectsPaths: remove unused parameters

### DIFF
--- a/Scalar/CommandLine/MaintenanceVerb.cs
+++ b/Scalar/CommandLine/MaintenanceVerb.cs
@@ -64,7 +64,7 @@ namespace Scalar.CommandLine
                             { nameof(this.StartedByService), this.StartedByService },
                         }));
 
-                this.InitializeLocalCacheAndObjectsPaths(tracer, enlistment, retryConfig: null, serverScalarConfig: null, cacheServer: null);
+                this.InitializeLocalCacheAndObjectsPaths(tracer, enlistment);
                 PhysicalFileSystem fileSystem = new PhysicalFileSystem();
                 using (ScalarContext context = new ScalarContext(tracer, fileSystem, enlistment))
                 {
@@ -187,7 +187,7 @@ namespace Scalar.CommandLine
                 this.Output.WriteLine("Configured cache server: " + cacheServer);
             }
 
-            this.InitializeLocalCacheAndObjectsPaths(tracer, enlistment, retryConfig, serverScalarConfig, cacheServer);
+            this.InitializeLocalCacheAndObjectsPaths(tracer, enlistment);
             objectRequestor = new GitObjectsHttpRequestor(tracer, enlistment, cacheServer, retryConfig);
         }
 

--- a/Scalar/CommandLine/ScalarVerb.cs
+++ b/Scalar/CommandLine/ScalarVerb.cs
@@ -809,10 +809,7 @@ You can specify a URL, a name of a configured cache server, or the special names
 
             protected void InitializeLocalCacheAndObjectsPaths(
                 ITracer tracer,
-                ScalarEnlistment enlistment,
-                RetryConfig retryConfig,
-                ServerScalarConfig serverScalarConfig,
-                CacheServerInfo cacheServer)
+                ScalarEnlistment enlistment)
             {
                 string error;
                 if (!RepoMetadata.TryInitialize(tracer, Path.Combine(enlistment.EnlistmentRoot, ScalarPlatform.Instance.Constants.DotScalarRoot), out error))


### PR DESCRIPTION
Resolves #160 

retryConfig, serverScalarConfig, and cacheServer are no longer by
InitializeLocalCacheAndObjectsPaths.