### PR TITLE
scalar: allow Git installer to downgrade; add logs

### DIFF
--- a/.azure-pipelines/templates/macos-functional-test.yml
+++ b/.azure-pipelines/templates/macos-functional-test.yml
@@ -30,6 +30,9 @@ steps:
       chmod +x $(Build.BinariesDirectory)/Installers_$(platformFriendlyName)_$(configuration)/*.sh
     displayName: Ensure all scripts are executable
 
+  - bash: mkdir -p $(Build.ArtifactStagingDirectory)/logs
+    displayName: Create logs directory
+
   - ${{ if eq(parameters.useWatchman, 'true') }}:
     - bash: $(Build.BinariesDirectory)/Installers_$(platformFriendlyName)_$(configuration)/InstallScalar.sh
       displayName: Install product (with watchman)
@@ -38,7 +41,7 @@ steps:
     - bash: $(Build.BinariesDirectory)/Installers_$(platformFriendlyName)_$(configuration)/InstallScalar.sh --no-watchman
       displayName: Install product (without watchman)
 
-  - bash: $(Build.BinariesDirectory)/FunctionalTests_$(platformFriendlyName)_$(configuration)/src/Scripts/Mac/RunFunctionalTests.sh $(configuration) --test-scalar-on-path --trace2-output=$(Build.ArtifactStagingDirectory)/trace2-event-mac.txt
+  - bash: $(Build.BinariesDirectory)/FunctionalTests_$(platformFriendlyName)_$(configuration)/src/Scripts/Mac/RunFunctionalTests.sh $(configuration) --test-scalar-on-path --trace2-output=$(Build.ArtifactStagingDirectory)/logs/trace2-event.log
     displayName: Run functional tests
 
   - ${{ if eq(parameters.useWatchman, 'true') }}:
@@ -63,11 +66,21 @@ steps:
         publishRunAttachments: true
       condition: succeededOrFailed()
     
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Git trace2 log
-    inputs:
-      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: trace2-event-mac.txt
+  - ${{ if eq(parameters.useWatchman, 'true') }}:
+    - task: PublishBuildArtifacts@1
+      displayName: Publish test and installation logs
+      inputs:
+        pathtoPublish: '$(Build.ArtifactStagingDirectory)/logs'
+        artifactName: Logs_$(platformFriendlyName)_Watchman
+      condition: failed()
+
+  - ${{ if ne(parameters.useWatchman, 'true') }}:
+    - task: PublishBuildArtifacts@1
+      displayName: Publish test and installation logs
+      inputs:
+        pathtoPublish: '$(Build.ArtifactStagingDirectory)/logs'
+        artifactName: Logs_$(platformFriendlyName)
+      condition: failed()
 
   - bash: $(Build.BinariesDirectory)/FunctionalTests_$(platformFriendlyName)_$(configuration)/src/Scripts/Mac/CleanupFunctionalTests.sh
     displayName: Cleanup

--- a/.azure-pipelines/templates/windows-functional-test.yml
+++ b/.azure-pipelines/templates/windows-functional-test.yml
@@ -26,13 +26,13 @@ steps:
       artifactName: Installers_$(platformFriendlyName)_$(configuration)
       downloadPath: $(Build.BinariesDirectory)
 
-  - script: $(Build.BinariesDirectory)/Installers_$(platformFriendlyName)_$(configuration)/InstallScalar.bat
+  - script: $(Build.BinariesDirectory)/Installers_$(platformFriendlyName)_$(configuration)/InstallScalar.bat $(Build.ArtifactStagingDirectory)\logs
     displayName: Install product
 
   - script: git config --global credential.interactive never
     displayName: Disable interactive auth
 
-  - script: $(Build.BinariesDirectory)/FunctionalTests_$(platformFriendlyName)_$(configuration)/src/Scripts/RunFunctionalTests.bat $(configuration) --test-scalar-on-path "--trace2-output=$(Build.ArtifactStagingDirectory)\trace2-event-windows.txt"
+  - script: $(Build.BinariesDirectory)/FunctionalTests_$(platformFriendlyName)_$(configuration)/src/Scripts/RunFunctionalTests.bat $(configuration) --test-scalar-on-path "--trace2-output=$(Build.ArtifactStagingDirectory)\logs\trace2-event.log"
     displayName: Run functional tests
 
   - task: PublishTestResults@2
@@ -46,8 +46,8 @@ steps:
     condition: succeededOrFailed()
 
   - task: PublishBuildArtifacts@1
-    displayName: Publish Git trace2 log
+    displayName: Publish test and installation logs
     inputs:
-      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: trace2-event-windows.txt
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)\logs'
+      artifactName: Logs_$(platformFriendlyName)
     condition: failed()

--- a/Scalar.Distribution.Windows/InstallScalar.template.bat
+++ b/Scalar.Distribution.Windows/InstallScalar.template.bat
@@ -10,21 +10,37 @@ SET SCALAR_DISTRIBUTION_ROOT=%~dp0
 SET GIT_INSTALLER_EXE=##GIT_INSTALLER_EXE_PLACEHOLDER##
 SET SCALAR_INSTALLER_EXE=##SCALAR_INSTALLER_EXE_PLACEHOLDER##
 
+IF "%1"=="" (SET "LOG_BASE=%TEMP%\scalar-install-logs") ELSE (SET "LOG_BASE=%1")
+SET GIT_INSTALLER_LOG=%LOG_BASE%\install-git.log
+SET SCALAR_INSTALLER_LOG=%LOG_BASE%\install-scalar.log
+
 ECHO Scalar distribution root: %SCALAR_DISTRIBUTION_ROOT%
 ECHO Git installer exe: %GIT_INSTALLER_EXE%
 ECHO Scalar installer exe: %SCALAR_INSTALLER_EXE%
+ECHO.
+ECHO Git installer log: %GIT_INSTALLER_LOG%
+ECHO Scalar installer log: %SCALAR_INSTALLER_LOG%
+
+REM Clean logs from previous installations
+IF EXIST "%LOG_BASE%" (
+    ECHO.
+    ECHO ==============================
+    rmdir /s /q %LOG_BASE%
+    ECHO Cleaning previous installation logs
+)
+mkdir %LOG_BASE%
 
 REM Install Git
 ECHO.
 ECHO ==============================
 ECHO Installing Git for Windows for Scalar
-%SCALAR_DISTRIBUTION_ROOT%\Git\%GIT_INSTALLER_EXE% /DIR="C:\Program Files\Git" /NOICONS /COMPONENTS="ext,ext\shellhere,ext\guihere,assoc,assoc_sh" /GROUP="Git" /VERYSILENT /SUPPRESSMSGBOXES /NORESTART || EXIT /B 1
+%SCALAR_DISTRIBUTION_ROOT%\Git\%GIT_INSTALLER_EXE% /DIR="C:\Program Files\Git" /NOICONS /COMPONENTS="ext,ext\shellhere,ext\guihere,assoc,assoc_sh" /GROUP="Git" /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /ALLOWDOWNGRADE=1 /LOG="%GIT_INSTALLER_LOG%" || EXIT /B 1
 
 REM Install Scalar
 ECHO.
 ECHO ==============================
 ECHO Installing Scalar
-%SCALAR_DISTRIBUTION_ROOT%\Scalar\%SCALAR_INSTALLER_EXE% /VERYSILENT /SUPPRESSMSGBOXES /NORESTART || EXIT /B 1
+%SCALAR_DISTRIBUTION_ROOT%\Scalar\%SCALAR_INSTALLER_EXE% /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /LOG="%SCALAR_INSTALLER_LOG%" || EXIT /B 1
 
 REM Run the post install script (if any)
 IF EXIST "%SCALAR_DISTRIBUTION_ROOT%\Scripts\PostInstall.bat" (


### PR DESCRIPTION
Allow the InstallProduct.bat script to downgrade the Git installation.
Also capture installation and FT logs in the case of any failure.