### PR TITLE
Cleanup NamedPipe related code

### DIFF
--- a/Scalar.Common/Git/ScalarGitObjects.cs
+++ b/Scalar.Common/Git/ScalarGitObjects.cs
@@ -19,26 +19,16 @@ namespace Scalar.Common.Git
             this.objectNegativeCache = new ConcurrentDictionary<string, DateTime>(StringComparer.OrdinalIgnoreCase);
         }
 
-        public enum RequestSource
-        {
-            Invalid = 0,
-            FileStreamCallback,
-            ScalarVerb,
-            NamedPipeMessage,
-            SymLinkCreation,
-        }
-
         protected ScalarContext Context { get; private set; }
 
-        public DownloadAndSaveObjectResult TryDownloadAndSaveObject(string objectId, RequestSource requestSource)
+        public DownloadAndSaveObjectResult TryDownloadAndSaveObject(string objectId)
         {
-            return this.TryDownloadAndSaveObject(objectId, CancellationToken.None, requestSource, retryOnFailure: true);
+            return this.TryDownloadAndSaveObject(objectId, CancellationToken.None, retryOnFailure: true);
         }
 
         private DownloadAndSaveObjectResult TryDownloadAndSaveObject(
             string objectId,
             CancellationToken cancellationToken,
-            RequestSource requestSource,
             bool retryOnFailure)
         {
             if (objectId == ScalarConstants.AllZeroSha)
@@ -64,7 +54,6 @@ namespace Scalar.Common.Git
                 objectId,
                 retryOnFailure,
                 cancellationToken,
-                requestSource.ToString(),
                 onSuccess: (tryCount, response) =>
                 {
                     // If the request is from git.exe (i.e. NamedPipeMessage) then we should assume that if there is an
@@ -72,7 +61,6 @@ namespace Scalar.Common.Git
                     this.WriteLooseObject(
                         response.Stream,
                         objectId,
-                        overwriteExistingObject: requestSource == RequestSource.NamedPipeMessage,
                         bufToCopyWith: bufToCopyWith);
 
                     return new RetryWrapper<GitObjectsHttpRequestor.GitObjectTaskResult>.CallbackResult(new GitObjectsHttpRequestor.GitObjectTaskResult(true));

--- a/Scalar.Common/Http/GitObjectsHttpRequestor.cs
+++ b/Scalar.Common/Http/GitObjectsHttpRequestor.cs
@@ -129,7 +129,6 @@ namespace Scalar.Common.Http
             string objectId,
             bool retryOnFailure,
             CancellationToken cancellationToken,
-            string requestSource,
             Func<int, GitEndPointResponseData, RetryWrapper<GitObjectTaskResult>.CallbackResult> onSuccess)
         {
             long requestId = HttpRequestor.GetNewRequestId();
@@ -137,7 +136,6 @@ namespace Scalar.Common.Http
             metadata.Add("objectId", objectId);
             metadata.Add("retryOnFailure", retryOnFailure);
             metadata.Add("requestId", requestId);
-            metadata.Add("requestSource", requestSource);
             this.Tracer.RelatedEvent(EventLevel.Informational, "DownloadLooseObject", metadata, Keywords.Network);
 
             return this.TrySendProtocolRequest(

--- a/Scalar.Common/NamedPipes/NamedPipeMessages.cs
+++ b/Scalar.Common/NamedPipes/NamedPipeMessages.cs
@@ -1,5 +1,4 @@
 using Newtonsoft.Json;
-using System.Collections.Generic;
 
 namespace Scalar.Common.NamedPipes
 {
@@ -9,9 +8,6 @@ namespace Scalar.Common.NamedPipes
     public static class NamedPipeMessages
     {
         public const string UnknownRequest = "UnknownRequest";
-        public const string UnknownScalarState = "UnknownScalarState";
-        public const string MountNotReadyResult = "MountNotReady";
-
         private const string ResponseSuffix = "Response";
         private const char MessageSeparator = '|';
 
@@ -22,16 +18,6 @@ namespace Scalar.Common.NamedPipes
             Failure
         }
 
-        public static class Unmount
-        {
-            public const string Request = "Unmount";
-            public const string NotMounted = "NotMounted";
-            public const string Acknowledged = "Ack";
-            public const string Completed = "Complete";
-            public const string AlreadyUnmounting = "AlreadyUnmounting";
-            public const string MountFailed = "MountFailed";
-        }
-
         public static class Notification
         {
             public class Request
@@ -40,9 +26,6 @@ namespace Scalar.Common.NamedPipes
 
                 public enum Identifier
                 {
-                    AutomountStart,
-                    MountSuccess,
-                    MountFailure,
                     UpgradeAvailable
                 }
 
@@ -51,10 +34,6 @@ namespace Scalar.Common.NamedPipes
                 public string Title { get; set; }
 
                 public string Message { get; set; }
-
-                public string Enlistment { get; set; }
-
-                public int EnlistmentCount { get; set; }
 
                 public string NewVersion { get; set; }
 

--- a/Scalar.Common/Platforms/Mac/MacPlatform.cs
+++ b/Scalar.Common/Platforms/Mac/MacPlatform.cs
@@ -57,11 +57,6 @@ namespace Scalar.Platform.Mac
             return MacPlatform.TryGetScalarEnlistmentRootImplementation(directory, out enlistmentRoot, out errorMessage);
         }
 
-        public override string GetNamedPipeName(string enlistmentRoot)
-        {
-            return MacPlatform.GetNamedPipeNameImplementation(enlistmentRoot);
-        }
-
         public override FileBasedLock CreateFileBasedLock(
             PhysicalFileSystem fileSystem,
             ITracer tracer,

--- a/Scalar.Common/Platforms/Windows/WindowsPlatform.cs
+++ b/Scalar.Common/Platforms/Windows/WindowsPlatform.cs
@@ -210,11 +210,6 @@ namespace Scalar.Platform.Windows
             running = service != null ? service.Status == ServiceControllerStatus.Running : false;
         }
 
-        public override string GetNamedPipeName(string enlistmentRoot)
-        {
-            return WindowsPlatform.GetNamedPipeNameImplementation(enlistmentRoot);
-        }
-
         public override string GetScalarServiceNamedPipeName(string serviceName)
         {
             return serviceName + ".pipe";

--- a/Scalar.Common/ScalarEnlistment.cs
+++ b/Scalar.Common/ScalarEnlistment.cs
@@ -21,7 +21,6 @@ namespace Scalar.Common
                   flushFileBuffersForPacks: true,
                   authentication: authentication)
         {
-            this.NamedPipeName = ScalarPlatform.Instance.GetNamedPipeName(this.EnlistmentRoot);
             this.DotScalarRoot = Path.Combine(this.EnlistmentRoot, ScalarPlatform.Instance.Constants.DotScalarRoot);
             this.GitStatusCacheFolder = Path.Combine(this.DotScalarRoot, ScalarConstants.DotScalar.GitStatusCache.Name);
             this.GitStatusCachePath = Path.Combine(this.DotScalarRoot, ScalarConstants.DotScalar.GitStatusCache.CachePath);
@@ -38,8 +37,6 @@ namespace Scalar.Common
                   authentication)
         {
         }
-
-        public string NamedPipeName { get; }
 
         public string DotScalarRoot { get; }
 

--- a/Scalar.Common/ScalarPlatform.cs
+++ b/Scalar.Common/ScalarPlatform.cs
@@ -60,7 +60,6 @@ namespace Scalar.Common
 
         public abstract bool IsProcessActive(int processId);
         public abstract void IsServiceInstalledAndRunning(string name, out bool installed, out bool running);
-        public abstract string GetNamedPipeName(string enlistmentRoot);
         public abstract string GetScalarServiceNamedPipeName(string serviceName);
         public abstract NamedPipeServerStream CreatePipeByName(string pipeName);
 

--- a/Scalar.Service.UI/ScalarToastRequestHandler.cs
+++ b/Scalar.Service.UI/ScalarToastRequestHandler.cs
@@ -43,36 +43,9 @@ namespace Scalar.Service.UI
             string message = null;
             string buttonTitle = null;
             string args = null;
-            string path = null;
 
             switch (request.Id)
             {
-                case NamedPipeMessages.Notification.Request.Identifier.AutomountStart:
-                    string reposSuffix = request.EnlistmentCount <= 1 ? ScalarSingleRepo : ScalarMultipleRepos;
-                    title = ScalarAutomountStartTitle;
-                    message = string.Format(ScalarAutomountStartMessageFormat, request.EnlistmentCount, reposSuffix);
-                    break;
-
-                case NamedPipeMessages.Notification.Request.Identifier.MountSuccess:
-                    if (this.TryValidatePath(request.Enlistment, out path, this.tracer))
-                    {
-                        title = ScalarAutomountSuccessTitle;
-                        message = string.Format(ScalarAutomountSuccessMessageFormat, Environment.NewLine, path);
-                    }
-
-                    break;
-
-                case NamedPipeMessages.Notification.Request.Identifier.MountFailure:
-                    if (this.TryValidatePath(request.Enlistment, out path, this.tracer))
-                    {
-                        title = ScalarAutomountErrorTitle;
-                        message = string.Format(ScalarAutomountErrorMessageFormat, Environment.NewLine, path);
-                        buttonTitle = ScalarAutomountButtonTitle;
-                        args = $"{ScalarRemountActionPrefix} {path}";
-                    }
-
-                    break;
-
                 case NamedPipeMessages.Notification.Request.Identifier.UpgradeAvailable:
                     title = string.Format(ScalarUpgradeTitleFormat, request.NewVersion);
                     message = string.Format(ScalarUpgradeMessage);

--- a/Scalar.UnitTests/Git/ScalarGitObjectsTests.cs
+++ b/Scalar.UnitTests/Git/ScalarGitObjectsTests.cs
@@ -37,7 +37,7 @@ namespace Scalar.UnitTests.Git
                 httpObjects.MediaType = ScalarConstants.MediaTypes.LooseObjectMediaType;
                 ScalarGitObjects dut = this.CreateTestableScalarGitObjects(httpObjects, fileSystem);
 
-                dut.TryDownloadAndSaveObject(ValidTestObjectFileContents, ScalarGitObjects.RequestSource.FileStreamCallback)
+                dut.TryDownloadAndSaveObject(ValidTestObjectFileContents)
                     .ShouldEqual(GitObjects.DownloadAndSaveObjectResult.Success);
             }
         }
@@ -49,7 +49,7 @@ namespace Scalar.UnitTests.Git
             this.AssertRetryableExceptionOnDownload(
                 new MemoryStream(),
                 ScalarConstants.MediaTypes.LooseObjectMediaType,
-                gitObjects => gitObjects.TryDownloadAndSaveObject("aabbcc", ScalarGitObjects.RequestSource.FileStreamCallback));
+                gitObjects => gitObjects.TryDownloadAndSaveObject("aabbcc"));
         }
 
         [TestCase]
@@ -59,7 +59,7 @@ namespace Scalar.UnitTests.Git
             this.AssertRetryableExceptionOnDownload(
                 new MemoryStream(new byte[256]),
                 ScalarConstants.MediaTypes.LooseObjectMediaType,
-                gitObjects => gitObjects.TryDownloadAndSaveObject("aabbcc", ScalarGitObjects.RequestSource.FileStreamCallback));
+                gitObjects => gitObjects.TryDownloadAndSaveObject("aabbcc"));
         }
 
         [TestCase]
