### PR TITLE
Use a bundled GCM Core if Git is not installed

### DIFF
--- a/Scalar.Common/FileBasedDictionary.cs
+++ b/Scalar.Common/FileBasedDictionary.cs
@@ -9,6 +9,7 @@ namespace Scalar.Common
 {
     public class FileBasedDictionary<TKey, TValue> : FileBasedCollection
     {
+        private IEqualityComparer<TKey> comparer;
         private ConcurrentDictionary<TKey, TValue> data;
 
         private FileBasedDictionary(
@@ -18,6 +19,7 @@ namespace Scalar.Common
             IEqualityComparer<TKey> keyComparer)
             : base(tracer, fileSystem, dataFilePath, collectionAppendsDirectlyToFile: false)
         {
+            this.comparer = keyComparer;
             this.data = new ConcurrentDictionary<TKey, TValue>(keyComparer);
         }
 
@@ -108,7 +110,7 @@ namespace Scalar.Common
 
         public Dictionary<TKey, TValue> GetAllKeysAndValues()
         {
-            return new Dictionary<TKey, TValue>(this.data);
+            return new Dictionary<TKey, TValue>(this.data, this.comparer);
         }
 
         private void Flush()

--- a/Scalar.Common/Git/GitCredentialManagerProcess.cs
+++ b/Scalar.Common/Git/GitCredentialManagerProcess.cs
@@ -1,0 +1,276 @@
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Text;
+using Scalar.Common.Tracing;
+
+namespace Scalar.Common.Git
+{
+    public class GitCredentialManagerProcess : ICredentialStore
+    {
+        private static readonly Encoding UTF8NoBOM = new UTF8Encoding(false);
+
+        private readonly string gcmBinPath;
+        private readonly string workingDirectoryRoot;
+
+        public GitCredentialManagerProcess(string gcmBinPath, string workingDirectoryRoot = null)
+        {
+            if (string.IsNullOrWhiteSpace(gcmBinPath))
+            {
+                throw new ArgumentException(nameof(gcmBinPath));
+            }
+
+            this.gcmBinPath = gcmBinPath;
+            this.workingDirectoryRoot = workingDirectoryRoot;
+        }
+
+        public virtual bool TryDeleteCredential(ITracer tracer, string repoUrl, string username, string password, out string errorMessage)
+        {
+            var stdin = new StringBuilder();
+            if (!TryAppendUrlLines(stdin, repoUrl, out errorMessage))
+            {
+                return false;
+            }
+
+            // Passing the username and password that we want to signal rejection for is optional.
+            // Credential helpers that support it can use the provided username/password values to
+            // perform a check that they're being asked to delete the same stored credential that
+            // the caller is asking them to erase.
+            // Ideally, we would provide these values if available, however it does not work as expected
+            // with our main credential helper - Windows GCM. With GCM for Windows, the credential acquired
+            // with credential fill for dev.azure.com URLs are not erased when the user name / password are passed in.
+            // Until the default credential helper works with this pattern, reject credential with just the URL.
+
+            stdin.Append("\n");
+
+            Result result = this.InvokeGcm("erase", stdin.ToString());
+
+            if (!result.IsSuccess)
+            {
+                tracer.RelatedError("GCM could not erase credentials: {0}", result.Errors);
+                errorMessage = result.Errors;
+                return false;
+            }
+
+            errorMessage = null;
+            return true;
+        }
+
+        public virtual bool TryStoreCredential(ITracer tracer, string repoUrl, string username, string password, out string errorMessage)
+        {
+            var stdin = new StringBuilder();
+            if (!TryAppendUrlLines(stdin, repoUrl, out errorMessage))
+            {
+                return false;
+            }
+            stdin.AppendFormat("username={0}\n", username);
+            stdin.AppendFormat("password={0}\n", password);
+            stdin.Append("\n");
+
+            Result result = this.InvokeGcm("store", stdin.ToString());
+
+            if (!result.IsSuccess)
+            {
+                tracer.RelatedError("GCM could not store credentials: {0}", result.Errors);
+                errorMessage = result.Errors;
+                return false;
+            }
+
+            errorMessage = null;
+            return true;
+        }
+
+        public virtual bool TryGetCredential(
+            ITracer tracer,
+            string repoUrl,
+            out string username,
+            out string password,
+            out string errorMessage)
+        {
+            username = null;
+            password = null;
+            errorMessage = null;
+
+            var stdin = new StringBuilder();
+            if (!TryAppendUrlLines(stdin, repoUrl, out errorMessage))
+            {
+                return false;
+            }
+            stdin.Append("\n");
+
+            using (ITracer activity = tracer.StartActivity(nameof(this.TryGetCredential), EventLevel.Informational))
+            {
+                Result result = this.InvokeGcm("get", stdin.ToString());
+
+                if (!result.IsSuccess)
+                {
+                    tracer.RelatedError("GCM could not get credentials: {0}", result.Errors);
+                    errorMessage = result.Errors;
+                    return false;
+                }
+
+                username = ParseValue(result.Output, "username=");
+                password = ParseValue(result.Output, "password=");
+
+                bool success = username != null && password != null;
+
+                var metadata = new EventMetadata();
+                metadata.Add("Success", success);
+                if (!success)
+                {
+                    metadata.Add("Output", result.Output);
+                }
+
+                activity.Stop(metadata);
+                return success;
+            }
+        }
+
+        private static bool TryAppendUrlLines(StringBuilder sb, string url, out string errorMessage)
+        {
+            if (Uri.TryCreate(url, UriKind.Absolute, out Uri uri))
+            {
+                sb.AppendFormat("protocol={0}\n", uri.Scheme);
+                sb.AppendFormat("host={0}\n", uri.Host);
+
+                if (uri.PathAndQuery != null)
+                {
+                    string[] pathAndQuery = uri.PathAndQuery.Split('?');
+                    if (pathAndQuery.Length > 0)
+                    {
+                        // Trim any trailing "/" from the path
+                        string path = pathAndQuery[0]?.TrimEnd('/');
+                        if (!string.IsNullOrWhiteSpace(path))
+                        {
+                            sb.AppendFormat("path={0}\n", uri.PathAndQuery);
+                        }
+                    }
+                }
+
+                errorMessage = null;
+                return true;
+            }
+
+            errorMessage = $"Failed to parse URL '{url}' as a valid URI";
+            return false;
+        }
+
+        private static string ParseValue(string contents, string prefix)
+        {
+            int startIndex = contents.IndexOf(prefix, StringComparison.Ordinal) + prefix.Length;
+            if (startIndex >= 0 && startIndex < contents.Length)
+            {
+                int endIndex = contents.IndexOf('\n', startIndex);
+                if (endIndex >= 0 && endIndex < contents.Length)
+                {
+                    return
+                        contents
+                            .Substring(startIndex, endIndex - startIndex)
+                            .Trim('\r');
+                }
+            }
+
+            return null;
+        }
+
+        private Result InvokeGcm(string command, string stdIn)
+        {
+            int timeoutMs = -1;
+
+            try
+            {
+                var processInfo = new ProcessStartInfo(this.gcmBinPath)
+                {
+                    Arguments = command,
+                    WorkingDirectory = this.workingDirectoryRoot,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                    RedirectStandardInput = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    StandardInputEncoding = UTF8NoBOM,
+                    StandardOutputEncoding = UTF8NoBOM,
+                    StandardErrorEncoding = UTF8NoBOM,
+                };
+
+                processInfo.EnvironmentVariables["GIT_TERMINAL_PROMPT"] = "0";
+
+                // From https://msdn.microsoft.com/en-us/library/system.diagnostics.process.standardoutput.aspx
+                // To avoid deadlocks, use asynchronous read operations on at least one of the streams.
+                // Do not perform a synchronous read to the end of both redirected streams.
+                using (var process = new Process {StartInfo = processInfo})
+                {
+                    var output = new StringBuilder();
+                    var errors = new StringBuilder();
+
+                    process.ErrorDataReceived += (sender, args) =>
+                    {
+                        if (args.Data != null)
+                        {
+                            errors.Append(args.Data + "\n");
+                        }
+                    };
+
+                    process.OutputDataReceived += (sender, args) =>
+                    {
+                        if (args.Data != null)
+                        {
+                            output.Append(args.Data + "\n");
+                        }
+                    };
+
+
+                    process.Start();
+                    process.BeginOutputReadLine();
+                    process.BeginErrorReadLine();
+
+                    try
+                    {
+                        if (stdIn != null)
+                        {
+                            process.StandardInput.Write(stdIn);
+                            process.StandardInput.Close();
+                        }
+                    }
+                    catch (Exception ex) when (ex is InvalidOperationException || ex is Win32Exception)
+                    {
+                        // This is thrown if the process completes before we can set a property.
+                    }
+
+                    if (!process.WaitForExit(timeoutMs))
+                    {
+                        process.Kill();
+
+                        return new Result(output.ToString(), $"Operation timed out: {errors}", Result.GenericFailureCode);
+                    }
+
+                    return new Result(output.ToString(), errors.ToString(), process.ExitCode);
+                }
+            }
+            catch (Win32Exception e)
+            {
+                return new Result(string.Empty, e.Message, Result.GenericFailureCode);
+            }
+        }
+
+        private class Result
+        {
+            public const int SuccessCode = 0;
+            public const int GenericFailureCode = 1;
+
+            public Result(string stdout, string stderr, int exitCode)
+            {
+                this.Output = stdout;
+                this.Errors = stderr;
+                this.ExitCode = exitCode;
+            }
+
+            public string Output { get; }
+            public string Errors { get; }
+            public int ExitCode { get; }
+
+            public bool IsSuccess => this.ExitCode == Result.SuccessCode;
+        }
+    }
+}

--- a/Scalar.Common/Git/GitCredentialManagerProcess.cs
+++ b/Scalar.Common/Git/GitCredentialManagerProcess.cs
@@ -173,7 +173,7 @@ namespace Scalar.Common.Git
             return null;
         }
 
-        private Result InvokeGcm(string command, string stdIn)
+        protected virtual Result InvokeGcm(string command, string stdIn)
         {
             int timeoutMs = -1;
 
@@ -254,7 +254,7 @@ namespace Scalar.Common.Git
             }
         }
 
