### PR TITLE
Update Readme and related docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ For details, see the build script in the previous step.
 Visual Studio 2019 will [automatically prompt you to install these dependencies](https://devblogs.microsoft.com/setup/configure-visual-studio-across-your-organization-with-vsconfig/)
 when you open the solution.
 
-The installer can now be found at `<repo root>\..\out\Scalar.Installer.Windows\dist\[Debug|Release]\Scalar\SetupScalar.<version>.exe`.
+The installer can now be found at `<repo root>\..\out\Scalar.Installer.Windows\dist\[Debug|Release]\Scalar\SetupScalar.0.2.173.2.exe`.
 Be sure to also install the latest Git for Windows installer at `<repo root>\..\out\Scalar.Installer.Windows\dist\[Debug|Release]\Git\Git-<version>.exe`.
 
 ## Building Scalar on Mac

--- a/Readme.md
+++ b/Readme.md
@@ -25,28 +25,30 @@ See [the documentation](docs/index.md) for more details.
 * [Quick start](#quick-start)
 * [License](#license)
 
-## Installing on macOS
+Installing on macOS
+------------------
 
 To install Scalar on macOS,
 [download the `Installers_macOS_Release.zip` from the releases page](https://github.com/microsoft/scalar/releases).
-Extract the `Installers_macOS_Release` directory, `cd` into it, and run `./InstallScalar.sh` in a Terminal window.
+Extract the `Installers_macOS_Release` folder, `cd` into it, and run `./InstallScalar.sh` in a Terminal window.
 The script may prompt for your password as it installs the following components:
 
 * [Git](https://github.com/microsoft/git) (with custom patches)
 * [Git Credential Manager Core](https://github.com/microsoft/Git-Credential-Manager-Core)
 * Scalar
-* [Watchman](https://github.com/facebook/watchman)
+* [Watchman](https://github.com/facebook/watchman), unless you use the `--no-watchman` argument.
 
-## Installing on Windows
+Installing on Windows
+--------------------
 
 To install Scalar on Windows,
 [download the `Installers_Windows_Release.zip` from the releases page](https://github.com/microsoft/scalar/releases).
-Extract the `Installers_Windows_Release` directory, open that directory in
-a command prompt, then run `InstallScalar.bat`. This script will install
-the following components:
+Extract the `Installers_Windows_Release` folder, open it in a command prompt, and
+run `InstallScalar.bat`. This will install the following components:
 
 * [Git for Windows](https://github.com/microsoft/git) (with custom patches)
 * Scalar
+* [Watchman](https://github.com/facebook/watchman), if you use the `--watchman` argument.
 
 ## Quick start
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -59,7 +59,7 @@ patterns to only match the files at root.
 
 If you are unfamiliar with what directories are available in the repository,
 then you can run `git ls-tree -d --name-only HEAD` to discover the directories
-at root, or `git ls-tree -d --name-onlye HEAD <path>` to discover the directories
+at root, or `git ls-tree -d --name-only HEAD <path>` to discover the directories
 in `<path>`.
 
 ### Options

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,15 +40,19 @@ The script may prompt for your password as it installs the following components:
 * [Git](https://github.com/microsoft/git) (with custom patches)
 * [Git Credential Manager Core](https://github.com/microsoft/Git-Credential-Manager-Core)
 * Scalar
-* [Watchman](https://github.com/facebook/watchman)
+* [Watchman](https://github.com/facebook/watchman), unless you use the `--no-watchman` argument.
 
 Installing on Windows
 --------------------
 
 To install Scalar on Windows,
 [download the `Installers_Windows_Release.zip` from the releases page](https://github.com/microsoft/scalar/releases).
-Extract the `Installers_Windows_Release` folder and run the Git installer and then Scalar installer.
+Extract the `Installers_Windows_Release` folder, open it in a command prompt, and
+run `InstallScalar.bat`. This will install the following components:
 
+* [Git for Windows](https://github.com/microsoft/git) (with custom patches)
+* Scalar
+* [Watchman](https://github.com/facebook/watchman), if you use the `--watchman` argument.
 Documentation
 -------------
 


### PR DESCRIPTION
This updates the `Readme.md` file with some updated details.

Take a look at the finished product [on my fork](https://github.com/derrickstolee/scalar/tree/readme) to see what this would look like for a user coming to the repo home page.

Here are some things I noticed:

1. Our build instructions still had the GVFS dependencies for Visual Studio.
2. Our instructions included the old `BuildOutput` directory, and needed updating to our new .NET `out` directory.
3. We did not have install instructions for Windows.
4. The intro did not mention existing Git repos.
5. The intro now links to our `docs` folder for more info.
6. All instructions regarding building Scalar are now in `CONTRIBUTING.md`.
7. Headings were strangely changing between headings 1, 2, and 3. All are now level 2 except for the top "Scalar" title.
8. Several references to the old `scalar sparse` verb are removed and reference `git sparse-checkout set` instead.