### PR TITLE
Mac: only warn on watchman install fail

### DIFF
--- a/.azure-pipelines/templates/osx/functional-test.yml
+++ b/.azure-pipelines/templates/osx/functional-test.yml
@@ -37,7 +37,8 @@ steps:
       displayName: Install product (without watchman)
 
   - ${{ if eq(parameters.useWatchman, 'true') }}:
-    - bash: watchman log-level debug
+    - bash: |
+        watchman log-level debug || echo "WARNING: watchman call failed"
       displayName: Set watchman log level to debug
 
   - bash: $(Build.BinariesDirectory)/ft/src/Scripts/Mac/RunFunctionalTests.sh $(configuration) --test-scalar-on-path --trace2-output=$(Build.ArtifactStagingDirectory)/logs/trace2-event.log
@@ -66,7 +67,8 @@ steps:
       condition: succeededOrFailed()
 
   - ${{ if eq(parameters.useWatchman, 'true') }}:
-    - bash: cp -pf '/usr/local/var/run/watchman/runner-state/log' '$(Build.ArtifactStagingDirectory)/logs/watchman-log'
+    - bash: |
+        cp -pf '/usr/local/var/run/watchman/runner-state/log' '$(Build.ArtifactStagingDirectory)/logs/watchman-log' || echo "WARNING: failed to archive logs"
       displayName: Copy watchman logs
       condition: failed()
 

--- a/Scalar.Installer.Mac/InstallScalar.template.sh
+++ b/Scalar.Installer.Mac/InstallScalar.template.sh
@@ -106,6 +106,7 @@ if [ $INSTALL_WATCHMAN -eq 1 ]; then
     echo "Installing watchman as: $CURRENT_USER"
 
     sudo -u $CURRENT_USER brew update
+    sudo -u $CURRENT_USER brew unlink python@2
     sudo -u $CURRENT_USER brew install watchman
 else
     echo ""


### PR DESCRIPTION
Our CI builds are failing the Mac watchman functional tests due to some external dependency changing. Try to succeed despite the install failing, just as a precaution.