### PR TITLE
CommitGraphStep: do not immediately delete expired commit-graph files

### DIFF
--- a/Scalar.Common/Git/GitProcess.cs
+++ b/Scalar.Common/Git/GitProcess.cs
@@ -498,7 +498,9 @@ namespace Scalar.Common.Git
         /// </summary>
         public Result WriteCommitGraph(string objectDir)
         {
-            string command = "commit-graph write --reachable --split --size-multiple=4 --object-dir \"" + objectDir + "\"";
+            // Do not expire commit-graph files that have been modified in the last hour.
+            // This will prevent deleting any commit-graph files that are currently in the commit-graph-chain.
+            string command = $"commit-graph write --reachable --split --size-multiple=4 --expire-time={1 * 60 * 60} --object-dir \"{objectDir}\"";
             return this.InvokeGitInWorkingDirectoryRoot(command, fetchMissingObjects: true);
         }
 

--- a/Scalar.UnitTests/Maintenance/CommitGraphStepTests.cs
+++ b/Scalar.UnitTests/Maintenance/CommitGraphStepTests.cs
@@ -18,7 +18,7 @@ namespace Scalar.UnitTests.Maintenance
         private MockGitProcess gitProcess;
         private ScalarContext context;
 
-        private string CommitGraphWriteCommand => $"commit-graph write --reachable --split --size-multiple=4 --object-dir \"{this.context.Enlistment.GitObjectsRoot}\"";
+        private string CommitGraphWriteCommand => $"commit-graph write --reachable --split --size-multiple=4 --expire-time=3600 --object-dir \"{this.context.Enlistment.GitObjectsRoot}\"";
         private string CommitGraphVerifyCommand => $"commit-graph verify --shallow --object-dir \"{this.context.Enlistment.GitObjectsRoot}\"";
 
         [TestCase]


### PR DESCRIPTION
We have noticed a lot of "cannot find all commit-graph files" errors,
more than is reasonable for simply hard-drive failures. Likely there is
an issue with how Git is comparing the paths of the commit-graph files
it is queueing for deletion and the ones it plans to keep, related to
how we use the --object-dir parameter.

The commit-graph code in Git will "touch" all the files that are
currently in the commit-graph-chain, so as long as we pass a non-zero
expire time, that will prevent us from deleting the files that are
still in the chain despite the path difference.

This is a faster fix than fixing Git first.

I noticed this after running the commit-graph step on a vanilla
Git repo that already had a long commit-graph chain generated by
fetch.writeCommitGraph.

See microsoft/vfsforgit#1615 for a similar change.

I'll remove this commit from #258.