### PR TITLE
Code hygiene: remove WorkingDirectoryBackingRoot

### DIFF
--- a/Scalar.Common/Enlistment.cs
+++ b/Scalar.Common/Enlistment.cs
@@ -10,7 +10,6 @@ namespace Scalar.Common
         protected Enlistment(
             string enlistmentRoot,
             string workingDirectoryRoot,
-            string workingDirectoryBackingRoot,
             string repoUrl,
             string gitBinPath,
             bool flushFileBuffersForPacks,
@@ -23,8 +22,7 @@ namespace Scalar.Common
 
             this.EnlistmentRoot = enlistmentRoot;
             this.WorkingDirectoryRoot = workingDirectoryRoot;
-            this.WorkingDirectoryBackingRoot = workingDirectoryBackingRoot;
-            this.DotGitRoot = Path.Combine(this.WorkingDirectoryBackingRoot, ScalarConstants.DotGit.Root);
+            this.DotGitRoot = Path.Combine(this.WorkingDirectoryRoot, ScalarConstants.DotGit.Root);
             this.GitBinPath = gitBinPath;
             this.FlushFileBuffersForPacks = flushFileBuffersForPacks;
 
@@ -55,12 +53,7 @@ namespace Scalar.Common
         public string EnlistmentRoot { get; }
 
         // Path to the root of the working (i.e. "src") directory.
-        // On platforms where the contents of the working directory are stored
-        // at a different location (e.g. Linux), WorkingDirectoryBackingRoot is the path of that backing
-        // storage location.  On all other platforms WorkingDirectoryRoot and WorkingDirectoryBackingRoot
-        // are the same.
         public string WorkingDirectoryRoot { get; }
-        public string WorkingDirectoryBackingRoot { get; }
 
         public string DotGitRoot { get; private set; }
         public abstract string GitObjectsRoot { get; protected set; }

--- a/Scalar.Common/Git/GitProcess.cs
+++ b/Scalar.Common/Git/GitProcess.cs
@@ -62,7 +62,7 @@ namespace Scalar.Common.Git
         }
 
         public GitProcess(Enlistment enlistment)
-            : this(enlistment.GitBinPath, enlistment.WorkingDirectoryBackingRoot)
+            : this(enlistment.GitBinPath, enlistment.WorkingDirectoryRoot)
         {
         }
 
@@ -86,7 +86,7 @@ namespace Scalar.Common.Git
 
         public static Result Init(Enlistment enlistment)
         {
-            return new GitProcess(enlistment).InvokeGitOutsideEnlistment("init \"" + enlistment.WorkingDirectoryBackingRoot + "\"");
+            return new GitProcess(enlistment).InvokeGitOutsideEnlistment("init \"" + enlistment.WorkingDirectoryRoot + "\"");
         }
 
         public static Result SparseCheckoutInit(Enlistment enlistment)

--- a/Scalar.Common/Maintenance/ConfigStep.cs
+++ b/Scalar.Common/Maintenance/ConfigStep.cs
@@ -80,7 +80,7 @@ namespace Scalar.Common.Maintenance
                 GitCoreGVFSFlags.PrefetchDuringFetch)
                 .ToString();
 
-            string expectedHooksPath = Path.Combine(this.Context.Enlistment.WorkingDirectoryBackingRoot, ScalarConstants.DotGit.Hooks.Root);
+            string expectedHooksPath = Path.Combine(this.Context.Enlistment.WorkingDirectoryRoot, ScalarConstants.DotGit.Hooks.Root);
             expectedHooksPath = Paths.ConvertPathToGitFormat(expectedHooksPath);
 
             // These settings are required for normal Scalar functionality.

--- a/Scalar.Common/Platforms/Mac/MacPlatform.cs
+++ b/Scalar.Common/Platforms/Mac/MacPlatform.cs
@@ -152,11 +152,6 @@ namespace Scalar.Platform.Mac
                 get { return ".dmg"; }
             }
 
