### PR TITLE
ConfigStep: don't fail copying over existing hook

### DIFF
--- a/Scalar.Common/Maintenance/ConfigStep.cs
+++ b/Scalar.Common/Maintenance/ConfigStep.cs
@@ -245,7 +245,7 @@ namespace Scalar.Common.Maintenance
                 this.Context.FileSystem.CopyFile(
                     fsMonitorWatchmanSampleHookPath,
                     queryWatchmanPath,
-                    overwrite: false);
+                    overwrite: true);
 
                 this.RunGitCommand(
                     process => process.SetInLocalConfig("core.fsmonitor", ".git/hooks/query-watchman"),


### PR DESCRIPTION
I was perusing my logs when I found the following error:

```
System.IO.IOException: The file 'C:\\_git\\scalar\\src\\.git\\hooks\\query-watchman' already exists.
   at System.IO.FileSystem.CopyFile(String sourceFullPath, String destFullPath, Boolean overwrite)
   at System.IO.File.Copy(String sourceFileName, String destFileName, Boolean overwrite)
   at Scalar.Common.FileSystem.PhysicalFileSystem.CopyFile(String sourcePath, String destinationPath, Boolean overwrite) in E:\\A\\_work\\23\\s\\Scalar.Common\\FileSystem\\PhysicalFileSystem.cs:line 75
   at Scalar.Common.Maintenance.ConfigStep.ConfigureWatchmanIntegration() in E:\\A\\_work\\23\\s\\Scalar.Common\\Maintenance\\ConfigStep.cs:line 250

"ErrorMessage":"Failed to configure Watchman integration: The file
'C:\\_git\\scalar\\src\\.git\\hooks\\query-watchman' already exists.
```

Avoid this issue by overwriting the existing hook. This should work perfectly on Mac, and could still get an exception if someone has a read handle open on Windows, but should be rare. In that case, having the exception in the logs is still useful. (Cc: @kewillford)