### PR TITLE
LocalScalarConfig: succeed when file doesn't exist

### DIFF
--- a/Scalar.Common/LocalScalarConfig.cs
+++ b/Scalar.Common/LocalScalarConfig.cs
@@ -1,8 +1,6 @@
 using Scalar.Common.FileSystem;
-using Scalar.Common.Tracing;
 using System;
 using System.Collections.Generic;
-using System.IO;
 
 namespace Scalar.Common
 {
@@ -21,6 +19,13 @@ namespace Scalar.Common
 
         public virtual bool TryGetAllConfig(out Dictionary<string, string> allConfig, out string error)
         {
+            if (!this.fileSystem.FileExists(this.configFile))
+            {
+                allConfig = new Dictionary<string, string>();
+                error = null;
+                return true;
+            }
+
             Dictionary<string, string> configCopy = null;
             if (!this.TryPerformAction(
                 () => configCopy = this.allSettings.GetAllKeysAndValues(),
@@ -40,6 +45,13 @@ namespace Scalar.Common
             out string value,
             out string error)
         {
+            if (!this.fileSystem.FileExists(this.configFile))
+            {
+                value = null;
+                error = null;
+                return true;
+            }
+
             string valueFromDict = null;
             if (!this.TryPerformAction(
                 () => this.allSettings.TryGetValue(name, out valueFromDict),


### PR DESCRIPTION
See microsoft/vfsforgit#1625 for a related change.

The problem happens when the config file doesn't exist, and we try to run `scalar config --list` without elevation. That process cannot create the file, so the `FileBasedDictionary` fails to load. When we are doing read-only operations, we can just return as if the file was empty.

Resolves #220.