### PR TITLE
[port rel165] Remove all vestiges of the mount process from C# code

### DIFF
--- a/AuthoringTests.md
+++ b/AuthoringTests.md
@@ -92,8 +92,7 @@ Mac:
 
 ## How to Write a Functional Test
 
-Each piece of functionality that we add to Scalar should have corresponding functional tests that clone a repo, mount the filesystem, and use existing tools and filesystem
-APIs to interact with the virtual repo.
+Each piece of functionality that we add to Scalar should have corresponding functional tests that clone a repo and use existing tools and filesystem APIs to interact with the virtual repo.
 
 Since these are functional tests that can potentially modify the state of files on disk, you need to be careful to make sure each test can run in a clean 
 environment.  There are three base classes that you can derive from when writing your tests.  It's also important to put your new class into the same namespace
@@ -101,14 +100,11 @@ as the base class, because NUnit treats namespaces like test suites, and we have
 
 1. `TestsWithLongRunningEnlistment`
 
-    Before any test in this namespace is executed, we create a single enlistment and mount Scalar.  We then run all tests in this namespace that derive
-	from this base class.  Only put tests in here that are purely readonly and will leave the repo in a good state for future tests.
+    Before any test in this namespace is executed, we create a single enlistment.  We then run all tests in this namespace that derive from this base class.  Only put tests in here that are purely readonly and will leave the repo in a good state for future tests.
 
 2. `TestsWithEnlistmentPerFixture`
 
-    For any test fixture (a fixture is the same as a class in NUnit) that derives from this class, we create an enlistment and mount Scalar before running
-	any of the tests in the fixture, and then we unmount and delete the enlistment after all tests are done (but before any other fixture runs).  If you need
-	to write a sequence of tests that manipulate the same repo, this is the right base class.
+    For any test fixture (a fixture is the same as a class in NUnit) that derives from this class, we create an enlistment before running any of the tests in the fixture, and then we delete the enlistment after all tests are done (but before any other fixture runs).  If you need to write a sequence of tests that manipulate the same repo, this is the right base class.
 
 3. `TestsWithEnlistmentPerTestCase`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,19 +2,18 @@
 
 Thank you for taking the time to contribute!
 