-        private class Result
+        public class Result
         {
             public const int SuccessCode = 0;
             public const int GenericFailureCode = 1;

--- a/Scalar.Common/NuGetUpgrade/NuGetFeed.cs
+++ b/Scalar.Common/NuGetUpgrade/NuGetFeed.cs
@@ -149,8 +149,8 @@ namespace Scalar.Common.NuGetUpgrade
             }
 
             // Locate bundled nuget CLI tool
-            string externalBinDir = ProcessHelper.GetBundledExternalBinariesLocation();
-            string nugetToolFileName = "nuget" + ScalarPlatform.Instance.Constants.ExecutableExtension;
+            string externalBinDir = ProcessHelper.GetBundledBinariesLocation();
+            string nugetToolFileName = ScalarConstants.BundledBinaries.NuGetFileName + ScalarPlatform.Instance.Constants.ExecutableExtension;
             string nugetToolFilePath = Path.Combine(externalBinDir, nugetToolFileName);
             if (!this.fileSystem.FileExists(nugetToolFilePath))
             {

--- a/Scalar.Common/ProcessHelper.cs
+++ b/Scalar.Common/ProcessHelper.cs
@@ -24,9 +24,9 @@ namespace Scalar.Common
             return Run(processInfo);
         }
 
-        public static string GetBundledExternalBinariesLocation()
+        public static string GetBundledBinariesLocation()
         {
-            return Path.Combine(ProcessHelper.GetCurrentProcessLocation(), ScalarConstants.ExternalBinariesDirectoryName);
+            return Path.Combine(GetCurrentProcessLocation(), ScalarConstants.BundledBinaries.DirectoryName);
         }
 
         public static string GetCurrentProcessLocation()

