### PR TITLE
[RELEASE] Pipelines: use configuration setting for msbuild task

### DIFF
--- a/.azure-pipelines/templates/win/pack.signed.yml
+++ b/.azure-pipelines/templates/win/pack.signed.yml
@@ -17,7 +17,8 @@ steps:
     displayName: Collect payload files
     inputs:
       solution: 'Scalar.Installer.Windows\Scalar.Installer.Windows.csproj'
-      msbuildArguments: '/t:BuildInstallerPhase1 /p:LayoutPath="$(Build.ArtifactStagingDirectory)\signpayload"'
+      configuration: $(configuration)
+      msbuildArguments: '/t:BuildInstallerPhase1 /p:LayoutPath="$(Build.ArtifactStagingDirectory)\signpayload"' /p:ScalarVersion=$(majorAndMinorVersion).$(revision)'
 
   - task: MSBuild@1
     displayName: Sign payload
@@ -29,6 +30,7 @@ steps:
     displayName: Build installer
     inputs:
       solution: 'Scalar.Installer.Windows\Scalar.Installer.Windows.csproj'
+      configuration: $(configuration)
       msbuildArguments: '/t:BuildInstallerPhase2 /p:LayoutPath="$(Build.ArtifactStagingDirectory)\signpayload" /p:InstallerOutputPath="$(Build.ArtifactStagingDirectory)\signinstaller" /p:ScalarVersion=$(majorAndMinorVersion).$(revision)'
 
   - task: MSBuild@1
@@ -44,6 +46,7 @@ steps:
     displayName: Create distribution
     inputs:
       solution: 'Scalar.Installer.Windows\Scalar.Installer.Windows.csproj'
+      configuration: $(configuration)
       msbuildArguments: '/t:BuildInstallerPhase3 /p:InstallerOutputPath="$(Build.ArtifactStagingDirectory)\signinstaller"'
 
   - script: Scripts\CI\CreateFTDrop.bat $(configuration) $(Build.ArtifactStagingDirectory)\Tests

--- a/Scripts/NukeBuildOutputs.bat
+++ b/Scripts/NukeBuildOutputs.bat
@@ -18,7 +18,7 @@ IF EXIST C:\Repos\ScalarPerfTest (
 
 IF EXIST %SCALAR_OUTPUTDIR% (
     ECHO deleting build outputs
-    rmdir /s /q %Scalar_OUTPUTDIR%
+    rmdir /s /q %SCALAR_OUTPUTDIR%
 ) ELSE (
     ECHO no build outputs found
 )


### PR DESCRIPTION
When we use the msbuild task to build the installers from our existing
binaries, we want to make sure we are using the right outputs. Let's
double-check that we are using the release outputs.

It is possible that we are re-building a debug build of scalar.exe in
the "Collect payload files" step, and without a specified version.