-## Guidelines
-
-* [Contributor License Agreement](#contributor-license-agreement)
-* [Code of Conduct](#code-of-conduct)
-* [Building Scalar on Windows](#building-scalar-on-windows)
-* [Building Scalar on Mac](#building-scalar-on-mac)
-* [Design Reviews](#design-reviews)
-* [Platform Specific Code](#platform-specific-code)
-* [Tracing and Logging](#tracing-and-logging)
-* [Error Handling](#error-handling)
-* [Background Threads](#background-threads)
-* [Coding Conventions](#coding-conventions)
-* [Testing](#testing)
+ - [Contributor License Agreement](#contributor-license-agreement)
+ - [Code of Conduct](#code-of-conduct)
+ - [Building Scalar on Windows](#building-scalar-on-windows)
+ - [Building Scalar on Mac](#building-scalar-on-mac)
+ - [Design Reviews](#design-reviews)
+ - [Platform Specific Code](#platform-specific-code)
+ - [Tracing and Logging](#tracing-and-logging)
+ - [Error Handling](#error-handling)
+ - [Background Threads](#background-threads)
+ - [Coding Conventions](#coding-conventions)
+ - [Testing](#testing)
+   - [C# Unit Tests](#c-unit-tests)
 
 ## Contributor License Agreement
 
@@ -115,11 +114,11 @@ The design review process is as follows:
   catch (Exception e)
   {
     EventMetadata metadata = new EventMetadata();
-    metadata.Add("Area", "Mount");
-    metadata.Add(nameof(enlistmentHookPath), enlistmentHookPath);
-    metadata.Add(nameof(installedHookPath), installedHookPath);
+    metadata.Add("Area", "Upgrade");
+    metadata.Add(nameof(packageVersion), packageVersion);
+    metadata.Add(nameof(packageName), packageName);
     metadata.Add("Exception", e.ToString());
-    context.Tracer.RelatedError(metadata, $"Failed to compare {hook.Name} version");
+    context.Tracer.RelatedError(metadata, $"Failed to compare {packageName} version");
   }
   ```
 
@@ -127,7 +126,7 @@ The design review process is as follows:
 
 - *Fail fast: An error or exception that risks data loss or corruption should shut down Scalar immediately*
 
-  Preventing data loss and repository corruption is critical.  If an error or exception occurs that could lead to data loss, it's better to shut down Scalar than keep the repository mounted and risk corruption.
+  Preventing data loss and repository corruption is critical.  If an error or exception occurs that could lead to data loss, it's better to shut down Scalar than risk corruption.
 
 - *Do not catch exceptions that are indicative of a programmer error (e.g. `ArgumentNullException`)*
 
@@ -222,7 +221,7 @@ The design review process is as follows:
 
 - <a id="bgexceptions"></a>*Catch all exceptions on long-running tasks and background threads*
 
-  Wrap all code that runs in the background thread in a top-level `try/catch(Exception)`.  Any exceptions caught by this handler should be logged, and then Scalar should be forced to terminate with `Environment.Exit`.  It's not safe to allow Scalar to continue to run after an unhandled exception stops a background thread or long-running task.  Testing has shown that `Environment.Exit` consistently terminates the Scalar mount process regardless of how background threads are started (e.g. native thread, `new Thread()`, `Task.Factory.StartNew()`).
+  Wrap all code that runs in the background thread in a top-level `try/catch(Exception)`.  Any exceptions caught by this handler should be logged, and then Scalar should be forced to terminate with `Environment.Exit`.  It's not safe to allow Scalar to continue to run after an unhandled exception stops a background thread or long-running task.  Testing has shown that `Environment.Exit` consistently terminates the process regardless of how background threads are started (e.g. native thread, `new Thread()`, `Task.Factory.StartNew()`).
 
   An example of this pattern can be seen in [`BackgroundFileSystemTaskRunner.ProcessBackgroundTasks`](https://github.com/Microsoft/Scalar/blob/4baa37df6bde2c9a9e1917fc7ce5debd653777c0/Scalar/Scalar.Virtualization/Background/BackgroundFileSystemTaskRunner.cs#L233).
 

--- a/Scalar.Common/GitHubUpgrader.cs
+++ b/Scalar.Common/GitHubUpgrader.cs
@@ -19,7 +19,7 @@ namespace Scalar.Common
         private const string JSONMediaType = @"application/vnd.github.v3+json";
         private const string UserAgent = @"Scalar_Auto_Upgrader";
         private const string CommonInstallerArgs = "/VERYSILENT /CLOSEAPPLICATIONS /SUPPRESSMSGBOXES /NORESTART";
-        private const string ScalarInstallerArgs = CommonInstallerArgs + " /REMOUNTREPOS=false";
+        private const string ScalarInstallerArgs = CommonInstallerArgs;
         private const string GitInstallerArgs = CommonInstallerArgs + " /ALLOWDOWNGRADE=1";
         private const string GitAssetId = "Git";
         private const string ScalarAssetId = "Scalar";

--- a/Scalar.Common/InstallerPreRunChecker.cs
+++ b/Scalar.Common/InstallerPreRunChecker.cs
@@ -44,32 +44,6 @@ namespace Scalar.Upgrader
             return true;
         }
 
-        // TODO: Move repo mount calls to Scalar.Upgrader project.
-        // https://github.com/Microsoft/Scalar/issues/293
-        public virtual bool TryMountAllScalarRepos(out string consoleError)
-        {
-            return this.TryRunScalarWithArgs("service --mount-all", out consoleError);
-        }
-
-        public virtual bool TryUnmountAllScalarRepos(out string consoleError)
-        {
-            consoleError = null;
-            this.tracer.RelatedInfo("Unmounting any mounted Scalar repositories.");
-
-            using (ITracer activity = this.tracer.StartActivity(nameof(this.TryUnmountAllScalarRepos), EventLevel.Informational))
-            {
-                if (!this.TryRunScalarWithArgs("service --unmount-all", out consoleError))
-                {
-                    this.tracer.RelatedError($"{nameof(this.TryUnmountAllScalarRepos)}: {consoleError}");
-                    return false;
-                }
-
-                activity.RelatedInfo("Successfully unmounted repositories.");
-            }
-
-            return true;
-        }
-
         public virtual bool IsInstallationBlockedByRunningProcess(out string consoleError)
         {
             consoleError = null;

--- a/Scalar.Common/Maintenance/GitMaintenanceStep.cs
+++ b/Scalar.Common/Maintenance/GitMaintenanceStep.cs
@@ -32,7 +32,7 @@ namespace Scalar.Common.Maintenance
 
         public static bool EnlistmentRootReady(ScalarContext context)
         {
-            // If a user locks their drive or disconnects an external drive while the mount process
+            // If a user locks their drive or disconnects an external drive while the process
             // is running, then it will appear as if the directories below do not exist or throw
             // a "Device is not ready" error.
             try
@@ -188,7 +188,7 @@ namespace Scalar.Common.Maintenance
                 {
                     this.Context.Tracer.RelatedWarning(
                         metadata: null,
-                        message: $"{this.Area}: Not launching Git process {gitCommand} because the mount is stopping",
+                        message: $"{this.Area}: Not launching Git process {gitCommand} because the process is stopping",
                         keywords: Keywords.Telemetry);
                     throw new StoppingException();
                 }

--- a/Scalar.Common/Platforms/Windows/WindowsPlatform.Shared.cs
+++ b/Scalar.Common/Platforms/Windows/WindowsPlatform.Shared.cs
@@ -50,7 +50,7 @@ namespace Scalar.Platform.Windows
                 }
                 else if (tryGetProcessById)
                 {
-                    // The process.IsInvalid may be true when the mount process doesn't have access to call
+                    // The process.IsInvalid may be true when the process doesn't have access to call
                     // OpenProcess for the specified processId. Fallback to slow way of finding process.
                     try
                     {

--- a/Scalar.Common/ScalarConstants.cs
+++ b/Scalar.Common/ScalarConstants.cs
@@ -83,14 +83,10 @@ namespace Scalar.Common
 
         public static class LogFileTypes
         {
-            public const string MountPrefix = "mount";
             public const string UpgradePrefix = "productupgrade";
 
             public const string Clone = "clone";
             public const string Maintenance = "maintenance";
-            public const string MountVerb = MountPrefix + "_verb";
-            public const string MountProcess = MountPrefix + "_process";
-            public const string MountUpgrade = MountPrefix + "_repoupgrade";
             public const string Repair = "repair";
             public const string Service = "service";
             public const string ServiceUI = "service_ui";
@@ -194,23 +190,6 @@ namespace Scalar.Common
         public static class VerbParameters
         {
             public const string InternalUseOnly = "internal_use_only";
-
-            public static class Mount
-            {
-                public const string StartedByService = "StartedByService";
-                public const string StartedByVerb = "StartedByVerb";
-                public const string Verbosity = "verbosity";
-                public const string Keywords = "keywords";
-                public const string DebugWindow = "debug-window";
-
-                public const string DefaultVerbosity = "Informational";
-                public const string DefaultKeywords = "Any";
-            }
-
-            public static class Unmount
-            {
-                public const string SkipLock = "skip-wait-for-lock";
-            }
 
             public static class Maintenance
             {

--- a/Scalar.Common/ScalarEnlistment.cs
+++ b/Scalar.Common/ScalarEnlistment.cs
@@ -45,7 +45,7 @@ namespace Scalar.Common
 
         public bool UsesGvfsProtocol { get; protected set; }
 
-        // These version properties are only used in logging during clone and mount to track version numbers
+        // These version properties are only used in logging during clone to track version numbers
         public string GitVersion
         {
             get { return this.gitVersion; }

--- a/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
+++ b/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
@@ -111,8 +111,6 @@ namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
             result.ExitCode.ShouldEqual(0, $"git {command} failed on {nameof(enlistment2)} with error: {result.Errors}");
         }
 
-        // Override OnTearDownEnlistmentsDeleted rathern than using [TearDown] as the enlistments need to be unmounted before
-        // localCacheParentPath can be deleted (as the SQLite blob sizes database cannot be deleted while Scalar is mounted)
         protected override void OnTearDownEnlistmentsDeleted()
         {
             RepositoryHelpers.DeleteTestDirectory(this.localCacheParentPath);

--- a/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/TestsWithMultiEnlistment.cs
+++ b/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/TestsWithMultiEnlistment.cs
@@ -22,7 +22,7 @@ namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
         }
 
         /// <summary>
-        /// Can be overridden for custom [TearDown] steps that occur after the test enlistements have been unmounted and deleted
+        /// Can be overridden for custom [TearDown] steps that occur after the test enlistments have been deleted
         /// </summary>
         protected virtual void OnTearDownEnlistmentsDeleted()
         {

--- a/Scalar.FunctionalTests/Tests/TestResultsHelper.cs
+++ b/Scalar.FunctionalTests/Tests/TestResultsHelper.cs
@@ -20,18 +20,7 @@ namespace Scalar.FunctionalTests.Tests
 
             foreach (string filename in GetAllFilesInDirectory(enlistment.ScalarLogsRoot))
             {
-                if (filename.Contains("mount_process"))
-                {
-                    // Validate that all mount processes started by the functional tests were started
-                    // by verbs, and that "StartedByVerb" was set to true when the mount process was launched
-                    OutputFileContents(
-                        filename,
-                        contents => contents.ShouldContain("\"StartedByVerb\":true"));
-                }
-                else
-                {
-                    OutputFileContents(filename);
-                }
+                OutputFileContents(filename);
             }
         }
 

--- a/Scalar.FunctionalTests/Tools/ScalarProcess.cs
+++ b/Scalar.FunctionalTests/Tools/ScalarProcess.cs
@@ -40,22 +40,6 @@ namespace Scalar.FunctionalTests.Tools
             this.CallScalar(args, expectedExitCode: SuccessExitCode);
         }
 
-        public void Mount()
-        {
-            string output;
-            this.TryMount(out output).ShouldEqual(true, "Scalar did not mount: " + output);
-
-            // TODO: Re-add this warning after we work out the version detail information
-            // output.ShouldNotContain(ignoreCase: true, unexpectedSubstrings: "warning");
-        }
-
-        public bool TryMount(out string output)
-        {
-            this.IsEnlistmentMounted().ShouldEqual(false, "Scalar is already mounted");
-            output = this.CallScalar("mount \"" + this.enlistmentRoot + "\"");
-            return this.IsEnlistmentMounted();
-        }
-
         public string RunVerb(string task, long? batchSize = null, bool failOnError = true)
         {
             string batchArg = batchSize == null
@@ -104,21 +88,6 @@ namespace Scalar.FunctionalTests.Tools
         public string CacheServer(string args)
         {
             return this.CallScalar("cache-server " + args + " \"" + this.enlistmentRoot + "\"");
-        }
-
-        public void Unmount()
-        {
-            if (this.IsEnlistmentMounted())
-            {
-                string result = this.CallScalar("unmount \"" + this.enlistmentRoot + "\"", expectedExitCode: SuccessExitCode);
-                this.IsEnlistmentMounted().ShouldEqual(false, "Scalar did not unmount: " + result);
-            }
-        }
-
-        public bool IsEnlistmentMounted()
-        {
-            string statusResult = this.CallScalar("status \"" + this.enlistmentRoot + "\"");
-            return statusResult.Contains("Mount status: Ready");
         }
 
         public string RunServiceVerb(string argument)

--- a/Scalar.Installer.Mac/scripts/preinstall
+++ b/Scalar.Installer.Mac/scripts/preinstall
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-SCALARBINPATH="/usr/local/scalar/scalar"
-if [ -f "${SCALARBINPATH}" ]; then
-    unmountCmd="${SCALARBINPATH} service --help"
-    echo $unmountCmd
-    eval $unmountCmd || exit 1
-fi

--- a/Scalar.UnitTests/Mock/MockInstallerPreRunChecker.cs
+++ b/Scalar.UnitTests/Mock/MockInstallerPreRunChecker.cs
@@ -22,8 +22,6 @@ namespace Scalar.UnitTests.Mock.Upgrader
             IsElevated = 0x2,
             BlockingProcessesRunning = 0x4,
             UnattendedMode = 0x8,
-            UnMountRepos = 0x10,
-            RemountRepos = 0x20,
             IsServiceInstalledAndNotRunning = 0x40,
         }
 
@@ -86,20 +84,6 @@ namespace Scalar.UnitTests.Mock.Upgrader
 
         protected override bool TryRunScalarWithArgs(string args, out string error)
         {
-            if (string.CompareOrdinal(args, "service --unmount-all") == 0)
-            {
-                bool result = this.FakedResultOfCheck(FailOnCheckType.UnMountRepos);
-                error = result == false ? "Unmount of some of the repositories failed." : null;
-                return result;
-            }
-
-            if (string.CompareOrdinal(args, "service --mount-all") == 0)
-            {
-                bool result = this.FakedResultOfCheck(FailOnCheckType.RemountRepos);
-                error = result == false ? "Auto remount failed." : null;
-                return result;
-            }
-
             error = "Unknown Scalar command";
             return false;
         }

--- a/Scalar.UnitTests/Service/Mac/MacScalarVerbRunnerTests.cs
+++ b/Scalar.UnitTests/Service/Mac/MacScalarVerbRunnerTests.cs
@@ -35,17 +35,17 @@ namespace Scalar.UnitTests.Service.Mac
             string expectedArgs =
                 $"run {taskVerbName} \"{ExpectedActiveRepoPath}\" --{ScalarConstants.VerbParameters.InternalUseOnly} {new InternalVerbParameters(startedByService: true).ToJson()}";
 
-            Mock<MacScalarVerbRunner.ScalarProcessLauncher> mountLauncherMock = new Mock<MacScalarVerbRunner.ScalarProcessLauncher>(MockBehavior.Strict, this.tracer);
-            mountLauncherMock.Setup(mp => mp.LaunchProcess(
+            Mock<MacScalarVerbRunner.ScalarProcessLauncher> procLauncherMock = new Mock<MacScalarVerbRunner.ScalarProcessLauncher>(MockBehavior.Strict, this.tracer);
+            procLauncherMock.Setup(mp => mp.LaunchProcess(
                 scalarBinPath,
                 expectedArgs,
                 ExpectedActiveRepoPath))
                 .Returns(new ProcessResult(output: string.Empty, errors: string.Empty, exitCode: 0));
 
-            MacScalarVerbRunner verbProcess = new MacScalarVerbRunner(this.tracer, mountLauncherMock.Object);
+            MacScalarVerbRunner verbProcess = new MacScalarVerbRunner(this.tracer, procLauncherMock.Object);
             verbProcess.CallMaintenance(task, ExpectedActiveRepoPath, ExpectedActiveUserId);
 
-            mountLauncherMock.VerifyAll();
+            procLauncherMock.VerifyAll();
         }
     }
 }

--- a/Scalar.UnitTests/Upgrader/UpgradeOrchestratorWithGitHubUpgraderTests.cs
+++ b/Scalar.UnitTests/Upgrader/UpgradeOrchestratorWithGitHubUpgraderTests.cs
@@ -34,24 +34,6 @@ namespace Scalar.UnitTests.Upgrader
             this.Tracer.RelatedErrorEvents.ShouldBeEmpty();
         }
 
-        [TestCase]
-        public void AutoUnmountError()
-        {
-            this.ConfigureRunAndVerify(
-                configure: () =>
-                {
-                    this.PrerunChecker.SetReturnFalseOnCheck(MockInstallerPrerunChecker.FailOnCheckType.UnMountRepos);
-                },
-                expectedReturn: ReturnCode.GenericError,
-                expectedOutput: new List<string>
-                {
-                    "Unmount of some of the repositories failed."
-                },
-                expectedErrors: new List<string>
-                {
-                    "Unmount of some of the repositories failed."
-                });
-        }
 
         [TestCase]
         public void AbortOnBlockingProcess()
@@ -194,7 +176,7 @@ namespace Scalar.UnitTests.Upgrader
 
             string args;
             gitInstallerInfo.TryGetValue("Args", out args).ShouldBeTrue();
-            args.ShouldContain(new string[] { "/VERYSILENT", "/CLOSEAPPLICATIONS", "/SUPPRESSMSGBOXES", "/NORESTART", "/Log", "/REMOUNTREPOS=false" });
+            args.ShouldContain(new string[] { "/VERYSILENT", "/CLOSEAPPLICATIONS", "/SUPPRESSMSGBOXES", "/NORESTART", "/Log" });
         }
 
         [TestCase]
@@ -268,25 +250,6 @@ namespace Scalar.UnitTests.Upgrader
                 expectedErrors: new List<string>
                 {
                     "Error deleting downloaded Git installer."
-                });
-        }
-
-        [TestCase]
-        public void RemountReposError()
-        {
-            this.ConfigureRunAndVerify(
-                configure: () =>
-                {
-                    this.PrerunChecker.SetReturnFalseOnCheck(MockInstallerPrerunChecker.FailOnCheckType.RemountRepos);
-                },
-                expectedReturn: ReturnCode.Success,
-                expectedOutput: new List<string>
-                {
-                    "Auto remount failed."
-                },
-                expectedErrors: new List<string>
-                {
-                    "Auto remount failed."
                 });
         }
 

--- a/Scalar.Upgrader/MacUpgradeOrchestrator.cs
+++ b/Scalar.Upgrader/MacUpgradeOrchestrator.cs
@@ -6,12 +6,5 @@ namespace Scalar.Upgrader
         : base(options)
         {
         }
-
-        protected override bool TryMountRepositories(out string consoleError)
-        {
-            // Mac upgrader does not mount repositories
-            consoleError = null;
-            return true;
-        }
     }
 }

--- a/Scalar.Upgrader/WindowsUpgradeOrchestrator.cs
+++ b/Scalar.Upgrader/WindowsUpgradeOrchestrator.cs
@@ -22,34 +22,5 @@ namespace Scalar.Upgrader
             : base(options)
         {
         }
-
-        protected override bool TryMountRepositories(out string consoleError)
-        {
-            string errorMessage = string.Empty;
-            if (this.mount && !this.LaunchInsideSpinner(
-                () =>
-                {
-                    string mountError;
-                    if (!this.preRunChecker.TryMountAllScalarRepos(out mountError))
-                    {
-                        EventMetadata metadata = new EventMetadata();
-                        metadata.Add("Upgrade Step", nameof(this.TryMountRepositories));
-                        metadata.Add("Mount Error", mountError);
-                        this.tracer.RelatedError(metadata, $"{nameof(this.preRunChecker.TryMountAllScalarRepos)} failed.");
-                        errorMessage += mountError;
-                        return false;
-                    }
-
-                    return true;
-                },
-                "Mounting repositories"))
-            {
-                consoleError = errorMessage;
-                return false;
-            }
-
-            consoleError = null;
-            return true;
-        }
     }
 }

--- a/Scalar/CommandLine/CacheServerVerb.cs
+++ b/Scalar/CommandLine/CacheServerVerb.cs
@@ -62,8 +62,6 @@ namespace Scalar.CommandLine
                     {
                         this.ReportErrorAndExit("Failed to save cache to config: " + error);
                     }
-
-                    this.Output.WriteLine("You must remount Scalar for this to take effect.");
                 }
                 else if (this.ListCacheServers)
                 {

--- a/Scalar/CommandLine/ScalarVerb.cs
+++ b/Scalar/CommandLine/ScalarVerb.cs
@@ -46,13 +46,13 @@ namespace Scalar.CommandLine
                 {
                     try
                     {
-                        InternalVerbParameters mountInternal = InternalVerbParameters.FromJson(value);
-                        if (!string.IsNullOrEmpty(mountInternal.ServiceName))
+                        InternalVerbParameters internalParams = InternalVerbParameters.FromJson(value);
+                        if (!string.IsNullOrEmpty(internalParams.ServiceName))
                         {
-                            this.ServiceName = mountInternal.ServiceName;
+                            this.ServiceName = internalParams.ServiceName;
                         }
 
-                        this.StartedByService = mountInternal.StartedByService;
+                        this.StartedByService = internalParams.StartedByService;
                     }
                     catch (JsonReaderException e)
                     {


### PR DESCRIPTION
Remove all vestiges of the mount process and related actions (mount, unmount) from the C# code and documentation.

Mount references are left in the Mac notifications app for now so we can use that code as a reference to add upgrade notifications later, like we have on Windows.

This is also preventing upgrade from working since it's trying to do unmount/remount during installation.

Ported from #315 