--- a/Scalar.Common/ScalarConstants.cs
+++ b/Scalar.Common/ScalarConstants.cs
@@ -22,7 +22,7 @@ namespace Scalar.Common
 
         public const string GitIsNotInstalledError = "Could not find git.exe.  Ensure that Git is installed.";
 
-        public static class BundledBinaries
+        public static partial class BundledBinaries
         {
             public const string NuGetFileName = "nuget";
 

--- a/Scalar.Common/ScalarConstants.cs
+++ b/Scalar.Common/ScalarConstants.cs
@@ -22,6 +22,14 @@ namespace Scalar.Common
 
         public const string GitIsNotInstalledError = "Could not find git.exe.  Ensure that Git is installed.";
 
+        public static class BundledBinaries
+        {
+            public const string NuGetFileName = "nuget";
+
+            public const string GcmDirectoryName = "gcm";
+            public const string GcmFileName = "git-credential-manager-core";
+        }
+
         public static class GitConfig
         {
             public const string ScalarPrefix = "scalar.";

--- a/Scalar.Common/ScalarPlatform.cs
+++ b/Scalar.Common/ScalarPlatform.cs
@@ -114,31 +114,32 @@ namespace Scalar.Common
             PhysicalFileSystem fileSystem,
             ITracer tracer);
 
-        public bool TryGetCredentialStore(ITracer tracer, PhysicalFileSystem fileSystem, out ICredentialStore credentialStore, out string errorMessage)
+        public bool TryCreateCredentialStore(ITracer tracer, PhysicalFileSystem fileSystem, out ICredentialStore credentialStore, out string errorMessage)
         {
             credentialStore = null;
 
             string gitBinPath = ScalarPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
-            if (string.IsNullOrEmpty(gitBinPath))
+            if (!string.IsNullOrEmpty(gitBinPath))
+            {
+                // Use the Git process for interacting with the configured credential helper
+                credentialStore = new GitProcess(gitBinPath, workingDirectoryRoot: null);
+                tracer.RelatedInfo("Using installed Git process for management");
+            }
+            else
             {
                 // Unable to locate a Git installation on the system, instead use GCM Core directly if it has been bundled
                 string externalBinDir = ProcessHelper.GetBundledBinariesLocation();
-                string gcmToolFileName = ScalarConstants.BundledBinaries.GcmFileName + ScalarPlatform.Instance.Constants.ExecutableExtension;
+                string gcmToolFileName = ScalarConstants.BundledBinaries.GcmFileName +
+                                         ScalarPlatform.Instance.Constants.ExecutableExtension;
                 string gcmToolFilePath = Path.Combine(externalBinDir, ScalarConstants.BundledBinaries.GcmDirectoryName, gcmToolFileName);
                 if (!fileSystem.FileExists(gcmToolFilePath))
                 {
-                    errorMessage = $"{nameof(this.TryGetCredentialStore)}: Unable to locate Git installation or bundled GCM Core. Ensure Git is installed and try again.";
+                    errorMessage = $"{nameof(this.TryCreateCredentialStore)}: Unable to locate Git installation or bundled GCM Core. Ensure Git is installed and try again.";
                     return false;
                 }
 
                 credentialStore = new GitCredentialManagerProcess(gcmToolFilePath);
                 tracer.RelatedInfo("Using bundled GCM process for credential management");
-            }
-            else
-            {
-                // Use the Git process for interacting with the configured credential helper
-                credentialStore = new GitProcess(gitBinPath, workingDirectoryRoot: null);
-                tracer.RelatedInfo("Using installed Git process for management");
             }
 
             errorMessage = null;

--- a/Scalar.MSBuild/GenerateScalarConstants.cs
+++ b/Scalar.MSBuild/GenerateScalarConstants.cs
@@ -44,7 +44,11 @@ namespace Scalar.Common
     public static partial class ScalarConstants
     {{
         public static readonly GitVersion SupportedGitVersion = new GitVersion({0}, {1}, {2}, ""{3}"", {4}, {5});
-        public const string ExternalBinariesDirectoryName = ""{6}"";
+
+        public static partial class BundledBinaries
+        {{
+            public const string DirectoryName = ""{6}"";
+        }}
     }}
 }}";
 

