### PR TITLE
ConfigStep: use full hook path for fsmonitor

### DIFF
--- a/Scalar.Common/Maintenance/ConfigStep.cs
+++ b/Scalar.Common/Maintenance/ConfigStep.cs
@@ -248,8 +248,9 @@ namespace Scalar.Common.Maintenance
                     queryWatchmanPath,
                     overwrite: true);
 
+                string dotGitRoot = this.Context.Enlistment.DotGitRoot.Replace(Path.DirectorySeparatorChar, ScalarConstants.GitPathSeparator);
                 this.RunGitCommand(
-                    process => process.SetInLocalConfig("core.fsmonitor", ".git/hooks/query-watchman"),
+                    process => process.SetInLocalConfig("core.fsmonitor",  dotGitRoot + "/hooks/query-watchman"),
                     "config");
 
                 this.Context.Tracer.RelatedInfo("Watchman configured!");


### PR DESCRIPTION
Resolves #338.

This appears to be the issue:

1. Someone runs `scalar register` in a repository that has worktrees.
2. The worktrees start to use the `core.fsmonitor` config setting.
3. The worktree tries to execute from `.git/hooks/query-watchman`, but that is not a path relative to the worktree.

This fixes the configs setting.

I've tested this on my Windows machine with a worktree of git/git.

Cc: @kewillford the expert on fsmonitor. As a longer plan, we should consider adding tests that cover the case for worktrees.