### PR TITLE
Add '-scalar' prefix to OrgInfoApp query param 'Platform'

### DIFF
--- a/Scalar.Common/OrgInfoApiClient.cs
+++ b/Scalar.Common/OrgInfoApiClient.cs
@@ -36,7 +36,10 @@ namespace Scalar.Common
             Dictionary<string, string> queryParams = new Dictionary<string, string>()
             {
                 { "Organization", orgName },
-                { "Platform", platform },
+                // Add '-scalar' suffix to Platform so we can continue to use the same orginfo function app as VFS for Git.
+                // We cannot use Organization as this is computed from the upgrade.feedUrl config entry, and cannot use
+                // Ring as this will complicate some scenarios regarding provisioning the downstream feeds.
+                { "Platform", $"{platform}-scalar" },
                 { "Ring", ring },
             };
 

--- a/Scalar.UnitTests/Common/OrgInfoApiClientTests.cs
+++ b/Scalar.UnitTests/Common/OrgInfoApiClientTests.cs
@@ -40,7 +40,7 @@ namespace Scalar.UnitTests.Common
             Mock<HttpMessageHandler> handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
 
             handlerMock.Protected().As<IHttpMessageHandlerProtectedMembers>()
-                .Setup(m => m.SendAsync(It.Is<HttpRequestMessage>(request => this.UriMatches(request.RequestUri, this.baseUrl, orgInfo.OrgName, orgInfo.Platform, orgInfo.Ring)), It.IsAny<CancellationToken>()))
+                .Setup(m => m.SendAsync(It.Is<HttpRequestMessage>(request => this.UriMatches(request.RequestUri, this.baseUrl, orgInfo.OrgName, $"{orgInfo.Platform}-scalar", orgInfo.Ring)), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new HttpResponseMessage()
                 {
                     StatusCode = HttpStatusCode.OK,


### PR DESCRIPTION
Add '-scalar' suffix to Platform so we can continue to use the same orginfo function app as VFS for Git. We cannot use Organization as this is computed from the upgrade.feedUrl config entry, and cannot use Ring as this will complicate some scenarios regarding provisioning the downstream feeds.