### PR TITLE
CloneVerb: Fall back to partial clone

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
 
     <!-- Version information -->
     <ScalarVersion>0.2.173.2</ScalarVersion>
-    <GitPackageVersion>2.20200221.5</GitPackageVersion>
+    <GitPackageVersion>2.20200227.1</GitPackageVersion>
     <MinimumGitVersion>v2.25.0.vfs.1.1</MinimumGitVersion>
     <WatchmanPackageUrl>https://github.com/facebook/watchman/suites/307436006/artifacts/304557</WatchmanPackageUrl>
     <GcmCoreOSXPackageUrl>https://github.com/microsoft/Git-Credential-Manager-Core/releases/download/v2.0.79-beta/gcmcore-osx-2.0.79.64449.pkg</GcmCoreOSXPackageUrl>

--- a/Scalar.Common/Git/GitAuthentication.cs
+++ b/Scalar.Common/Git/GitAuthentication.cs
@@ -160,7 +160,7 @@ namespace Scalar.Common.Git
             return true;
         }
 
-        public bool TryInitialize(ITracer tracer, Enlistment enlistment, out string errorMessage)
+        public Result TryInitialize(ITracer tracer, Enlistment enlistment, out string errorMessage)
         {
             if (this.isInitialized)
             {
@@ -173,18 +173,18 @@ namespace Scalar.Common.Git
             if (!this.TryAnonymousQuery(tracer, enlistment, out isAnonymous))
             {
                 errorMessage = $"Unable to determine if authentication is required";
-                return false;
+                return Result.UnableToDetermine;
             }
 
             if (!isAnonymous &&
                 !this.TryCallGitCredential(tracer, out errorMessage))
             {
-                return false;
+                return Result.Failed;
             }
 
             this.IsAnonymous = isAnonymous;
             this.isInitialized = true;
-            return true;
+            return Result.Success;
         }
 
         public bool TryInitializeAndRequireAuth(ITracer tracer, out string errorMessage)
@@ -322,6 +322,13 @@ namespace Scalar.Common.Git
             }
 
             return true;
+        }
+
+        public enum Result
+        {
+            Success = 0,
+            Failed = 1,
+            UnableToDetermine = 2,
         }
     }
 }

--- a/Scalar.Common/Git/GitProcess.cs
+++ b/Scalar.Common/Git/GitProcess.cs
@@ -90,8 +90,6 @@ namespace Scalar.Common.Git
             string filterArg = filterBlobs ? "--filter=blob:none" : string.Empty;
 
             string dir = Paths.ConvertPathToGitFormat(targetDir);
-            dir.Replace(" ", "\\ ");
-            url.Replace(" ", "%20");
 
             GitProcess git = new GitProcess(gitBinPath, workingDirectoryRoot: null);
 

