### PR TITLE
DiagnoseVerb: fix colliding files on Mac

### DIFF
--- a/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/DiagnoseTests.cs
+++ b/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/DiagnoseTests.cs
@@ -1,5 +1,4 @@
 using NUnit.Framework;
-using Scalar.FunctionalTests.FileSystemRunners;
 using Scalar.Tests.Should;
 using System.Collections.Generic;
 using System.IO;
@@ -9,17 +8,8 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
 {
     [TestFixture]
     [NonParallelizable]
-    [Category(Categories.ExtraCoverage)]
-    [Category(Categories.NeedsUpdatesForNonVirtualizedMode)]
     public class DiagnoseTests : TestsWithEnlistmentPerFixture
     {
-        private FileSystemRunner fileSystem;
-
-        public DiagnoseTests()
-        {
-            this.fileSystem = new SystemIORunner();
-        }
-
         [TestCase]
         public void DiagnoseProducesZipFile()
         {


### PR DESCRIPTION
The SecureDataRoot and CommonAppDataRoot are the same on Mac, so we were
double-copying files from the same place when running 'scalar diagnose'.
We also never ran the diagnose verb in the functional tests, so fix
that.