### PR TITLE
Drop --no-update-remote-refs based on upstream feedback

### DIFF
--- a/Scalar.Common/Git/GitProcess.cs
+++ b/Scalar.Common/Git/GitProcess.cs
@@ -432,10 +432,12 @@ namespace Scalar.Common.Git
             string refspec = $"+{ScalarConstants.DotGit.Refs.Heads.RefName}/*"
                            + $":{ScalarConstants.DotGit.Refs.Scalar.Hidden.RefName}/{remote}/*";
 
-            // By using "--no-update-remote-refs", the user will see their remote refs update
+            // By using "--refmap", we override the configured refspec,
+            // ignoring the normal "+refs/heads/*:refs/remotes/<remote>/*".
+            // The user will see their remote refs update
             // normally when they do a foreground fetch.
             return this.InvokeGitInWorkingDirectoryRoot(
-                $"fetch {remote} --quiet --prune --no-update-remote-refs \"{refspec}\"",
+                $"fetch {remote} --quiet --prune --no-tags --refmap= \"{refspec}\"",
                 fetchMissingObjects: true);
         }
 

--- a/Scalar.FunctionalTests/Tests/GitRepoPerFixture/RunVerbTests.cs
+++ b/Scalar.FunctionalTests/Tests/GitRepoPerFixture/RunVerbTests.cs
@@ -106,13 +106,17 @@ namespace Scalar.FunctionalTests.Tests.GitRepoPerFixture
             string refsRemotesOrigin = Path.Combine(refsRoot, "remotes", "origin");
             string refsHidden = Path.Combine(refsRoot, "scalar", "hidden");
             string refsHiddenOriginFake = Path.Combine(refsHidden, "origin", "fake");
+            string packedRefs = Path.Combine(this.Enlistment.RepoRoot, ".git", "packed-refs");
 
             // Removing refs makes the next fetch need to download a new pack
             this.fileSystem.DeleteDirectory(refsHeads);
             this.fileSystem.DeleteDirectory(refsRemotesOrigin);
             this.fileSystem.DeleteDirectory(this.PackRoot);
             this.fileSystem.CreateDirectory(this.PackRoot);
-            this.fileSystem.DirectoryExists(refsRemotesOrigin).ShouldBeFalse($"{refsRemotesOrigin} was not deleted");
+            if (this.fileSystem.FileExists(packedRefs))
+            {
+                this.fileSystem.DeleteFile(packedRefs);
+            }
 
             this.Enlistment.RunVerb("fetch");
 


### PR DESCRIPTION
As I was upstreaming the `--no-update-remote-refs` option, Peff pointed out that we already have a way to do what I was trying to do. It's a little obscure, but the `--refmap=` option will override the configured refspec that is normally populating the remote refs.

This will allow me to revert [the `--no-update-remote-refs` option](https://github.com/microsoft/git/pull/228/commits/7f8481bc1436f3fbbde67adc8e30b22e65ca6756) in microsoft/git.