--- a/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/ScalarCloneFromGithub.cs
+++ b/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/ScalarCloneFromGithub.cs
@@ -35,6 +35,11 @@ namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
         [TestCase]
         public void PartialCloneSsh()
         {
+            ProcessResult result = ProcessHelper.Run("ssh-keygen", "-H github.com");
+
+            string userDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            this.fileSystem.AppendAllText(Path.Combine(userDir, ".ssh", "known_hosts"), result.Output);
+
             ScalarFunctionalTestEnlistment enlistment = this.CreateNewEnlistment(
                                                                 url: MicrosoftScalarSsh,
                                                                 branch: "master",

--- a/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/ScalarCloneFromGithub.cs
+++ b/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/ScalarCloneFromGithub.cs
@@ -32,33 +32,6 @@ namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
             VerifyPartialCloneBehavior(enlistment);
         }
 
-        [TestCase]
-        public void PartialCloneSsh()
-        {
-            ProcessResult result = ProcessHelper.Run("ssh-keygen", "-H github.com");
-
-            string userDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            string sshDir = Path.Combine(userDir, ".ssh");
-
-            if (this.fileSystem.DirectoryExists(sshDir))
-            {
-                this.fileSystem.CreateDirectory(sshDir);
-            }
-
-            string knownHosts = Path.Combine(sshDir, "known_hosts");
-            if (this.fileSystem.FileExists(knownHosts) && !this.fileSystem.ReadAllText(knownHosts).Contains("github.com"))
-            {
-                this.fileSystem.AppendAllText(knownHosts, result.Output);
-            }
-
-            ScalarFunctionalTestEnlistment enlistment = this.CreateNewEnlistment(
-                                                                url: MicrosoftScalarSsh,
-                                                                branch: "master",
-                                                                fullClone: false);
-
-            VerifyPartialCloneBehavior(enlistment);
-        }
-
         private void VerifyPartialCloneBehavior(ScalarFunctionalTestEnlistment enlistment)
         {
             this.fileSystem.DirectoryExists(enlistment.RepoRoot).ShouldBeTrue($"'{enlistment.RepoRoot}' does not exist");

--- a/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/ScalarCloneFromGithub.cs
+++ b/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/ScalarCloneFromGithub.cs
@@ -1,0 +1,86 @@
+﻿using NUnit.Framework;
+using Scalar.FunctionalTests.FileSystemRunners;
+using Scalar.FunctionalTests.Tools;
+using Scalar.Tests.Should;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
+{
+    [Category(Categories.GitRepository)]
+    public class ScalarCloneFromGithub : TestsWithMultiEnlistment
+    {
+        private static readonly string MicrosoftScalarHttp = "https://github.com/microsoft/scalar";
+        private static readonly string MicrosoftScalarSsh = "git@github.com:microsoft/scalar.git";
+
+        private FileSystemRunner fileSystem;
+
+        public ScalarCloneFromGithub()
+        {
+            this.fileSystem = new SystemIORunner();
+        }
+
+        [TestCase]
+        public void PartialCloneHttps()
+        {
+            ScalarFunctionalTestEnlistment enlistment = this.CreateNewEnlistment(
+                                                                url: MicrosoftScalarHttp,
+                                                                branch: "master",
+                                                                fullClone: false);
+
+            VerifyPartialCloneBehavior(enlistment);
+        }
+
+        [TestCase]
+        public void PartialCloneSsh()
+        {
+            ScalarFunctionalTestEnlistment enlistment = this.CreateNewEnlistment(
+                                                                url: MicrosoftScalarSsh,
+                                                                branch: "master",
+                                                                fullClone: false);
+
+            VerifyPartialCloneBehavior(enlistment);
+        }
+
+        private void VerifyPartialCloneBehavior(ScalarFunctionalTestEnlistment enlistment)
+        {
+            this.fileSystem.DirectoryExists(enlistment.RepoRoot).ShouldBeTrue($"'{enlistment.RepoRoot}' does not exist");
+
+            string gitPack = Path.Combine(enlistment.RepoRoot, ".git", "objects", "pack");
+            this.fileSystem.DirectoryExists(gitPack).ShouldBeTrue($"'{gitPack}' does not exist");
+
+            void checkPacks(string dir, int count, string when)
+            {
+                string dirContents = this.fileSystem
+                    .EnumerateDirectory(dir);
+
+                dirContents
+                    .Split()
+                    .Where(file => string.Equals(Path.GetExtension(file), ".pack", StringComparison.OrdinalIgnoreCase))
+                    .Count()
+                    .ShouldEqual(count, $"'{dir}' after '{when}': '{dirContents}'");
+            }
+
+            // Two packs for clone: commits and trees, blobs at root
+            checkPacks(gitPack, 2, "clone");
+
+            string srcScalar = Path.Combine(enlistment.RepoRoot, "Scalar");
+            this.fileSystem.DirectoryExists(srcScalar).ShouldBeFalse($"'{srcScalar}' should not exist due to sparse-checkout");
+
+            ProcessResult sparseCheckoutResult = GitProcess.InvokeProcess(enlistment.RepoRoot, "sparse-checkout disable");
+            sparseCheckoutResult.ExitCode.ShouldEqual(0, "git sparse-checkout disable exit code");
+
+            this.fileSystem.DirectoryExists(srcScalar).ShouldBeTrue($"'{srcScalar}' should exist after sparse-checkout");
+
+            // Three packs for sparse-chekcout: commits and trees, blobs at root, blobs outside root
+            checkPacks(gitPack, 3, "sparse-checkout");
+
+            ProcessResult checkoutResult = GitProcess.InvokeProcess(enlistment.RepoRoot, "checkout HEAD~10");
+            checkoutResult.ExitCode.ShouldEqual(0, "git checkout exit code");
+
+            // Four packs for chekcout: commits and trees, blobs at root, blobs outside root, checkout diff
+            checkPacks(gitPack, 4, "checkout");
+        }
+    }
+}

--- a/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/ScalarCloneFromGithub.cs
+++ b/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/ScalarCloneFromGithub.cs
@@ -38,7 +38,18 @@ namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
             ProcessResult result = ProcessHelper.Run("ssh-keygen", "-H github.com");
 
             string userDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            this.fileSystem.AppendAllText(Path.Combine(userDir, ".ssh", "known_hosts"), result.Output);
+            string sshDir = Path.Combine(userDir, ".ssh");
+
+            if (this.fileSystem.DirectoryExists(sshDir))
+            {
+                this.fileSystem.CreateDirectory(sshDir);
+            }
+
+            string knownHosts = Path.Combine(sshDir, "known_hosts");
+            if (this.fileSystem.FileExists(knownHosts) && !this.fileSystem.ReadAllText(knownHosts).Contains("github.com"))
+            {
+                this.fileSystem.AppendAllText(knownHosts, result.Output);
+            }
 
             ScalarFunctionalTestEnlistment enlistment = this.CreateNewEnlistment(
                                                                 url: MicrosoftScalarSsh,

--- a/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/TestsWithMultiEnlistment.cs
+++ b/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/TestsWithMultiEnlistment.cs
@@ -31,13 +31,17 @@ namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
         protected ScalarFunctionalTestEnlistment CreateNewEnlistment(
             string localCacheRoot = null,
             string branch = null,
-            bool skipFetchCommitsAndTrees = false)
+            bool skipFetchCommitsAndTrees = false,
+            string url = null,
+            bool fullClone = true)
         {
             ScalarFunctionalTestEnlistment output = ScalarFunctionalTestEnlistment.Clone(
                 ScalarTestConfig.PathToScalar,
                 branch,
                 localCacheRoot,
-                skipFetchCommitsAndTrees);
+                skipFetchCommitsAndTrees,
+                fullClone: fullClone,
+                url: url);
             this.enlistmentsToDelete.Add(output);
             return output;
         }

--- a/Scalar.FunctionalTests/Tools/ScalarFunctionalTestEnlistment.cs
+++ b/Scalar.FunctionalTests/Tools/ScalarFunctionalTestEnlistment.cs
@@ -100,10 +100,11 @@ namespace Scalar.FunctionalTests.Tools
             string commitish = null,
             string localCacheRoot = null,
             bool skipFetchCommitsAndTrees = false,
-            bool fullClone = true)
+            bool fullClone = true,
+            string url = null)
         {
             string enlistmentRoot = ScalarFunctionalTestEnlistment.GetUniqueEnlistmentRoot();
-            return Clone(pathToScalar, enlistmentRoot, commitish, localCacheRoot, skipFetchCommitsAndTrees, fullClone);
+            return Clone(pathToScalar, enlistmentRoot, commitish, localCacheRoot, skipFetchCommitsAndTrees, fullClone, url);
         }
 
         public static ScalarFunctionalTestEnlistment CloneEnlistmentWithSpacesInPath(string pathToScalar, string commitish = null)
