### PR TITLE
Attempt to remove watchman watch directories when enlistment is deleted

### DIFF
--- a/Scalar.FunctionalTests/Tools/ProcessHelper.cs
+++ b/Scalar.FunctionalTests/Tools/ProcessHelper.cs
@@ -1,5 +1,8 @@
+using System;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace Scalar.FunctionalTests.Tools
 {
@@ -50,6 +53,45 @@ namespace Scalar.FunctionalTests.Tools
                 }
 
                 return new ProcessResult(output.ToString(), errors.ToString(), executingProcess.ExitCode);
+            }
+        }
+
+        public static string GetProgramLocation(string processName)
+        {
+            ProcessResult result = ProcessHelper.Run(GetProgramLocator(), processName);
+            if (result.ExitCode != 0)
+            {
+                return null;
+            }
+
+            string firstPath =
+                string.IsNullOrWhiteSpace(result.Output)
+                ? null
+                : result.Output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+            if (firstPath == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                return Path.GetDirectoryName(firstPath);
+            }
+            catch (IOException)
+            {
+                return null;
+            }
+        }
+
+        private static string GetProgramLocator()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return "where";
+            }
+            else
+            {
+                return "which";
             }
         }
 

--- a/Scalar.FunctionalTests/Tools/ScalarFunctionalTestEnlistment.cs
+++ b/Scalar.FunctionalTests/Tools/ScalarFunctionalTestEnlistment.cs
@@ -122,6 +122,19 @@ namespace Scalar.FunctionalTests.Tools
 
         public void DeleteEnlistment()
         {
+            string watchmanLocation = ProcessHelper.GetProgramLocation("watchman");
+            if (!string.IsNullOrEmpty(watchmanLocation))
+            {
+                try
+                {
+                    ProcessHelper.Run(Path.Combine(watchmanLocation, "watchman"), $"watch-del {this.RepoRoot}");
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Failed to delete watch on {this.RepoRoot}. {ex.ToString()}");
+                }
+            }
+
             TestResultsHelper.OutputScalarLogs(this);
             RepositoryHelpers.DeleteTestDirectory(this.EnlistmentRoot);
         }


### PR DESCRIPTION
There are functional tests on MacOS that run with watchman that are intermittently failing.  This change is to try an help watchman have less to do by removing the watch path from watchman when the test for that enlistment finishes.  Hopefully this will help watchman be more efficient in it's processing so these tests will no longer fail.  

We need to do more performance testing around watchman and see where it will run into issues and what we can do to keep it in top shape so we don't hit issues in production. 