### PR TITLE
Actions: increase stale timeout to 90 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,5 +17,5 @@ jobs:
         stale-pr-message: 'Labeling this pull request as stale. There has been no activity for 30 days. Remove stale label or comment or this PR will be closed in 7 days.'
         stale-issue-label: 'no-activity'
         stale-pr-label: 'no-activity'
-        days-before-stale: 30
+        days-before-stale: 90
         days-before-close: 7


### PR DESCRIPTION
The stale bot has been a bit too aggressive with its 30-day timeout, especially around the holidays when work slowed a bit.

90 days is more reasonable of a limit, as that's more than three sprints of not touching an issue.