@@ -268,14 +269,15 @@ namespace Scalar.FunctionalTests.Tools
             string commitish,
             string localCacheRoot,
             bool skipFetchCommitsAndTrees = false,
-            bool fullClone = true)
+            bool fullClone = true,
+            string url = null)
         {
             enlistmentRoot = enlistmentRoot ?? GetUniqueEnlistmentRoot();
 
             ScalarFunctionalTestEnlistment enlistment = new ScalarFunctionalTestEnlistment(
                 pathToScalar,
                 enlistmentRoot,
-                ScalarTestConfig.RepoToClone,
+                url ?? ScalarTestConfig.RepoToClone,
                 commitish ?? Properties.Settings.Default.Commitish,
                 localCacheRoot ?? ScalarTestConfig.LocalCacheRoot,
                 fullClone);

--- a/Scalar/CommandLine/CacheServerVerb.cs
+++ b/Scalar/CommandLine/CacheServerVerb.cs
@@ -1,5 +1,6 @@
 using CommandLine;
 using Scalar.Common;
+using Scalar.Common.Git;
 using Scalar.Common.Http;
 using Scalar.Common.Tracing;
 using System;
@@ -43,7 +44,7 @@ namespace Scalar.CommandLine
             using (ITracer tracer = new JsonTracer(ScalarConstants.ScalarEtwProviderName, "CacheVerb"))
             {
                 string authErrorMessage;
-                if (!this.TryAuthenticate(tracer, enlistment, out authErrorMessage))
+                if (this.TryAuthenticate(tracer, enlistment, out authErrorMessage) != GitAuthentication.Result.Success)
                 {
                     this.ReportErrorAndExit(tracer, "Authentication failed: " + authErrorMessage);
                 }

--- a/Scalar/CommandLine/CloneVerb.cs
+++ b/Scalar/CommandLine/CloneVerb.cs
@@ -218,8 +218,14 @@ namespace Scalar.CommandLine
             this.Output.WriteLine("  Destination:  " + this.enlistment.EnlistmentRoot);
             this.Output.WriteLine("  FullClone:     " + this.FullClone);
 
-            string authErrorMessage;
-            GitAuthentication.Result authResult = this.TryAuthenticate(this.tracer, this.enlistment, out authErrorMessage);
+            string authErrorMessage = null;
+            GitAuthentication.Result authResult = GitAuthentication.Result.UnableToDetermine;
+
+            // Do not try authentication on SSH URLs.
+            if (this.enlistment.RepoUrl.StartsWith("https://"))
+            {
+                authResult = this.TryAuthenticate(this.tracer, this.enlistment, out authErrorMessage);
+            }
 
             if (authResult == GitAuthentication.Result.UnableToDetermine)
             {

--- a/Scalar/CommandLine/CloneVerb.cs
+++ b/Scalar/CommandLine/CloneVerb.cs
@@ -219,7 +219,15 @@ namespace Scalar.CommandLine
             this.Output.WriteLine("  FullClone:     " + this.FullClone);
 
             string authErrorMessage;
-            if (!this.TryAuthenticate(this.tracer, this.enlistment, out authErrorMessage))
+            GitAuthentication.Result authResult = this.TryAuthenticate(this.tracer, this.enlistment, out authErrorMessage);
+
+            if (authResult == GitAuthentication.Result.UnableToDetermine)
+            {
+                // We can't tell, because we don't have the right endpoint!
+                return this.GitClone();
+            }
+
+            if (authResult == GitAuthentication.Result.Failed)
             {
                 this.ReportErrorAndExit(this.tracer, "Cannot clone because authentication failed: " + authErrorMessage);
             }
@@ -291,6 +299,88 @@ namespace Scalar.CommandLine
             return cloneResult;
         }
 
+        private Result GitClone()
+        {
+            string gitBinPath = ScalarPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
+            if (string.IsNullOrWhiteSpace(gitBinPath))
+            {
+                return new Result(ScalarConstants.GitIsNotInstalledError);
+            }
+
+            GitProcess git = new GitProcess(this.enlistment);
+
+            git.SetInLocalConfig("protocol.version", "2");
+            git.SetInLocalConfig("remote.origin.url", this.RepositoryURL);
+            git.SetInLocalConfig("remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*");
+            git.SetInLocalConfig("remote.origin.promisor", "true");
+            git.SetInLocalConfig("remote.origin.partialCloneFilter", "blob:none");
+
+            string branch = this.Branch ?? "master";
+            git.SetInLocalConfig($"branch.{branch}.remote", "origin");
+            git.SetInLocalConfig($"branch.{branch}.merge", $"refs/heads/{branch}");
+
+            if (!this.FullClone)
+            {
+                git.SetInLocalConfig($"core.sparseCheckout", "true");
+                git.SetInLocalConfig($"core.sparseCheckoutCone", "true");
+
+                this.fileSystem.CreateDirectory(Path.Combine(this.enlistment.DotGitRoot, "info"));
+                this.fileSystem.WriteAllText(Path.Combine(this.enlistment.DotGitRoot, "info", "sparse-checkout"), "/*\n!/*/*");
+            }
+
+            this.context = new ScalarContext(this.tracer, this.fileSystem, this.enlistment);
+
+            // Set required and optional config.
+            // Explicitly pass useGvfsProtocol: true as the enlistment can not discover that setting from
+            // Git config yet. Other verbs will discover this automatically from the config we set now.
+            ConfigStep configStep = new ConfigStep(this.context, useGvfsProtocol: false);
+
+            if (!configStep.TrySetConfig(out string configError))
+            {
+                return new Result($"Failed to set initial config: {configError}");
+            }
+
+            GitProcess.Result fetchResult = null;
+            if (!this.ShowStatusWhileRunning(() =>
+            {
+                fetchResult = git.ForegroundFetch("origin");
+                return fetchResult.ExitCodeIsSuccess;
+            },
+                "Fetching objects from remote"))
+            {
+                if (!fetchResult.Errors.Contains("filtering not recognized by server"))
+                {
+                    return new Result($"Failed to complete regular clone: {fetchResult?.Errors}");
+                }
+            }
+
+            if (fetchResult.ExitCodeIsFailure &&
+                !this.ShowStatusWhileRunning(() =>
+                {
+                    git.DeleteFromLocalConfig("remote.origin.promisor");
+                    git.DeleteFromLocalConfig("remote.origin.partialCloneFilter");
+                    fetchResult = git.ForegroundFetch("origin");
+                    return fetchResult.ExitCodeIsSuccess;
+                },
+                "Fetching objects from remote"))
+            {
+                return new Result($"Failed to complete regular clone: {fetchResult?.Errors}");
+            }
+
+            GitProcess.Result checkoutResult = null;
+
+            if (!this.ShowStatusWhileRunning(() =>
+                {
+                    checkoutResult = git.ForceCheckout(branch);
+                    return checkoutResult.ExitCodeIsSuccess;
+                },
+                $"Checking out '{branch}'"))
+            {
+                return new Result($"Failed to complete regular clone: {checkoutResult?.Errors}");
+            }
+            return new Result(true);
+        }
+
         private Result TryCreateEnlistment(
             string fullEnlistmentRootPathParameter,
             string normalizedEnlistementRootPath,
@@ -329,7 +419,9 @@ namespace Scalar.CommandLine
                 return new Result($"Error when creating a new Scalar enlistment at '{normalizedEnlistementRootPath}'. {e.Message}");
             }
 
-            return new Result(true);
+            GitProcess.Result initResult = GitProcess.Init(enlistment);
+
+            return new Result(initResult.ExitCodeIsSuccess);
         }
 
         private Result CreateScalarDirctories(string resolvedLocalCacheRoot)

--- a/Scalar/CommandLine/RunVerb.cs
+++ b/Scalar/CommandLine/RunVerb.cs
@@ -231,7 +231,7 @@ namespace Scalar.CommandLine
             if (!this.SkipVersionCheck)
             {
                 string authErrorMessage;
-                if (!this.TryAuthenticate(tracer, enlistment, out authErrorMessage))
+                if (this.TryAuthenticate(tracer, enlistment, out authErrorMessage) != GitAuthentication.Result.Success)
                 {
                     this.ReportErrorAndExit(tracer, "Unable to fetch because authentication failed: " + authErrorMessage);
                 }

--- a/Scalar/CommandLine/ScalarVerb.cs
+++ b/Scalar/CommandLine/ScalarVerb.cs
@@ -162,12 +162,17 @@ namespace Scalar.CommandLine
                 initialDelayMs: 0);
         }
 