--- a/Scalar.UnitTests/Git/GitCredentialManagerProcessTests.cs
+++ b/Scalar.UnitTests/Git/GitCredentialManagerProcessTests.cs
@@ -1,0 +1,422 @@
+using System;
+using NUnit.Framework;
+using Scalar.Common.Git;
+using Scalar.UnitTests.Mock.Common;
+
+namespace Scalar.UnitTests.Git
+{
+    [TestFixture]
+    public class GitCredentialManagerProcessTests
+    {
+        private const string GcmBinPath = @"C:\gcm\gcm.exe";
+        private const string WorkingDirectoryRoot = @"C:\Windows";
+
+        [TestCase]
+        public void TryGetCredential_UrlHostOnly_InvokesGcmGetWithUrlHostOnly()
+        {
+            const string expectedUsername = "john.doe";
+            const string expectedPassword = "letmein123";
+            const string repoProtocol = "https";
+            const string repoHost = "example.com";
+            string repoUrl = $"{repoProtocol}://{repoHost}";
+
+            string expectedStdin = $"protocol={repoProtocol}\n" +
+                                   $"host={repoHost}\n" +
+                                   "\n";
+
+            var tracer = new MockTracer();
+
+            var proc = new TestGcmProcess(GcmBinPath, WorkingDirectoryRoot)
+            {
+                InvokeFunc = (command, stdin) =>
+                {
+                    Assert.AreEqual("get", command);
+                    Assert.AreEqual(expectedStdin, stdin);
+
+                    string stdout = $"{stdin}username={expectedUsername}\npassword={expectedPassword}\n";
+                    string stderr = null;
+                    int exitCode = 0;
+
+                    return new GitCredentialManagerProcess.Result(stdout, stderr, exitCode);
+                }
+            };
+
+            bool result = proc.TryGetCredential(tracer, repoUrl, out string username, out string password, out string errorMessage);
+
+            Assert.True(result);
+            Assert.AreEqual(expectedUsername, username);
+            Assert.AreEqual(expectedPassword, password);
+            Assert.IsNull(errorMessage);
+        }
+
+        [TestCase]
+        public void TryGetCredential_UrlWithPath_InvokesGcmGetWithUrlHostAndPath()
+        {
+            const string expectedUsername = "john.doe";
+            const string expectedPassword = "letmein123";
+            const string repoProtocol = "https";
+            const string repoHost = "example.com";
+            const string repoPath = "/path/to/some/repo";
+            string repoUrl = $"{repoProtocol}://{repoHost}{repoPath}";
+
+            string expectedStdin = $"protocol={repoProtocol}\n" +
+                                   $"host={repoHost}\n" +
+                                   $"path={repoPath}" +
+                                   "\n\n";
+
+            var tracer = new MockTracer();
+
+            var proc = new TestGcmProcess(GcmBinPath, WorkingDirectoryRoot)
+            {
+                InvokeFunc = (command, stdin) =>
+                {
+                    Assert.AreEqual("get", command);
+                    Assert.AreEqual(expectedStdin, stdin);
+
+                    string stdout = $"{stdin}username={expectedUsername}\npassword={expectedPassword}\n";
+                    string stderr = null;
+                    int exitCode = 0;
+
+                    return new GitCredentialManagerProcess.Result(stdout, stderr, exitCode);
+                }
+            };
+
+            bool result = proc.TryGetCredential(tracer, repoUrl, out string username, out string password, out string errorMessage);
+
+            Assert.True(result);
+            Assert.AreEqual(expectedUsername, username);
+            Assert.AreEqual(expectedPassword, password);
+            Assert.IsNull(errorMessage);
+        }
+
+        [TestCase]
+        public void TryGetCredential_BadUrl_ReturnsFalse()
+        {
+            const string repoUrl = "this is not a valid URL";
+
+            var tracer = new MockTracer();
+
+            var proc = new TestGcmProcess(GcmBinPath, WorkingDirectoryRoot)
+            {
+                InvokeFunc = (command, stdin) =>
+                {
+                    Assert.Fail("Should never invoke GCM with bad URL data");
+                    return new GitCredentialManagerProcess.Result(null, null, 127);
+                }
+            };
+
+            bool result = proc.TryGetCredential(tracer, repoUrl, out string username, out string password, out string errorMessage);
+
+            Assert.False(result);
+            Assert.IsNull(username);
+            Assert.IsNull(password);
+            Assert.IsNotNull(errorMessage);
+        }
+
+        [TestCase]
+        public void TryGetCredential_NonZeroExitCode_ReturnsFalse()
+        {
+            const string repoProtocol = "https";
+            const string repoHost = "example.com";
+            string repoUrl = $"{repoProtocol}://{repoHost}";
+
+            const string expectedErrorMessage = "This is an error!";
+
+            var tracer = new MockTracer();
+
+            var proc = new TestGcmProcess(GcmBinPath, WorkingDirectoryRoot)
+            {
+                InvokeFunc = (command, stdin) =>
+                {
+                    string stdout = null;
+                    string stderr = expectedErrorMessage;
+                    int exitCode = 127;
+
+                    return new GitCredentialManagerProcess.Result(stdout, stderr, exitCode);
+                }
+            };
+
+            bool result = proc.TryGetCredential(tracer, repoUrl, out string username, out string password, out string errorMessage);
+
+            Assert.False(result);
+            Assert.IsNull(username);
+            Assert.IsNull(password);
+            Assert.AreEqual(expectedErrorMessage, errorMessage);
+        }
+
+        [TestCase]
+        public void TryStoreCredential_UrlHostOnly_InvokesGcmStoreWithUrlHostOnly()
+        {
+            const string username = "john.doe";
+            const string password = "letmein123";
+            const string repoProtocol = "https";
+            const string repoHost = "example.com";
+            string repoUrl = $"{repoProtocol}://{repoHost}";
+
+            string expectedStdin = $"protocol={repoProtocol}\n" +
+                                   $"host={repoHost}\n" +
+                                   $"username={username}\n" +
+                                   $"password={password}\n" +
+                                   "\n";
+
+            var tracer = new MockTracer();
+
+            var proc = new TestGcmProcess(GcmBinPath, WorkingDirectoryRoot)
+            {
+                InvokeFunc = (command, stdin) =>
+                {
+                    Assert.AreEqual("store", command);
+                    Assert.AreEqual(expectedStdin, stdin);
+
+                    string stdout = null;
+                    string stderr = null;
+                    int exitCode = 0;
+
+                    return new GitCredentialManagerProcess.Result(stdout, stderr, exitCode);
+                }
+            };
+
+            bool result = proc.TryStoreCredential(tracer, repoUrl, username, password, out string errorMessage);
+
+            Assert.True(result);
+            Assert.IsNull(errorMessage);
+        }
+
+        [TestCase]
+        public void TryStoreCredential_UrlWithPath_InvokesGcmStoreWithUrlHostAndPath()
+        {
+            const string username = "john.doe";
+            const string password = "letmein123";
+            const string repoProtocol = "https";
+            const string repoHost = "example.com";
+            const string repoPath = "/path/to/some/repo";
+            string repoUrl = $"{repoProtocol}://{repoHost}{repoPath}";
+
+            string expectedStdin = $"protocol={repoProtocol}\n" +
+                                   $"host={repoHost}\n" +
+                                   $"path={repoPath}\n" +
+                                   $"username={username}\n" +
+                                   $"password={password}\n" +
+                                   "\n";
+
+            var tracer = new MockTracer();
+
+            var proc = new TestGcmProcess(GcmBinPath, WorkingDirectoryRoot)
+            {
+                InvokeFunc = (command, stdin) =>
+                {
+                    Assert.AreEqual("store", command);
+                    Assert.AreEqual(expectedStdin, stdin);
+
+                    string stdout = null;
+                    string stderr = null;
+                    int exitCode = 0;
+
+                    return new GitCredentialManagerProcess.Result(stdout, stderr, exitCode);
+                }
+            };
+
+            bool result = proc.TryStoreCredential(tracer, repoUrl, username, password, out string errorMessage);
+
+            Assert.True(result);
+            Assert.IsNull(errorMessage);
+        }
+
+        [TestCase]
+        public void TryStoreCredential_BadUrl_ReturnsFalse()
+        {
+            const string username = "john.doe";
+            const string password = "letmein123";
+            const string repoUrl = "this is not a valid URL";
+
+            var tracer = new MockTracer();
+
+            var proc = new TestGcmProcess(GcmBinPath, WorkingDirectoryRoot)
+            {
+                InvokeFunc = (command, stdin) =>
+                {
+                    Assert.Fail("Should never invoke GCM with bad URL data");
+                    return new GitCredentialManagerProcess.Result(null, null, 127);
+                }
+            };
+
+            bool result = proc.TryStoreCredential(tracer, repoUrl, username, password, out string errorMessage);
+
+            Assert.False(result);
+            Assert.IsNotNull(errorMessage);
+        }
+
+        [TestCase]
+        public void TryStoreCredential_NonZeroExitCode_ReturnsFalse()
+        {
+            const string username = "john.doe";
+            const string password = "letmein123";
+            const string repoProtocol = "https";
+            const string repoHost = "example.com";
+            string repoUrl = $"{repoProtocol}://{repoHost}";
+
+            const string expectedErrorMessage = "This is an error!";
+
+            var tracer = new MockTracer();
+
+            var proc = new TestGcmProcess(GcmBinPath, WorkingDirectoryRoot)
+            {
+                InvokeFunc = (command, stdin) =>
+                {
+                    string stdout = null;
+                    string stderr = expectedErrorMessage;
+                    int exitCode = 127;
+
+                    return new GitCredentialManagerProcess.Result(stdout, stderr, exitCode);
+                }
+            };
+
+            bool result = proc.TryStoreCredential(tracer, repoUrl, username, password, out string errorMessage);
+
+            Assert.False(result);
+            Assert.AreEqual(expectedErrorMessage, errorMessage);
+        }
+
+        [TestCase]
+        public void TryDeleteCredential_UrlHostOnly_InvokesGcmEraseWithUrlHostOnly()
+        {
+            const string username = "john.doe";
+            const string password = "letmein123";
+            const string repoProtocol = "https";
+            const string repoHost = "example.com";
+            string repoUrl = $"{repoProtocol}://{repoHost}";
+
+            string expectedStdin = $"protocol={repoProtocol}\n" +
+                                   $"host={repoHost}\n" +
+                                   "\n";
+
+            var tracer = new MockTracer();
+
+            var proc = new TestGcmProcess(GcmBinPath, WorkingDirectoryRoot)
+            {
+                InvokeFunc = (command, stdin) =>
+                {
+                    Assert.AreEqual("erase", command);
+                    Assert.AreEqual(expectedStdin, stdin);
+
+                    string stdout = null;
+                    string stderr = null;
+                    int exitCode = 0;
+
+                    return new GitCredentialManagerProcess.Result(stdout, stderr, exitCode);
+                }
+            };
+
+            bool result = proc.TryDeleteCredential(tracer, repoUrl, username, password, out string errorMessage);
+
+            Assert.True(result);
+            Assert.IsNull(errorMessage);
+        }
+
+        [TestCase]
+        public void TryDeleteCredential_UrlWithPath_InvokesGcmEraseWithUrlHostAndPath()
+        {
+            const string username = "john.doe";
+            const string password = "letmein123";
+            const string repoProtocol = "https";
+            const string repoHost = "example.com";
+            const string repoPath = "/path/to/some/repo";
+            string repoUrl = $"{repoProtocol}://{repoHost}{repoPath}";
+
+            string expectedStdin = $"protocol={repoProtocol}\n" +
+                                   $"host={repoHost}\n" +
+                                   $"path={repoPath}" +
+                                   "\n\n";
+
+            var tracer = new MockTracer();
+
+            var proc = new TestGcmProcess(GcmBinPath, WorkingDirectoryRoot)
+            {
+                InvokeFunc = (command, stdin) =>
+                {
+                    Assert.AreEqual("erase", command);
+                    Assert.AreEqual(expectedStdin, stdin);
+
+                    string stdout = null;
+                    string stderr = null;
+                    int exitCode = 0;
+
+                    return new GitCredentialManagerProcess.Result(stdout, stderr, exitCode);
+                }
+            };
+
+            bool result = proc.TryDeleteCredential(tracer, repoUrl, username, password, out string errorMessage);
+
+            Assert.True(result);
+            Assert.IsNull(errorMessage);
+        }
+
+        [TestCase]
+        public void TryDeleteCredential_BadUrl_ReturnsFalse()
+        {
+            const string username = "john.doe";
+            const string password = "letmein123";
+            const string repoUrl = "this is not a valid URL";
+
+            var tracer = new MockTracer();
+
+            var proc = new TestGcmProcess(GcmBinPath, WorkingDirectoryRoot)
+            {
+                InvokeFunc = (command, stdin) =>
+                {
+                    Assert.Fail("Should never invoke GCM with bad URL data");
+                    return new GitCredentialManagerProcess.Result(null, null, 127);
+                }
+            };
+
+            bool result = proc.TryDeleteCredential(tracer, repoUrl, username, password, out string errorMessage);
+
+            Assert.False(result);
+            Assert.IsNotNull(errorMessage);
+        }
+
+        [TestCase]
+        public void TryDeleteCredential_NonZeroExitCode_ReturnsFalse()
+        {
+            const string username = "john.doe";
+            const string password = "letmein123";
+            const string repoProtocol = "https";
+            const string repoHost = "example.com";
+            string repoUrl = $"{repoProtocol}://{repoHost}";
+
+            const string expectedErrorMessage = "This is an error!";
+
+            var tracer = new MockTracer();
+
+            var proc = new TestGcmProcess(GcmBinPath, WorkingDirectoryRoot)
+            {
+                InvokeFunc = (command, stdin) =>
+                {
+                    string stdout = null;
+                    string stderr = expectedErrorMessage;
+                    int exitCode = 127;
+
+                    return new GitCredentialManagerProcess.Result(stdout, stderr, exitCode);
+                }
+            };
+
+            bool result = proc.TryDeleteCredential(tracer, repoUrl, username, password, out string errorMessage);
+
+            Assert.False(result);
+            Assert.AreEqual(expectedErrorMessage, errorMessage);
+        }
+
+        private class TestGcmProcess : GitCredentialManagerProcess
+        {
+            public Func<string, string, Result> InvokeFunc { get; set; }
+
+            public TestGcmProcess(string gcmBinPath, string workingDirectoryRoot)
+                : base(gcmBinPath, workingDirectoryRoot) { }
+
+            protected override Result InvokeGcm(string command, string stdIn)
+            {
+                return InvokeFunc(command, stdIn);
+            }
+        }
+    }
+}

