### PR TITLE
Mac: install Python 2 before Watchman

### DIFF
--- a/Scalar.Installer.Mac/InstallScalar.template.sh
+++ b/Scalar.Installer.Mac/InstallScalar.template.sh
@@ -106,6 +106,7 @@ if [ $INSTALL_WATCHMAN -eq 1 ]; then
     echo "Installing watchman as: $CURRENT_USER"
 
     sudo -u $CURRENT_USER brew update
+    sudo -u $CURRENT_USER brew install python@2
     sudo -u $CURRENT_USER brew install watchman
 else
     echo ""


### PR DESCRIPTION
A recent change to Azure Pipelines seems to have changed our builds to use Python 3 by default. Manually install Python 2 before installing Watchman.