-        protected bool TryAuthenticate(ITracer tracer, ScalarEnlistment enlistment, out string authErrorMessage)
+        protected GitAuthentication.Result TryAuthenticate(ITracer tracer, ScalarEnlistment enlistment, out string authErrorMessage)
         {
             string authError = null;
 
-            bool result = this.ShowStatusWhileRunning(
-                () => enlistment.Authentication.TryInitialize(tracer, enlistment, out authError),
+            GitAuthentication.Result result = GitAuthentication.Result.UnableToDetermine;
+            bool runResult = this.ShowStatusWhileRunning(
+                () =>
+                {
+                    result = enlistment.Authentication.TryInitialize(tracer, enlistment, out authError);
+                    return true;
+                },
                 "Authenticating");
 
             authErrorMessage = authError;
@@ -270,7 +275,7 @@ namespace Scalar.CommandLine
                 },
                 "Querying remote for config"))
             {
-                this.ReportErrorAndExit(tracer, "Unable to query /gvfs/config" + Environment.NewLine + errorMessage);
+                tracer.RelatedWarning("Unable to query /gvfs/config" + Environment.NewLine + errorMessage);
             }
 
             return serverScalarConfig;


### PR DESCRIPTION
This requires microsoft/git#249 in order to avoid a bad partial clone bug.

