### PR TITLE
TEST: let Windows have an untracked cache

### DIFF
--- a/Scalar.Common/Platforms/Windows/WindowsFileSystem.cs
+++ b/Scalar.Common/Platforms/Windows/WindowsFileSystem.cs
@@ -14,7 +14,7 @@ namespace Scalar.Platform.Windows
     {
         public bool SupportsFileMode { get; } = false;
 
-        public bool SupportsUntrackedCache { get; } = false;
+        public bool SupportsUntrackedCache { get; } = true;
 
         /// <summary>
         /// Adds a new FileSystemAccessRule granting read (and optionally modify) access for all users.


### PR DESCRIPTION
We have some performance issues without an untracked cache. However, I remember the functional tests failing on Windows with the untracked cache. Trying again. (Perhaps it will be different with Watchman enabled.)