### PR TITLE
ScalarVerb: explicitly disable new config settings

### DIFF
--- a/Scalar/CommandLine/ScalarVerb.cs
+++ b/Scalar/CommandLine/ScalarVerb.cs
@@ -178,6 +178,9 @@ namespace Scalar.CommandLine
                 { "receive.autogc", "false" },
                 { "reset.quiet", "true" },
                 { "http.version", "HTTP/1.1" },
+                { "feature.manyFiles", "false" },
+                { "feature.experimental", "false" },
+                { "fetch.writeCommitGraph", "false" },
             };
 
             if (!TrySetConfig(enlistment, requiredSettings, isRequired: true))


### PR DESCRIPTION
In Git 2.24.0, some new config settings were created. Disable them
locally in Scalar repos in case a user has set them globally.

The feature.* config settings change the defaults for some other
config settings. We already monitor config settings pretty carefully,
so let's disable these.

The fetch.writeCommitGraph setting choses to write a commit-graph
file at the end of each git fetch call. We already build the
commit-graph file in the background AND put it in the shared cache
instead of the local Git repo.