### PR TITLE
Configure watchman when setting config so it will happen at clone time

### DIFF
--- a/Scalar.Common/Maintenance/ConfigStep.cs
+++ b/Scalar.Common/Maintenance/ConfigStep.cs
@@ -163,6 +163,8 @@ namespace Scalar.Common.Maintenance
                 return false;
             }
 
+            this.ConfigureWatchmanIntegration();
+
             error = null;
             return true;
         }
@@ -170,7 +172,6 @@ namespace Scalar.Common.Maintenance
         protected override void PerformMaintenance()
         {
             this.TrySetConfig(out _);
-            this.ConfigureWatchmanIntegration();
         }
 
         private bool TrySetConfig(Dictionary<string, string> configSettings, bool isRequired, out string error)


### PR DESCRIPTION
Watchman wasn't getting configured during clone but was once the maintenance step ran.  It should really be configured in both place.  At clone time and when maintenance runs.