### PR TITLE
MaintenanceVerb: use "_service" instead of timestamp

### DIFF
--- a/Scalar.Common/Enlistment.cs
+++ b/Scalar.Common/Enlistment.cs
@@ -95,7 +95,7 @@ namespace Scalar.Common
                 logsRoot,
                 name + ".log");
 
-            if (fileSystem.FileExists(fullPath))
+            if (string.IsNullOrEmpty(logId) && fileSystem.FileExists(fullPath))
             {
                 fullPath = Path.Combine(
                     logsRoot,

--- a/Scalar.Common/ScalarEnlistment.cs
+++ b/Scalar.Common/ScalarEnlistment.cs
@@ -108,7 +108,7 @@ namespace Scalar.Common
             return Enlistment.GetNewLogFileName(
                 logsRoot,
                 "scalar_" + logFileType,
-                logId: null,
+                logId: logId,
                 fileSystem: fileSystem);
         }
 

--- a/Scalar/CommandLine/MaintenanceVerb.cs
+++ b/Scalar/CommandLine/MaintenanceVerb.cs
@@ -47,8 +47,13 @@ namespace Scalar.CommandLine
             {
                 string cacheServerUrl = CacheServerResolver.GetUrlFromConfig(enlistment);
 
+                string logFileName = ScalarEnlistment.GetNewScalarLogFileName(
+                                                        enlistment.ScalarLogsRoot,
+                                                        ScalarConstants.LogFileTypes.Maintenance,
+                                                        logId: this.StartedByService ? "service" : null);
+
                 tracer.AddLogFileEventListener(
-                    ScalarEnlistment.GetNewScalarLogFileName(enlistment.ScalarLogsRoot, ScalarConstants.LogFileTypes.Maintenance),
+                    logFileName,
                     EventLevel.Informational,
                     Keywords.Any);
                 tracer.WriteStartEvent(


### PR DESCRIPTION
The service overloads the logs dir by running maintenance verbs in
the background. Change the name to use "service" instead of
a timestamp when the log is started by the service.

This will cause the log files to grow, as we append to the logs
every time.

Resolves #177.