### PR TITLE
Fix verification of upgrade packages

### DIFF
--- a/Dependencies.props
+++ b/Dependencies.props
@@ -6,7 +6,8 @@
     <PackageReference Update="Microsoft.PowerShell.SDK"        Version="6.2.2"  />
     <PackageReference Update="Microsoft.Windows.Compatibility" Version="2.1.1"  />
     <PackageReference Update="Newtonsoft.Json"                 Version="12.0.2" />
-    <PackageReference Update="NuGet.Commands"                  Version="5.2.0"  />
+    <PackageReference Update="NuGet.CommandLine"               Version="5.4.0"  />
+    <PackageReference Update="NuGet.Commands"                  Version="5.4.0"  />
     <PackageReference Update="GitForWindows.GVFS.Installer"    Version="$(GitPackageVersion)" />
     <PackageReference Update="GitForMac.GVFS.Installer"        Version="$(GitPackageVersion)" />
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,7 +25,7 @@
     <BaseIntermediateOutputPath>$(ProjectOutPath)obj\</BaseIntermediateOutputPath>
 
     <!-- Common build properties -->
-    <RuntimeIdentifiers>win-x64;osx-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x64;osx-x64</RuntimeIdentifiers>
     <Deterministic>true</Deterministic>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <CodeAnalysisRuleSet>$(RepoPath)Scalar.ruleset</CodeAnalysisRuleSet>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,6 +43,9 @@
     <!-- Signing certificates -->
     <AuthenticodeCert>Microsoft400</AuthenticodeCert>
     <MacFilesCert>8003</MacFilesCert>
+
+    <!-- Compiled build constants -->
+    <ExternalBinariesDirectoryName>extbin</ExternalBinariesDirectoryName>
   </PropertyGroup>
 
   <!-- Common build-only dependencies -->

--- a/Scalar.Common/NuGetUpgrade/NuGetUpgrader.cs
+++ b/Scalar.Common/NuGetUpgrade/NuGetUpgrader.cs
@@ -47,7 +47,8 @@ namespace Scalar.Common.NuGetUpgrade
                     downloadFolder,
                     null,
                     ScalarPlatform.Instance.UnderConstruction.SupportsNuGetEncryption,
-                    tracer),
+                    tracer,
+                    fileSystem),
                 credentialStore,
                 ScalarPlatform.Instance.CreateProductUpgraderPlatformInteractions(fileSystem, tracer))
         {

--- a/Scalar.Common/Platforms/Mac/MacPlatform.cs
+++ b/Scalar.Common/Platforms/Mac/MacPlatform.cs
@@ -19,7 +19,8 @@ namespace Scalar.Platform.Mac
              underConstruction: new UnderConstructionFlags(
                 supportsScalarUpgrade: true,
                 supportsScalarConfig: true,
-                supportsNuGetEncryption: false))
+                supportsNuGetEncryption: false,
+                supportsNuGetVerification: false))
         {
         }
 

--- a/Scalar.Common/Platforms/POSIX/POSIXPlatform.cs
+++ b/Scalar.Common/Platforms/POSIX/POSIXPlatform.cs
@@ -23,7 +23,8 @@ namespace Scalar.Platform.POSIX
             underConstruction: new UnderConstructionFlags(
                 supportsScalarUpgrade: false,
                 supportsScalarConfig: false,
-                supportsNuGetEncryption: false))
+                supportsNuGetEncryption: false,
+                supportsNuGetVerification: false))
         {
         }
 

--- a/Scalar.Common/ProcessHelper.cs
+++ b/Scalar.Common/ProcessHelper.cs
@@ -24,6 +24,11 @@ namespace Scalar.Common
             return Run(processInfo);
         }
 
