### PR TITLE
Migrate to Azure Artifacts

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="ScalarBuildDependencies" value="https://vfsforgit.myget.org/F/build-dependencies/api/v3/index.json" />
+    <add key="Dependencies" value="https://pkgs.dev.azure.com/gvfs/ci/_packaging/Dependencies/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Let's use an Azure Artifacts public feed for our build dependencies.