### PR TITLE
Add missing Git SSL/TLS unit tests

### DIFF
--- a/Scalar.UnitTests/Common/Git/GitSslTests.cs
+++ b/Scalar.UnitTests/Common/Git/GitSslTests.cs
@@ -1,4 +1,3 @@
-#if NETCOREAPP2_1
 using Moq;
 using NUnit.Framework;
 using Scalar.Common;
@@ -268,4 +267,3 @@ namespace Scalar.UnitTests.Common.Git
         }
     }
 }
-#endif


### PR DESCRIPTION
During the port to .NET Core 3, we missed the fact that the `GitSslTests` test fixture was being conditionally compiled only when `NETCOREAPP_21` was defined.

Removing the `#if` directive and always including those tests.