### PR TITLE
Ignore intermittently failing test: CreateFileWithoutClose

### DIFF
--- a/Scalar.FunctionalTests/Tests/GitCommands/StatusTests.cs
+++ b/Scalar.FunctionalTests/Tests/GitCommands/StatusTests.cs
@@ -41,6 +41,7 @@ namespace Scalar.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
+        [Ignore("Intermittently failing test")]
         public void CreateFileWithoutClose()
         {
             string srcPath = @"CreateFileWithoutClose.md";


### PR DESCRIPTION
Disable a bad test in this release.