+        public static string GetBundledExternalBinariesLocation()
+        {
+            return Path.Combine(ProcessHelper.GetCurrentProcessLocation(), ScalarConstants.ExternalBinariesDirectoryName);
+        }
+
         public static string GetCurrentProcessLocation()
         {
             Assembly assembly = Assembly.GetExecutingAssembly();

--- a/Scalar.Common/Scalar.Common.csproj
+++ b/Scalar.Common/Scalar.Common.csproj
@@ -8,11 +8,20 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="NuGet.CommandLine" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
     <PackageReference Include="NuGet.Commands" />
     <PackageReference Include="Microsoft.PowerShell.SDK" />
     <PackageReference Include="Microsoft.Windows.Compatibility" />
     <PackageReference Include="GitForWindows.GVFS.Installer" PrivateAssets="all" />
     <PackageReference Include="GitForMac.GVFS.Installer" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="$(PkgNuGet_CommandLine)\tools\nuget.exe"
+          CopyToOutputDirectory="PreserveNewest"
+          Visible="false"
+          LinkBase="$(ExternalBinariesDirectoryName)"
+          Condition="$(RuntimeIdentifier.StartsWith('win'))" />
   </ItemGroup>
 
   <Target Name="_GenerateConstantsFile" BeforeTargets="BeforeBuild">
@@ -28,6 +37,7 @@
 
     <!-- Generate Scalar constants file with the minimum Git version -->
     <GenerateScalarConstants MinimumGitVersion="$(MinimumGitVersion)"
+                             ExternalBinariesDirectoryName="$(ExternalBinariesDirectoryName)"
                              OutputFile="$(IntermediateOutputPath)ScalarConstants.g.cs" />
 
     <!-- Add the generated file to the list of file writes for MSBuild to keep track of for clean-up -->

--- a/Scalar.Common/ScalarPlatform.cs
+++ b/Scalar.Common/ScalarPlatform.cs
@@ -173,16 +173,19 @@ namespace Scalar.Common
             public UnderConstructionFlags(
                 bool supportsScalarUpgrade = true,
                 bool supportsScalarConfig = true,
-                bool supportsNuGetEncryption = true)
+                bool supportsNuGetEncryption = true,
+                bool supportsNuGetVerification = true)
             {
                 this.SupportsScalarUpgrade = supportsScalarUpgrade;
                 this.SupportsScalarConfig = supportsScalarConfig;
                 this.SupportsNuGetEncryption = supportsNuGetEncryption;
+                this.SupportsNuGetVerification = supportsNuGetVerification;
             }
 
             public bool SupportsScalarUpgrade { get; }
             public bool SupportsScalarConfig { get; }
             public bool SupportsNuGetEncryption { get; }
+            public bool SupportsNuGetVerification { get; }
         }
     }
 }

--- a/Scalar.Installer.Windows/Scalar.Installer.Windows.csproj
+++ b/Scalar.Installer.Windows/Scalar.Installer.Windows.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
     <LayoutPath Condition="'$(LayoutPath)' == ''">$(ProjectOutPath)layout\$(Configuration)\</LayoutPath>
     <InstallerOutputPath Condition="'$(InstallerOutputPath)' == ''">$(ProjectOutPath)installer\$(Configuration)\</InstallerOutputPath>
     <DistributionOutputPath Condition="'$(DistributionOutputPath)' == ''">$(ProjectOutPath)dist\$(Configuration)\</DistributionOutputPath>

--- a/Scalar.MSBuild/GenerateScalarConstants.cs
+++ b/Scalar.MSBuild/GenerateScalarConstants.cs
@@ -11,6 +11,9 @@ namespace Scalar.MSBuild
         public string MinimumGitVersion { get; set; }
 
         [Required]
+        public string ExternalBinariesDirectoryName { get; set; }
+
+        [Required]
         public string OutputFile { get; set; }
 
         public override bool Execute()
@@ -41,6 +44,7 @@ namespace Scalar.Common
     public static partial class ScalarConstants
     {{
         public static readonly GitVersion SupportedGitVersion = new GitVersion({0}, {1}, {2}, ""{3}"", {4}, {5});
+        public const string ExternalBinariesDirectoryName = ""{6}"";
     }}
 }}";
 
@@ -53,7 +57,8 @@ namespace Scalar.Common
                     version.Build,
                     version.Platform,
                     version.Revision,
-                    version.MinorRevision));
+                    version.MinorRevision,
+                    ExternalBinariesDirectoryName));
 
             return true;
         }

--- a/Scalar.Service.UI/Scalar.Service.UI.csproj
+++ b/Scalar.Service.UI/Scalar.Service.UI.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
     <AssemblyName>scalar.service.ui</AssemblyName>
     <RootNamespace>Scalar.Service.UI</RootNamespace>
   </PropertyGroup>

--- a/Scalar.UnitTests/Common/NuGetUpgrade/NuGetUpgraderTests.cs
+++ b/Scalar.UnitTests/Common/NuGetUpgrade/NuGetUpgraderTests.cs
@@ -66,20 +66,21 @@ namespace Scalar.UnitTests.Common.NuGetUpgrade
 
             this.tracer = new MockTracer();
 
+            this.mockFileSystem = new MockFileSystem(
+                new MockDirectory(
+                    Path.GetDirectoryName(this.downloadDirectoryPath),
+                    new[] { new MockDirectory(this.downloadDirectoryPath, null, null) },
+                    null));
+
             this.mockNuGetFeed = new Mock<NuGetFeed>(
                 NuGetFeedUrl,
                 NuGetFeedName,
                 this.downloadDirectoryPath,
                 null,
                 ScalarPlatform.Instance.UnderConstruction.SupportsNuGetEncryption,
-                this.tracer);
+                this.tracer,
+                this.mockFileSystem);
             this.mockNuGetFeed.Setup(feed => feed.SetCredentials(It.IsAny<string>()));
