### PR TITLE
Configure Watchman during ConfigStep

### DIFF
--- a/Scalar/CommandLine/CloneVerb.cs
+++ b/Scalar/CommandLine/CloneVerb.cs
@@ -274,8 +274,6 @@ namespace Scalar.CommandLine
                     }
                 }
 
-                this.ConfigureWatchmanIntegration();
-
                 cloneResult = this.CheckoutRepo();
             }
 
@@ -285,46 +283,6 @@ namespace Scalar.CommandLine
             }
 
             return cloneResult;
-        }
-
-        private void ConfigureWatchmanIntegration()
-        {
-            string watchmanLocation = ProcessHelper.GetProgramLocation(ScalarPlatform.Instance.Constants.ProgramLocaterCommand, "watchman");
-            this.Output.Write("Configuring Watchman...");
-            if (string.IsNullOrEmpty(watchmanLocation))
-            {
-                this.Output.WriteLine("Skipping: Watchman not installed.");
-                this.tracer.RelatedWarning("Watchman is not installed - skipping Watchman configuration.");
-                return;
-            }
-
-            try
-            {
-                string fsMonitorWatchmanSampleHookPath = Path.Combine(
-                    this.enlistment.WorkingDirectoryRoot,
-                    ScalarConstants.DotGit.Hooks.FsMonitorWatchmanSamplePath);
-
-                string queryWatchmanPath = Path.Combine(
-                    this.enlistment.WorkingDirectoryRoot,
-                    ScalarConstants.DotGit.Hooks.QueryWatchmanPath);
-
-                this.fileSystem.CopyFile(
-                    fsMonitorWatchmanSampleHookPath,
-                    queryWatchmanPath,
-                    overwrite: false);
-
-                this.git.SetInLocalConfig("core.fsmonitor", ".git/hooks/query-watchman");
-
-                // Complete the Configuring Watchman progress line...
-                this.Output.WriteLine("Succeeded.");
-                this.tracer.RelatedWarning("Watchman configured!");
-            }
-            catch (IOException ex)
-            {
-                this.Output.WriteLine("Failed: Check clone logs for details.");
-                EventMetadata metadata = this.CreateEventMetadata(ex);
-                this.tracer.RelatedError(metadata, $"Failed to configure Watchman integration: {ex.Message}");
-            }
         }
 
         private Result TryCreateEnlistment(


### PR DESCRIPTION
Resolves #291.

Mostly a code move from `CloneVerb` to `ConfigStep`. We lose some output during clone, like "Watchman configured!" as we don't have access to `Output` during the `ConfigStep`. The `CloneVerb` runs the `ConfigStep` directly, but so does the `RegisterStep` and background maintenance.

There is a benefit, though: we will try configuring Watchman on every upgrade and once a day. If a user installs Watchman after cloning, then we will configure it automatically.

One remaining thing to think about: we are currently _copying_ the existing hook template from the hooks directory. As this changes (see microsoft/git#225 and gitgitgadget/git#510), we will need a different way to populate the hook. Perhaps we should store the hook contents in the Scalar codebase to avoid using a stale (or malicious) hook. Cc @kewillford for thoughts on this.