### PR TITLE
RunVerb: fall back to timestamp log if service log is busy

### DIFF
--- a/Scalar.FunctionalTests/Tests/GitRepoPerFixture/RunVerbTests.cs
+++ b/Scalar.FunctionalTests/Tests/GitRepoPerFixture/RunVerbTests.cs
@@ -150,6 +150,26 @@ namespace Scalar.FunctionalTests.Tests.GitRepoPerFixture
             this.Enlistment.RunVerb("all");
         }
 
+        [TestCase]
+        [Order(6)]
+        [Category(Categories.WindowsOnly)]
+        public void ServiceLogFallback()
+        {
+            string logsRoot = Path.Combine(this.Enlistment.RepoRoot, ".git", "logs");
+            string serviceLogFile = Path.Combine(logsRoot, "scalar_maintenance_service.log");
+
+            using (Stream stream = File.OpenWrite(serviceLogFile))
+            {
+                int numLogsBefore = Directory.GetFiles(logsRoot, "*.log").Length;
+
+                this.Enlistment.RunVerb("config", asService: true);
+
+                int numLogsAfter = Directory.GetFiles(logsRoot, "*.log").Length;
+
+                numLogsAfter.ShouldEqual(numLogsBefore + 1, $"`scalar run config` should have created new log file");
+            }
+        }
+
         private List<string> GetPackfiles()
         {
             return Directory.GetFiles(this.PackRoot, "*.pack").ToList();

--- a/Scalar.FunctionalTests/Tools/ScalarFunctionalTestEnlistment.cs
+++ b/Scalar.FunctionalTests/Tools/ScalarFunctionalTestEnlistment.cs
@@ -187,9 +187,9 @@ namespace Scalar.FunctionalTests.Tools
             this.InitializeConfig();
         }
 
-        public string RunVerb(string task, long? batchSize = null, bool failOnError = true)
+        public string RunVerb(string task, long? batchSize = null, bool failOnError = true, bool asService = false)
         {
-            return this.scalarProcess.RunVerb(task, batchSize, failOnError);
+            return this.scalarProcess.RunVerb(task, batchSize, failOnError, asService);
         }
 
         public void Unregister()

--- a/Scalar.FunctionalTests/Tools/ScalarProcess.cs
+++ b/Scalar.FunctionalTests/Tools/ScalarProcess.cs
@@ -40,16 +40,21 @@ namespace Scalar.FunctionalTests.Tools
             this.CallScalar(args, expectedExitCode: SuccessExitCode);
         }
 
-        public string RunVerb(string task, long? batchSize = null, bool failOnError = true)
+        public string RunVerb(string task, long? batchSize = null, bool failOnError = true, bool asService = false)
         {
             string batchArg = batchSize == null
                                     ? string.Empty
                                     : $"--batch-size={batchSize}";
 
+            string serviceArg = asService
+                                    ? "{\"StartedByService\":\"true\"}"
+                                    : null;
+
             return this.CallScalar(
                 $"run {task} \"{this.enlistmentRoot}\" {batchArg}",
                 failOnError ? SuccessExitCode : DoNotCheckExitCode,
-                standardInput: null);
+                standardInput: null,
+                internalParameter: serviceArg);
         }
 
         public void Repair(bool confirm)


### PR DESCRIPTION
Resolves #328.

If another process holds a write lock on the `.git/logs/scalar_maintenance_service.log` file, then the process exits with an `IOException` stack trace.

Instead of failing, first try creating a log file using a timestamp and logging the first exception. If that fails, then write an error to output and continue with the command.