### PR TITLE
Publish 'Installers' nupkgs as an Artifact

### DIFF
--- a/.azure-pipelines/templates/osx/pack.signed/step5-dist.yml
+++ b/.azure-pipelines/templates/osx/pack.signed/step5-dist.yml
@@ -42,9 +42,15 @@ steps:
       basePath: $(Build.ArtifactStagingDirectory)/dist
 
   - task: NuGetCommand@2
-    displayName: Publish distribution package (internal)
+    displayName: Push distribution package (internal)
     inputs:
       command: push
       packagesToPush: $(Build.ArtifactStagingDirectory)/nupkg/*.nupkg
       nuGetFeedType: external
       publishFeedCredentials: $(1ESFeedCredentials)
+
+  - task: PublishPipelineArtifact@1
+    displayName: Publish distribution package (internal)
+    inputs:
+      targetPath: $(Build.ArtifactStagingDirectory)/nupkg
+      artifactName: Package_macOS_$(configuration)

--- a/.azure-pipelines/templates/win/pack.signed.yml
+++ b/.azure-pipelines/templates/win/pack.signed.yml
@@ -79,9 +79,16 @@ steps:
       basePath: ..\out\Scalar.Installer.Windows\dist\$(configuration)
 
   - task: NuGetCommand@2
-    displayName: Publish distribution package (internal)
+    displayName: Push distribution package (internal)
     inputs:
       command: push
       packagesToPush: $(Build.ArtifactStagingDirectory)\NuGetPackage\*.nupkg
       nuGetFeedType: external
       publishFeedCredentials: $(1ESFeedCredentials)
+
+  - task: PublishPipelineArtifact@1
+    displayName: Publish distribution package (internal)
+    inputs:
+      targetPath: $(Build.ArtifactStagingDirectory)\NuGetPackage\
+      artifactName: "Package_Windows_$(configuration)"
+    condition: succeeded()


### PR DESCRIPTION
Publish the 'Scalar.Installers.<platform>' NuGet packages as a build artifact as well as pushing to the internal feed. This way we can always derive which package version a particular build pushed.

In VFS for Git we used to keep the build number of the build pipeline uniform across branches meaning we could always derive the pushed 'Installers' NuGet package version from that build number. Since we now only include the _product_ version number in branches built matching `releases/xx.xx.xx` we cannot do that.