### PR TITLE
CloneVerb: Show progress during initial checkout

### DIFF
--- a/Scalar/CommandLine/CloneVerb.cs
+++ b/Scalar/CommandLine/CloneVerb.cs
@@ -274,7 +274,13 @@ namespace Scalar.CommandLine
                     }
                 }
 
-                cloneResult = this.CheckoutRepo();
+                this.ShowStatusWhileRunning(
+                    () =>
+                    {
+                        cloneResult = this.CheckoutRepo();
+                        return cloneResult.Success;
+                    },
+                    "Populating working directory");
             }
 
             if (cloneResult.Success)


### PR DESCRIPTION
Resolves #179 to create a spinner during the `git checkout` portion of `scalar clone`. This step was trivial in VFS for Git, because Git didn't need to do any work since everything was projected at this point.