-
-            this.mockFileSystem = new MockFileSystem(
-                new MockDirectory(
-                    Path.GetDirectoryName(this.downloadDirectoryPath),
-                    new[] { new MockDirectory(this.downloadDirectoryPath, null, null) },
-                    null));
 
             this.mockCredentialManager = new Mock<ICredentialStore>();
             string credentialManagerString = "value";

--- a/Scalar.UnitTests/Common/NuGetUpgrade/OrgNuGetUpgraderTests.cs
+++ b/Scalar.UnitTests/Common/NuGetUpgrade/OrgNuGetUpgraderTests.cs
@@ -81,7 +81,8 @@ namespace Scalar.UnitTests.Common.NuGetUpgrade
                 this.downloadDirectoryPath,
                 null,
                 ScalarPlatform.Instance.UnderConstruction.SupportsNuGetEncryption,
-                this.tracer);
+                this.tracer,
+                this.mockFileSystem);
 
             this.mockFileSystem = new MockFileSystem(
                 new MockDirectory(

--- a/Scripts/BuildScalarForWindows.bat
+++ b/Scripts/BuildScalarForWindows.bat
@@ -6,6 +6,6 @@ CALL %~dp0\InitializeEnvironment.bat || EXIT /b 10
 IF "%1"=="" (SET "Configuration=Debug") ELSE (SET "Configuration=%1")
 IF "%2"=="" (SET "ScalarVersion=0.2.173.2") ELSE (SET "ScalarVersion=%2")
 
-dotnet publish %SCALAR_SRCDIR%\Scalar.sln -p:ScalarVersion=%ScalarVersion% --configuration %Configuration% --runtime win-x64 -v:n || exit /b 1
+dotnet publish %SCALAR_SRCDIR%\Scalar.sln -p:ScalarVersion=%ScalarVersion% --configuration %Configuration% --runtime win10-x64 -v:n || exit /b 1
 
 ENDLOCAL

--- a/Scripts/CI/CreateFTDrop.bat
+++ b/Scripts/CI/CreateFTDrop.bat
@@ -14,10 +14,10 @@ IF EXIST %SCALAR_STAGEDIR% (
 )
 
 SET scriptsSrc=%SCALAR_SCRIPTSDIR%\*
-SET testsSrc=%SCALAR_OUTPUTDIR%\Scalar.FunctionalTests\bin\%Configuration%\netcoreapp3.0\win-x64\publish
+SET testsSrc=%SCALAR_OUTPUTDIR%\Scalar.FunctionalTests\bin\%Configuration%\netcoreapp3.0\win10-x64\publish
 
 SET scriptsDest=%SCALAR_STAGEDIR%\src\Scripts
-SET testsDest=%SCALAR_STAGEDIR%\out\Scalar.FunctionalTests\bin\%Configuration%\netcoreapp3.0\win-x64\publish
+SET testsDest=%SCALAR_STAGEDIR%\out\Scalar.FunctionalTests\bin\%Configuration%\netcoreapp3.0\win10-x64\publish
 
 mkdir %scriptsDest%
 mkdir %testsDest%

--- a/Scripts/RunFunctionalTests.bat
+++ b/Scripts/RunFunctionalTests.bat
@@ -6,7 +6,7 @@ IF "%1"=="" (SET "Configuration=Debug") ELSE (SET "Configuration=%1")
 SETLOCAL
 SET PATH=C:\Program Files\Scalar;C:\Program Files\watchman;C:\Program Files\Git\cmd;%PATH%
 
-SET publishFragment=bin\%Configuration%\netcoreapp3.0\win-x64\publish
+SET publishFragment=bin\%Configuration%\netcoreapp3.0\win10-x64\publish
 SET functionalTestsDir=%SCALAR_OUTPUTDIR%\Scalar.FunctionalTests\%publishFragment%
 
 IF "%2"=="--test-scalar-on-path" GOTO :testPath


### PR DESCRIPTION
The NuGet SDK for .NET Core does not support verification of NuGet packages, even on Windows. We instead bundle a copy of nuget.exe on Windows installs of Scalar and shell out to the CLI tool to perform validation. The tool must be Authenticode signed before we delegate package verification to it.

This change also makes us target builds to Windows 10 64-bit specifically.
Because we have a dependency on PowerShell, which itself has native dependencies that are tied to specific Windows versions, we must pick a (minimum) Windows version for Scalar to support. We select Windows 10, mainly because Windows 7 is now out of support, and we only test for Windows 10.