### PR TITLE
MacScalarVerbRunner: stop using launchctl

### DIFF
--- a/Scalar.Service/MacScalarVerbRunner.cs
+++ b/Scalar.Service/MacScalarVerbRunner.cs
@@ -8,8 +8,6 @@ namespace Scalar.Service
 {
     public class MacScalarVerbRunner : IScalarVerbRunner
     {
-        private const string ExecutablePath = "/bin/launchctl";
-
         private readonly string scalarBinPath;
         private readonly string internalVerbJson;
 
@@ -29,21 +27,46 @@ namespace Scalar.Service
             this.internalVerbJson = internalParams.ToJson();
         }
 
+        /// <summary>
+        /// Calls the 'scalar maintenance' verb
+        /// </summary>
+        /// <param name="task">Maintenance task to run</param>
+        /// <param name="repoRoot">Repo to maintain</param>
+        /// <param name="sessionId">Ignored</param>
+        /// <returns>
+        /// true if the maintenance verb succeeded, and false otherwise
+        /// </returns>
+        /// <remarks>
+        /// 'CallMaintenance' should only be called for repos that are owned by
+        /// the owner of the current process.
+        ///
+        /// 'launchctl asuser' *could* be used to launch has an arbitrary user,
+        /// however, it is not used because it does not pass back the output/errors
+        /// of the maintenance verb correctly.
+        ///
+        /// On Mac this method:
+        /// 
+        ///   - Is only called by Scalar.Service
+        ///   - Is only called for repos owned by the same user that's running Scalar.Service
+        ///   
+        /// And so there is no need to use 'launchctl'.
+        /// </remarks>
         public bool CallMaintenance(MaintenanceTasks.Task task, string repoRoot, int sessionId)
         {
             string taskVerbName = MaintenanceTasks.GetVerbTaskName(task);
             string arguments =
-                $"asuser {sessionId} {this.scalarBinPath} maintenance \"{repoRoot}\" --{ScalarConstants.VerbParameters.Maintenance.Task} {taskVerbName} --{ScalarConstants.VerbParameters.InternalUseOnly} {this.internalVerbJson}";
+                $"maintenance \"{repoRoot}\" --{ScalarConstants.VerbParameters.Maintenance.Task} {taskVerbName} --{ScalarConstants.VerbParameters.InternalUseOnly} {this.internalVerbJson}";
 
-            ProcessResult result = this.processLauncher.LaunchProcess(ExecutablePath, arguments, repoRoot);
+            ProcessResult result = this.processLauncher.LaunchProcess(this.scalarBinPath, arguments, repoRoot);
             if (result.ExitCode != 0)
             {
                 EventMetadata metadata = new EventMetadata();
                 metadata.Add("Area", "ScalarVerbRunner");
-                metadata.Add(nameof(ExecutablePath), ExecutablePath);
+                metadata.Add(nameof(this.scalarBinPath), this.scalarBinPath);
                 metadata.Add(nameof(arguments), arguments);
                 metadata.Add(nameof(repoRoot), repoRoot);
                 metadata.Add(nameof(result.ExitCode), result.ExitCode);
+                metadata.Add(nameof(result.Output), result.Output);
                 metadata.Add(nameof(result.Errors), result.Errors);
 
                 this.tracer.RelatedError(metadata, $"{nameof(this.CallMaintenance)}: Maintenance verb failed");

--- a/Scalar.UnitTests/Service/Mac/MacScalarVerbRunnerTests.cs
+++ b/Scalar.UnitTests/Service/Mac/MacScalarVerbRunnerTests.cs
@@ -31,14 +31,13 @@ namespace Scalar.UnitTests.Service.Mac
         {
             MaintenanceTasks.Task task = MaintenanceTasks.Task.FetchCommitsAndTrees;
             string taskVerbName = MaintenanceTasks.GetVerbTaskName(task);
-            string executable = @"/bin/launchctl";
             string scalarBinPath = Path.Combine(this.scalarPlatform.Constants.ScalarBinDirectoryPath, this.scalarPlatform.Constants.ScalarExecutableName);
             string expectedArgs =
-                $"asuser {ExpectedActiveUserId} {scalarBinPath} maintenance \"{ExpectedActiveRepoPath}\" --{ScalarConstants.VerbParameters.Maintenance.Task} {taskVerbName} --{ScalarConstants.VerbParameters.InternalUseOnly} {new InternalVerbParameters(startedByService: true).ToJson()}";
+                $"maintenance \"{ExpectedActiveRepoPath}\" --{ScalarConstants.VerbParameters.Maintenance.Task} {taskVerbName} --{ScalarConstants.VerbParameters.InternalUseOnly} {new InternalVerbParameters(startedByService: true).ToJson()}";
 
             Mock<MacScalarVerbRunner.ScalarProcessLauncher> mountLauncherMock = new Mock<MacScalarVerbRunner.ScalarProcessLauncher>(MockBehavior.Strict, this.tracer);
             mountLauncherMock.Setup(mp => mp.LaunchProcess(
-                executable,
+                scalarBinPath,
                 expectedArgs,
                 ExpectedActiveRepoPath))
                 .Returns(new ProcessResult(output: string.Empty, errors: string.Empty, exitCode: 0));


### PR DESCRIPTION
Resolves #225 

There is no need to use launchctl when calling the 'maintenance'
verb as Scalar.Service is always running as the current user on Mac.

By making this change Scalar.Service is able to properly read the exit
code and stdout/stderr from the 'scalar maintenance' verb.