You can now try this:

```
$ scalar clone https://github.com/microsoft/scalar
Clone parameters:
  Repo URL:     https://github.com/microsoft/scalar
  Branch:       Default
  Cache Server: Default
  Local Cache:  C:\.scalarCache
  Destination:  C:\_git\t\scalar
  FullClone:     False
Authenticating...Succeeded
Fetching objects from remote...Succeeded
Checking out 'master'...Succeeded

$ ls scalar/src/
AuthoringTests.md  Dependencies.props     Directory.Build.targets  License.md    Protocol.md  Scalar.ruleset  SECURITY.md
CONTRIBUTING.md    Directory.Build.props  global.json              nuget.config  Readme.md    Scalar.sln      Signing.targets

$ cd scalar/src/

$ git sparse-checkout disable
remote: Enumerating objects: 418, done.
remote: Counting objects: 100% (418/418), done.
remote: Compressing objects: 100% (410/410), done.
remote: Total 483 (delta 71), reused 9 (delta 8), pack-reused 65
Receiving objects: 100% (483/483), 556.94 KiB | 8.57 MiB/s, done.
Resolving deltas: 100% (77/77), done.
Updating files: 100% (491/491), done.

$ ls
AuthoringTests.md        global.json   Scalar.Common/             Scalar.ruleset              Scalar.UnitTests/
CONTRIBUTING.md          License.md    Scalar.FunctionalTests/    Scalar.Service/             Scalar.Upgrader/
Dependencies.props       nuget.config  Scalar.Installer.Mac/      Scalar.Service.UI/          Scripts/
Directory.Build.props    Protocol.md   Scalar.Installer.Windows/  Scalar.Signing/             SECURITY.md
Directory.Build.targets  Readme.md     Scalar.MSBuild/            Scalar.sln                  Signing.targets
docs/                    Scalar/       Scalar.Notifications.Mac/  Scalar.TestInfrastructure/
```