@@ -153,7 +153,6 @@ namespace Scalar.UnitTests.Git
                 string objectId,
                 bool retryOnFailure,
                 CancellationToken cancellationToken,
-                string requestSource,
                 Func<int, GitEndPointResponseData, RetryWrapper<GitObjectTaskResult>.CallbackResult> onSuccess)
             {
                 return this.TryDownloadObjects(new[] { objectId }, onSuccess, null, false);

--- a/Scalar.UnitTests/Mock/Common/MockPhysicalGitObjects.cs
+++ b/Scalar.UnitTests/Mock/Common/MockPhysicalGitObjects.cs
@@ -15,7 +15,7 @@ namespace Scalar.UnitTests.Mock.Common
         {
         }
 
-        public override string WriteLooseObject(Stream responseStream, string sha, bool overwriteExisting, byte[] sharedBuf = null)
+        public override string WriteLooseObject(Stream responseStream, string sha, byte[] sharedBuf = null)
         {
             using (StreamReader reader = new StreamReader(responseStream))
             {

--- a/Scalar.UnitTests/Mock/Common/MockPlatform.cs
+++ b/Scalar.UnitTests/Mock/Common/MockPlatform.cs
@@ -43,11 +43,6 @@ namespace Scalar.UnitTests.Mock.Common
             throw new NotImplementedException();
         }
 
-        public override string GetNamedPipeName(string enlistmentRoot)
-        {
-            return "Scalar_Mock_PipeName";
-        }
-
         public override string GetScalarServiceNamedPipeName(string serviceName)
         {
             return Path.Combine("Scalar_Mock_ServicePipeName", serviceName);

--- a/Scalar.UnitTests/Windows/ServiceUI/ScalarToastRequestHandlerTests.cs
+++ b/Scalar.UnitTests/Windows/ServiceUI/ScalarToastRequestHandlerTests.cs
@@ -41,41 +41,9 @@ namespace Scalar.UnitTests.Windows.ServiceUI
         }
 
         [TestCase]
-        public void MountFailureToastIsActionableAndContainEnlistmentInfo()
-        {
-            const string enlistmentRoot = "D:\\Work\\OS";
-
-            this.request.Id = NamedPipeMessages.Notification.Request.Identifier.MountFailure;
-            this.request.Enlistment = enlistmentRoot;
-
-            this.VerifyToastMessage(
-                expectedTitle: "Scalar Automount",
-                expectedMessage: enlistmentRoot,
-                expectedButtonTitle: "Retry",
-                expectedScalarCmd: "scalar mount " + enlistmentRoot);
-        }
-
-        [TestCase]
-        public void MountStartIsNotActionableAndContainsEnlistmentCount()
-        {
-            const int enlistmentCount = 10;
-
-            this.request.Id = NamedPipeMessages.Notification.Request.Identifier.AutomountStart;
-            this.request.EnlistmentCount = enlistmentCount;
-
-            this.VerifyToastMessage(
-                expectedTitle: "Scalar Automount",
-                expectedMessage: "mount " + enlistmentCount.ToString() + " Scalar repos",
-                expectedButtonTitle: null,
-                expectedScalarCmd: null);
-        }
-
-        [TestCase]
         public void UnknownToastRequestGetsIgnored()
         {
             this.request.Id = (NamedPipeMessages.Notification.Request.Identifier)10;
-            this.request.EnlistmentCount = 232;
-            this.request.Enlistment = "C:\\OS";
 
             this.toastHandler.HandleToastRequest(this.tracer, this.request);
 

--- a/Scalar/CommandLine/CloneVerb.cs
+++ b/Scalar/CommandLine/CloneVerb.cs
@@ -188,7 +188,6 @@ namespace Scalar.CommandLine
                     { nameof(this.NoFetchCommitsAndTrees), this.NoFetchCommitsAndTrees },
                     { nameof(this.Unattended), this.Unattended },
                     { nameof(ScalarPlatform.Instance.IsElevated), ScalarPlatform.Instance.IsElevated() },
-                    { nameof(this.enlistment.NamedPipeName), this.enlistment.NamedPipeName },
                     { "ProcessID", Process.GetCurrentProcess().Id },
                     { nameof(this.EnlistmentRootPathParameter), this.EnlistmentRootPathParameter },
                     { nameof(fullEnlistmentRootPathParameter), fullEnlistmentRootPathParameter },

--- a/Scalar/CommandLine/ScalarVerb.cs
+++ b/Scalar/CommandLine/ScalarVerb.cs
@@ -586,7 +586,7 @@ You can specify a URL, a name of a configured cache server, or the special names
                 return false;
             }
 
-            if (gitObjects.TryDownloadAndSaveObject(gitAttributes.TargetSha, ScalarGitObjects.RequestSource.ScalarVerb) != GitObjects.DownloadAndSaveObjectResult.Success)
+            if (gitObjects.TryDownloadAndSaveObject(gitAttributes.TargetSha) != GitObjects.DownloadAndSaveObjectResult.Success)
             {
                 error = "Could not download " + ScalarConstants.SpecialGitFiles.GitAttributes + " file";
                 return false;


### PR DESCRIPTION
Resolves #178 

Remove named pipe related code that is no longer required for Scalar.

This includes removing code from GitObjectsHttpRequestor that is
specific to download requests that used to be sent to Scalar over
named pipes.