### PR TITLE
BackgroundFetch: disable interactive auth

### DIFF
--- a/Scalar.UnitTests/Mock/Git/MockGitProcess.cs
+++ b/Scalar.UnitTests/Mock/Git/MockGitProcess.cs
@@ -82,7 +82,8 @@ namespace Scalar.UnitTests.Mock.Git
             Action<StreamWriter> writeStdIn,
             Action<string> parseStdOutLine,
             int timeoutMs,
-            string gitObjectsDirectory = null)
+            string gitObjectsDirectory = null,
+            bool userInteractive = true)
         {
             this.CommandsRun.Add(command);
 


### PR DESCRIPTION
The [`GCM_INTERACTIVE`](https://github.com/microsoft/Git-Credential-Manager-for-Windows/blob/0d9a0dd5f0d52e8586feb816069b1db5d5e2dbca/Docs/Environment.md#gcm_interactive) environment variable toggles whether or not the interactive prompt will appear when trying to gain credentials.

Disable interactive auth when running background fetch.

See also microsoft/Git-Credential-Manager-Core#90.