### PR TITLE
Delete CreateFileWithoutClose test

### DIFF
--- a/Scalar.FunctionalTests/FileSystemRunners/BashRunner.cs
+++ b/Scalar.FunctionalTests/FileSystemRunners/BashRunner.cs
@@ -304,11 +304,6 @@ namespace Scalar.FunctionalTests.FileSystemRunners
             return long.Parse(this.RunProcess(statCommand));
         }
 
-        public override void CreateFileWithoutClose(string path)
-        {
-            throw new NotImplementedException();
-        }
-
         public override IDisposable OpenFileAndWrite(string path, string data)
         {
             throw new NotImplementedException();

--- a/Scalar.FunctionalTests/FileSystemRunners/CmdRunner.cs
+++ b/Scalar.FunctionalTests/FileSystemRunners/CmdRunner.cs
@@ -229,11 +229,6 @@ namespace Scalar.FunctionalTests.FileSystemRunners
             throw new NotSupportedException();
         }
 
-        public override void CreateFileWithoutClose(string path)
-        {
-            throw new NotImplementedException();
-        }
-
         public override IDisposable OpenFileAndWrite(string path, string data)
         {
             throw new NotImplementedException();

--- a/Scalar.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
+++ b/Scalar.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
@@ -75,7 +75,6 @@ namespace Scalar.FunctionalTests.FileSystemRunners
         /// <param name="path">Path to file</param>
         /// <param name="contents">File contents</param>
         public abstract void WriteAllText(string path, string contents);
-        public abstract void CreateFileWithoutClose(string path);
         public abstract IDisposable OpenFileAndWrite(string path, string data);
 
         /// <summary>

--- a/Scalar.FunctionalTests/FileSystemRunners/PowerShellRunner.cs
+++ b/Scalar.FunctionalTests/FileSystemRunners/PowerShellRunner.cs
@@ -211,11 +211,6 @@ namespace Scalar.FunctionalTests.FileSystemRunners
             throw new System.NotSupportedException();
         }
 
-        public override void CreateFileWithoutClose(string path)
-        {
-            throw new System.NotSupportedException();
-        }
-
         public override IDisposable OpenFileAndWrite(string path, string data)
         {
             throw new System.NotSupportedException();

--- a/Scalar.FunctionalTests/FileSystemRunners/SystemIORunner.cs
+++ b/Scalar.FunctionalTests/FileSystemRunners/SystemIORunner.cs
@@ -22,11 +22,6 @@ namespace Scalar.FunctionalTests.FileSystemRunners
             return string.Empty;
         }
 
-        public override void CreateFileWithoutClose(string path)
-        {
-            File.Create(path);
-        }
-
         public override IDisposable OpenFileAndWrite(string path, string content)
         {
             StreamWriter file = new StreamWriter(path);

--- a/Scalar.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
+++ b/Scalar.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
@@ -305,14 +305,6 @@ namespace Scalar.FunctionalTests.Tests.GitCommands
             this.FileSystem.WriteAllText(controlFile, content);
         }
 
-        protected void CreateFileWithoutClose(string path)
-        {
-            string virtualFile = Path.Combine(this.Enlistment.RepoRoot, path);
-            string controlFile = Path.Combine(this.ControlGitRepo.RootPath, path);
-            this.FileSystem.CreateFileWithoutClose(virtualFile);
-            this.FileSystem.CreateFileWithoutClose(controlFile);
-        }
-
         protected IDisposable ReadFileAndWriteWithoutClose(string path, string contents)
         {
             string virtualFile = Path.Combine(this.Enlistment.RepoRoot, path);

--- a/Scalar.FunctionalTests/Tests/GitCommands/StatusTests.cs
+++ b/Scalar.FunctionalTests/Tests/GitCommands/StatusTests.cs
@@ -41,14 +41,6 @@ namespace Scalar.FunctionalTests.Tests.GitCommands
         }
 
         [TestCase]
-        public void CreateFileWithoutClose()
-        {
-            string srcPath = @"CreateFileWithoutClose.md";
-            this.CreateFileWithoutClose(srcPath);
-            this.ValidGitStatusWithRetry(srcPath);
-        }
-
-        [TestCase]
         public void WriteWithoutClose()
         {
             string srcPath = @"Readme.md";


### PR DESCRIPTION
This test has been flaky, and that is to be expected for a test that creates a `FileStream` and doesn't wrap it in a `using` statement. The handles get GC'd in parallel, causing the test validation to have different results between the comparison repo and the Scalar repo.

We already have a similar test with `WriteWithoutClose` that does the right thing.