-            public override string WorkingDirectoryBackingRootPath
-            {
-                get { return ScalarConstants.WorkingDirectoryRootName; }
-            }
-
             public override string ScalarBinDirectoryPath
             {
                 get { return Path.Combine("/usr", "local", this.ScalarBinDirectoryName); }

--- a/Scalar.Common/Platforms/Windows/WindowsPlatform.cs
+++ b/Scalar.Common/Platforms/Windows/WindowsPlatform.cs
@@ -404,11 +404,6 @@ namespace Scalar.Platform.Windows
 
             public override bool SupportsUpgradeWhileRunning => false;
 
-            public override string WorkingDirectoryBackingRootPath
-            {
-                get { return ScalarConstants.WorkingDirectoryRootName; }
-            }
-
             public override string ScalarBinDirectoryPath
             {
                 get

--- a/Scalar.Common/ScalarEnlistment.cs
+++ b/Scalar.Common/ScalarEnlistment.cs
@@ -15,7 +15,6 @@ namespace Scalar.Common
             : this(
                   enlistmentRoot,
                   Path.Combine(enlistmentRoot, ScalarConstants.WorkingDirectoryRootName),
-                  Path.Combine(enlistmentRoot, ScalarPlatform.Instance.Constants.WorkingDirectoryBackingRootPath),
                   repoUrl,
                   gitBinPath,
                   authentication)
@@ -24,33 +23,16 @@ namespace Scalar.Common
 
         // Existing, configured enlistment
         private ScalarEnlistment(string enlistmentRoot, string workingDirectory, string repoUrl, string gitBinPath, GitAuthentication authentication)
-            : this(
-                  enlistmentRoot,
-                  workingDirectory,
-                  workingDirectory,
-                  repoUrl,
-                  gitBinPath,
-                  authentication)
-        {
-        }
-
-        private ScalarEnlistment(string enlistmentRoot,
-                                 string workingDirectory,
-                                 string workingDirectoryBackingRoot,
-                                 string repoUrl,
-                                 string gitBinPath,
-                                 GitAuthentication authentication)
             : base(
                   enlistmentRoot,
                   workingDirectory,
-                  workingDirectoryBackingRoot,
                   repoUrl,
                   gitBinPath,
                   flushFileBuffersForPacks: true,
                   authentication: authentication)
         {
-            this.ScalarLogsRoot = Path.Combine(this.WorkingDirectoryBackingRoot, ScalarConstants.DotGit.Logs.Root);
-            this.LocalObjectsRoot = Path.Combine(this.WorkingDirectoryBackingRoot, ScalarConstants.DotGit.Objects.Root);
+            this.ScalarLogsRoot = Path.Combine(this.WorkingDirectoryRoot, ScalarConstants.DotGit.Logs.Root);
+            this.LocalObjectsRoot = Path.Combine(this.WorkingDirectoryRoot, ScalarConstants.DotGit.Objects.Root);
         }
 
         public string ScalarLogsRoot { get; }

--- a/Scalar.Common/ScalarPlatform.cs
+++ b/Scalar.Common/ScalarPlatform.cs
@@ -141,7 +141,6 @@ namespace Scalar.Common
             /// the upgrade verb is running.
             /// </summary>
             public abstract bool SupportsUpgradeWhileRunning { get; }
-            public abstract string WorkingDirectoryBackingRootPath { get; }
 
             public abstract string ScalarBinDirectoryPath { get; }
 

--- a/Scalar.UnitTests/Mock/Common/MockPlatform.cs
+++ b/Scalar.UnitTests/Mock/Common/MockPlatform.cs
@@ -185,11 +185,6 @@ namespace Scalar.UnitTests.Mock.Common
                 get { return ".mockexe"; }
             }
 
-            public override string WorkingDirectoryBackingRootPath
-            {
-                get { return ScalarConstants.WorkingDirectoryRootName; }
-            }
-
             public override string ScalarBinDirectoryPath
             {
                 get { return Path.Combine("MockProgramFiles", this.ScalarBinDirectoryName); }

--- a/Scalar/CommandLine/CloneVerb.cs
+++ b/Scalar/CommandLine/CloneVerb.cs
@@ -301,11 +301,11 @@ namespace Scalar.CommandLine
             try
             {
                 string fsMonitorWatchmanSampleHookPath = Path.Combine(
-                    this.enlistment.WorkingDirectoryBackingRoot,
+                    this.enlistment.WorkingDirectoryRoot,
                     ScalarConstants.DotGit.Hooks.FsMonitorWatchmanSamplePath);
 
                 string queryWatchmanPath = Path.Combine(
-                    this.enlistment.WorkingDirectoryBackingRoot,
+                    this.enlistment.WorkingDirectoryRoot,
                     ScalarConstants.DotGit.Hooks.QueryWatchmanPath);
 
                 this.fileSystem.CopyFile(
@@ -543,7 +543,7 @@ namespace Scalar.CommandLine
             }
 
             File.WriteAllText(
-                Path.Combine(this.enlistment.WorkingDirectoryBackingRoot, ScalarConstants.DotGit.Head),
+                Path.Combine(this.enlistment.WorkingDirectoryRoot, ScalarConstants.DotGit.Head),
                 "ref: refs/heads/" + this.Branch);
 
             try
@@ -582,7 +582,7 @@ namespace Scalar.CommandLine
 
         private Result TryInitRepo()
         {
-            string repoPath = this.enlistment.WorkingDirectoryBackingRoot;
+            string repoPath = this.enlistment.WorkingDirectoryRoot;
             GitProcess.Result initResult = GitProcess.Init(this.enlistment);
             if (initResult.ExitCodeIsFailure)
             {

--- a/Scalar/CommandLine/ScalarVerb.cs
+++ b/Scalar/CommandLine/ScalarVerb.cs
@@ -458,7 +458,7 @@ You can specify a URL, a name of a configured cache server, or the special names
 
         private string GetAlternatesPath(ScalarEnlistment enlistment)
         {
-            return Path.Combine(enlistment.WorkingDirectoryBackingRoot, ScalarConstants.DotGit.Objects.Info.Alternates);
+            return Path.Combine(enlistment.WorkingDirectoryRoot, ScalarConstants.DotGit.Objects.Info.Alternates);
         }
 
         private void CheckGitVersion(ITracer tracer, ScalarEnlistment enlistment, out string version)


### PR DESCRIPTION
WorkingDirectoryBackingRoot was used to back the virtualization subsystem in Linux. This is not necessary in Scalar. Remove the property and direct everything through WorkingDirectoryRoot.