--- a/Scalar.Upgrader/UpgradeOrchestrator.cs
+++ b/Scalar.Upgrader/UpgradeOrchestrator.cs
@@ -169,7 +169,7 @@ namespace Scalar.Upgrader
         {
             if (this.upgrader == null)
             {
-                if (!ScalarPlatform.Instance.TryGetCredentialStore(this.tracer, this.fileSystem, out ICredentialStore credentialStore, out errorMessage))
+                if (!ScalarPlatform.Instance.TryCreateCredentialStore(this.tracer, this.fileSystem, out ICredentialStore credentialStore, out errorMessage))
                 {
                     return false;
                 }

--- a/Scalar.Upgrader/UpgradeOrchestrator.cs
+++ b/Scalar.Upgrader/UpgradeOrchestrator.cs
@@ -169,14 +169,10 @@ namespace Scalar.Upgrader
         {
             if (this.upgrader == null)
             {
-                string gitBinPath = ScalarPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
-                if (string.IsNullOrEmpty(gitBinPath))
+                if (!ScalarPlatform.Instance.TryGetCredentialStore(this.tracer, this.fileSystem, out ICredentialStore credentialStore, out errorMessage))
                 {
-                    errorMessage = $"nameof(this.TryInitialize): Unable to locate git installation. Ensure git is installed and try again.";
                     return false;
                 }
-
-                ICredentialStore credentialStore = new GitProcess(gitBinPath, workingDirectoryRoot: null);
 
                 ProductUpgrader upgrader;
                 if (!ProductUpgrader.TryCreateUpgrader(this.tracer, this.fileSystem, new LocalScalarConfig(), credentialStore, this.DryRun, this.NoVerify, out upgrader, out errorMessage))

--- a/Scalar/CommandLine/UpgradeVerb.cs
+++ b/Scalar/CommandLine/UpgradeVerb.cs
@@ -113,14 +113,10 @@ namespace Scalar.CommandLine
                     this.tracer = jsonTracer;
                     this.prerunChecker = new InstallerPreRunChecker(this.tracer, this.Confirmed ? ScalarConstants.UpgradeVerbMessages.ScalarUpgradeConfirm : ScalarConstants.UpgradeVerbMessages.ScalarUpgrade);
 
-                    string gitBinPath = ScalarPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
-                    if (string.IsNullOrEmpty(gitBinPath))
+                    if (!ScalarPlatform.Instance.TryGetCredentialStore(jsonTracer, this.fileSystem, out ICredentialStore credentialStore, out error))
                     {
-                        error = $"nameof(this.TryInitializeUpgrader): Unable to locate git installation. Ensure git is installed and try again.";
                         return false;
                     }
-
-                    ICredentialStore credentialStore = new GitProcess(gitBinPath, workingDirectoryRoot: null);
 
                     ProductUpgrader upgrader;
                     if (ProductUpgrader.TryCreateUpgrader(this.tracer, this.fileSystem, new LocalScalarConfig(), credentialStore, this.DryRun, this.NoVerify, out upgrader, out error))

--- a/Scalar/CommandLine/UpgradeVerb.cs
+++ b/Scalar/CommandLine/UpgradeVerb.cs
@@ -113,7 +113,7 @@ namespace Scalar.CommandLine
                     this.tracer = jsonTracer;
                     this.prerunChecker = new InstallerPreRunChecker(this.tracer, this.Confirmed ? ScalarConstants.UpgradeVerbMessages.ScalarUpgradeConfirm : ScalarConstants.UpgradeVerbMessages.ScalarUpgrade);
 
-                    if (!ScalarPlatform.Instance.TryGetCredentialStore(jsonTracer, this.fileSystem, out ICredentialStore credentialStore, out error))
+                    if (!ScalarPlatform.Instance.TryCreateCredentialStore(jsonTracer, this.fileSystem, out ICredentialStore credentialStore, out error))
                     {
                         return false;
                     }


### PR DESCRIPTION
If Git is not installed, try to use a bundled GCM binary drop for getting credentials for use in Upgrade. This can help in bootstrapping scenarios where the user does not have an installed copy of Git/GCM.