### PR TITLE
Allow `dotnet publish` without runtime identifier args

### DIFF
--- a/Scalar.Installer.Mac/Scalar.Installer.Mac.csproj
+++ b/Scalar.Installer.Mac/Scalar.Installer.Mac.csproj
@@ -18,9 +18,20 @@
     <ProjectReference Include="..\Scalar.Notifications.Mac\Scalar.Notifications.Mac.csproj" />
   </ItemGroup>
 
-  <!-- Only create the installer on 'publish' and when running on macOS -->
-  <Target Name="PublishInstaller" AfterTargets="Publish" Condition="'$(OSPlatform)' == 'osx'" >
+  <!-- Only create the installer when running on macOS -->
+  <Target Name="BuildInstaller" AfterTargets="Publish" Condition="'$(OSPlatform)' == 'osx'" >
+    <!-- Ensure all projects have been published with the correct runtime identifier and configuration -->
+    <MSBuild Projects="@(ProjectReference)"
+             Targets="Publish"
+             Properties="
+             Configuration=$(Configuration);
+             RuntimeIdentifier=$(RuntimeIdentifier);"
+             BuildInParallel="true" />
+
+    <!-- Bring together all published binaries and native applications/plists -->
     <Exec Command="$(MSBuildProjectDirectory)/layout.sh '$(Configuration)' '$(TargetFramework)' '$(RuntimeIdentifier)' '$(RepoSrcPath)' '$(RepoOutPath)' '$(LayoutPath)'"/>
+
+    <!-- Build the installer package(s) -->
     <Exec Command="$(MSBuildProjectDirectory)/pack.sh '$(ScalarVersion)' '$(RepoSrcPath)' '$(LayoutPath)' '$(InstallerOutputPath)'"/>
   </Target>
 

--- a/Scalar.Installer.Windows/Scalar.Installer.Windows.csproj
+++ b/Scalar.Installer.Windows/Scalar.Installer.Windows.csproj
@@ -22,8 +22,16 @@
     <PackageReference Include="Tools.InnoSetup" />
   </ItemGroup>
 
-  <!-- Only create the installer on 'publish' and when running on Windows -->
-  <Target Name="CreateInstaller" AfterTargets="Publish" Condition="'$(OSPlatform)' == 'windows'" >
+  <!-- Only create the installer when running on Windows -->
+  <Target Name="BuildInstaller" AfterTargets="Publish" Condition="'$(OSPlatform)' == 'windows'" >
+    <!-- Ensure all projects have been published with the correct runtime identifier and configuration -->
+    <MSBuild Projects="@(ProjectReference)"
+             Targets="Publish"
+             Properties="
+             Configuration=$(Configuration);
+             RuntimeIdentifier=$(RuntimeIdentifier);"
+             BuildInParallel="true" />
+
     <!-- Bring together all published binaries -->
     <PropertyGroup>
       <PublishPathFragment>bin\$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\publish\</PublishPathFragment>

--- a/Scalar.Notifications.Mac/Scalar.Notifications.Mac.csproj
+++ b/Scalar.Notifications.Mac/Scalar.Notifications.Mac.csproj
@@ -12,7 +12,7 @@
   <!--
     Only build and test the native bits when running on macOS.
     -->
-  <Target Name="_XcodeBuild" AfterTargets="AfterBuild" Condition="'$(OSPlatform)' == 'osx'">
+  <Target Name="_XcodeBuild" AfterTargets="Publish" Condition="'$(OSPlatform)' == 'osx'">
     <Exec Command="$(MSBuildProjectDirectory)\build.sh $(Configuration) '$(ProjectOutPath)xcodebuild' '$(ProjectOutPath)bin\$(Configuration)\native\$(RuntimeIdentifier)' $(Version)" />
     <Exec Command="$(MSBuildProjectDirectory)\test.sh $(Configuration) '$(ProjectOutPath)xcodebuild.test'" />
   </Target>

--- a/Scripts/Mac/BuildScalarForMac.sh
+++ b/Scripts/Mac/BuildScalarForMac.sh
@@ -17,4 +17,4 @@ if [ "$CONFIGURATION" == "Profiling(Release)" ]; then
   CONFIGURATION=Release
 fi
 
-dotnet publish $SCALAR_SRCDIR/Scalar.sln --runtime osx-x64 --configuration $CONFIGURATION || exit 1
+dotnet publish $SCALAR_SRCDIR/Scalar.sln --runtime osx-x64 -p:ScalarVersion=$VERSION --configuration $CONFIGURATION || exit 1


### PR DESCRIPTION
Allow the use of `dotnet publish` without the need to specify `--runtime`.

The `Scalar.Installer.*` project `BuildInstaller` targets will now force a publish of all `@(ProjectReference)`s with the correct runtime identifier (and configuration) for the installer platform.