or use SSH:

```
$ scalar clone git@github.com:microsoft/scalar.git scalar-ssh
Clone parameters:
  Repo URL:     git@github.com:microsoft/scalar.git
  Branch:       Default
  Cache Server: Default
  Local Cache:  C:\.scalarCache
  Destination:  C:\_git\t\scalar-ssh
  FullClone:     False
Fetching objects from remote...Succeeded
Checking out 'master'...Succeeded

$ cd scalar-ssh/src/

$ ls
AuthoringTests.md  Dependencies.props     Directory.Build.targets  License.md    Protocol.md  Scalar.ruleset  SECURITY.md
CONTRIBUTING.md    Directory.Build.props  global.json              nuget.config  Readme.md    Scalar.sln      Signing.targets

$ git sparse-checkout disable
remote: Enumerating objects: 418, done.
remote: Counting objects: 100% (418/418), done.
remote: Compressing objects: 100% (410/410), done.
remote: Total 483 (delta 71), reused 9 (delta 8), pack-reused 65
Receiving objects: 100% (483/483), 556.94 KiB | 9.95 MiB/s, done.
Resolving deltas: 100% (77/77), done.
Updating files: 100% (491/491), done.

$ ls
AuthoringTests.md        global.json   Scalar.Common/             Scalar.ruleset              Scalar.UnitTests/
CONTRIBUTING.md          License.md    Scalar.FunctionalTests/    Scalar.Service/             Scalar.Upgrader/
Dependencies.props       nuget.config  Scalar.Installer.Mac/      Scalar.Service.UI/          Scripts/
Directory.Build.props    Protocol.md   Scalar.Installer.Windows/  Scalar.Signing/             SECURITY.md
Directory.Build.targets  Readme.md     Scalar.MSBuild/            Scalar.sln                  Signing.targets
docs/                    Scalar/       Scalar.Notifications.Mac/  Scalar.TestInfrastructure/
```

I test a scenario for HTTPS clones, but SSH clones don't work due to the protections against man-in-the-middle attacks. Not sure how to resolve that, but the test I had would work from my dev box that had GitHub.com in my `known_hosts` file.