### PR TITLE
Update Git to v2.25.0.vfs.1.3 to include disabled fetch-pack and block 'git update'

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
 
     <!-- Version information -->
     <ScalarVersion>0.2.173.2</ScalarVersion>
-    <GitPackageVersion>2.20200116.1</GitPackageVersion>
+    <GitPackageVersion>2.20200205.1</GitPackageVersion>
     <MinimumGitVersion>v2.25.0.vfs.1.1</MinimumGitVersion>
     <WatchmanPackageUrl>https://github.com/facebook/watchman/suites/307436006/artifacts/304557</WatchmanPackageUrl>
     <GcmCoreOSXPackageUrl>https://github.com/microsoft/Git-Credential-Manager-Core/releases/download/v2.0.79-beta/gcmcore-osx-2.0.79.64449.pkg</GcmCoreOSXPackageUrl>


### PR DESCRIPTION
See microsoft/git#240 and microsoft/git#243.

Because of #320, we do not need to update the minimum Git version from `v2.25.0.vfs.1.1` even though we are packaging with `v2.25.0.vfs.1.3` now.