### PR TITLE
Update Git to v2.26.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,8 +36,16 @@
 
     <!-- Version information -->
     <ScalarVersion>0.2.173.2</ScalarVersion>
-    <GitPackageVersion>2.20200227.1</GitPackageVersion>
+
+    <!--
+       Update the GitPackageVersion for the version that is shipped and tested with Scalar.
+       The MinimumGitVersion is intentionally lower to allow side-by-side installs of
+       VFS for Git (which is less flexible). Only update that version if we rely upon a
+       new command-line interface in Git or if there is a truly broken interaction.
+    -->
+    <GitPackageVersion>2.20200323.8</GitPackageVersion>
     <MinimumGitVersion>v2.25.0.vfs.1.1</MinimumGitVersion>
+
     <WatchmanPackageUrl>https://github.com/facebook/watchman/suites/307436006/artifacts/304557</WatchmanPackageUrl>
     <GcmCoreOSXPackageUrl>https://github.com/microsoft/Git-Credential-Manager-Core/releases/download/v2.0.79-beta/gcmcore-osx-2.0.79.64449.pkg</GcmCoreOSXPackageUrl>
 

--- a/Scalar.Common/Maintenance/ConfigStep.cs
+++ b/Scalar.Common/Maintenance/ConfigStep.cs
@@ -235,9 +235,18 @@ namespace Scalar.Common.Maintenance
 
             try
             {
+                string hooksDir = ScalarPlatform.Instance.GetTemplateHooksDirectory();
+
+                if (string.IsNullOrEmpty(hooksDir))
+                {
+                    this.Context.Tracer.RelatedError("Could not find hook templates directory. Skipping watchman integration.");
+                    return;
+                }
+
+                // Install query-watchman hook from latest Git path
                 string fsMonitorWatchmanSampleHookPath = Path.Combine(
-                    this.Context.Enlistment.WorkingDirectoryRoot,
-                    ScalarConstants.DotGit.Hooks.FsMonitorWatchmanSamplePath);
+                    hooksDir,
+                    ScalarConstants.DotGit.Hooks.FsMonitorWatchmanSampleName);
 
                 string queryWatchmanPath = Path.Combine(
                     this.Context.Enlistment.WorkingDirectoryRoot,
@@ -250,7 +259,10 @@ namespace Scalar.Common.Maintenance
 
                 string dotGitRoot = this.Context.Enlistment.DotGitRoot.Replace(Path.DirectorySeparatorChar, ScalarConstants.GitPathSeparator);
                 this.RunGitCommand(
-                    process => process.SetInLocalConfig("core.fsmonitor",  dotGitRoot + "/hooks/query-watchman"),
+                    process => process.SetInLocalConfig("core.fsmonitor", dotGitRoot + "/hooks/query-watchman"),
+                    "config");
+                this.RunGitCommand(
+                    process => process.SetInLocalConfig("core.fsmonitorHookVersion", "2"),
                     "config");
 
                 this.Context.Tracer.RelatedInfo("Watchman configured!");

--- a/Scalar.Common/Platforms/Mac/MacPlatform.cs
+++ b/Scalar.Common/Platforms/Mac/MacPlatform.cs
@@ -146,6 +146,11 @@ namespace Scalar.Platform.Mac
             running = installed && scalarService.IsRunning;
         }
 
+        public override string GetTemplateHooksDirectory()
+        {
+            return Path.Combine("usr", "local", ScalarConstants.InstalledGit.HookTemplateDir);
+        }
+
         public class MacPlatformConstants : POSIXPlatformConstants
         {
             public override string InstallerExtension

--- a/Scalar.Common/Platforms/Windows/WindowsPlatform.cs
+++ b/Scalar.Common/Platforms/Windows/WindowsPlatform.cs
@@ -337,6 +337,20 @@ namespace Scalar.Platform.Windows
             return new WindowsProductUpgraderPlatformStrategy(fileSystem, tracer);
         }
 
+        public override string GetTemplateHooksDirectory()
+        {
+            string gitBinPath = GitInstallation.GetInstalledGitBinPath();
+
+            string tail = Path.Combine("cmd", "git.exe");
+            if (gitBinPath.EndsWith(tail))
+            {
+                string gitBasePath = gitBinPath.Substring(0, gitBinPath.Length - tail.Length);
+                return Path.Combine(gitBasePath, "mingw64", ScalarConstants.InstalledGit.HookTemplateDir);
+            }
+
+            return null;
+        }
+
         public override bool TryGetDefaultLocalCacheRoot(string enlistmentRoot, out string localCacheRoot, out string localCacheRootError)
         {
             string pathRoot;

--- a/Scalar.Common/ScalarConstants.cs
+++ b/Scalar.Common/ScalarConstants.cs
@@ -187,6 +187,11 @@ namespace Scalar.Common
             }
         }
 
+        public static class InstalledGit
+        {
+            public static readonly string HookTemplateDir = Path.Combine("share", "git-core", "templates", "hooks");
+        }
+
         public static class VerbParameters
         {
             public const string InternalUseOnly = "internal_use_only";

--- a/Scalar.Common/ScalarPlatform.cs
+++ b/Scalar.Common/ScalarPlatform.cs
@@ -114,6 +114,8 @@ namespace Scalar.Common
             PhysicalFileSystem fileSystem,
             ITracer tracer);
 
+        public abstract string GetTemplateHooksDirectory();
+
         public bool TryGetNormalizedPathRoot(string path, out string pathRoot, out string errorMessage)
         {
             pathRoot = null;

--- a/Scalar.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
+++ b/Scalar.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
@@ -980,7 +980,7 @@ namespace Scalar.FunctionalTests.Tests.GitCommands
             string command = "checkout -b tests/functional/OpenFileThenCheckout_2";
             ProcessResult expectedResult = GitProcess.InvokeProcess(controlRepoRoot, command);
             ProcessResult actualResult = GitHelpers.InvokeGitAgainstScalarRepo(scalarRepoRoot, command);
-            GitHelpers.ErrorsShouldMatch(command, expectedResult, actualResult);
+            GitHelpers.LinesShouldMatch(command, expectedResult.Errors, actualResult.Errors);
             actualResult.Errors.ShouldContain("Switched to a new branch");
 
             this.ValidateGitCommand("status");

--- a/Scalar.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
+++ b/Scalar.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
@@ -261,7 +261,7 @@ namespace Scalar.FunctionalTests.Tests.GitCommands
 
             if (!ignoreErrors)
             {
-                GitHelpers.ErrorsShouldMatch(command, expectedResult, actualResult);
+                GitHelpers.LinesShouldMatch(command, expectedResult.Errors, actualResult.Errors);
             }
 
             if (command != "status" && checkStatus)

--- a/Scalar.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
+++ b/Scalar.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
@@ -212,6 +212,7 @@ namespace Scalar.FunctionalTests.Tests.GitCommands
                                                                 ScalarTestConfig.PathToScalar,
                                                                 commitish: commitish,
                                                                 fullClone: this.validateWorkingTree != Settings.ValidateWorkingTreeMode.SparseMode);
+            GitProcess.Invoke(this.Enlistment.RepoRoot, "config core.editor true");
             GitProcess.Invoke(this.Enlistment.RepoRoot, "config advice.statusUoption false");
             this.ControlGitRepo = ControlGitRepo.Create(commitish);
             this.ControlGitRepo.Initialize();

--- a/Scalar.FunctionalTests/Tools/ControlGitRepo.cs
+++ b/Scalar.FunctionalTests/Tools/ControlGitRepo.cs
@@ -1,7 +1,5 @@
-using Scalar.FunctionalTests.FileSystemRunners;
 using System;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace Scalar.FunctionalTests.Tools
 {
@@ -52,6 +50,7 @@ namespace Scalar.FunctionalTests.Tools
             Directory.CreateDirectory(this.RootPath);
             GitProcess.Invoke(this.RootPath, "init");
             GitProcess.Invoke(this.RootPath, "config core.autocrlf false");
+            GitProcess.Invoke(this.RootPath, "config core.editor true");
             GitProcess.Invoke(this.RootPath, "config merge.stat false");
             GitProcess.Invoke(this.RootPath, "config merge.renames false");
             GitProcess.Invoke(this.RootPath, "config advice.statusUoption false");

--- a/Scalar.FunctionalTests/Tools/GitHelpers.cs
+++ b/Scalar.FunctionalTests/Tools/GitHelpers.cs
@@ -87,9 +87,8 @@ namespace Scalar.FunctionalTests.Tools
             ProcessResult expectedResult = GitProcess.InvokeProcess(controlRepoRoot, command, environmentVariables);
             ProcessResult actualResult = GitHelpers.InvokeGitAgainstScalarRepo(scalarRepoRoot, command, environmentVariables);
 
-            ErrorsShouldMatch(command, expectedResult, actualResult);
-            actualResult.Output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-                .ShouldMatchInOrder(expectedResult.Output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries), LinesAreEqual, command + " Output Lines");
+            LinesShouldMatch(command + " Errors Lines", actualResult.Errors, expectedResult.Errors);
+            LinesShouldMatch(command + " Output Lines", actualResult.Output, expectedResult.Output);
 
             if (command != "status")
             {
@@ -97,10 +96,18 @@ namespace Scalar.FunctionalTests.Tools
             }
         }
 
-        public static void ErrorsShouldMatch(string command, ProcessResult expectedResult, ProcessResult actualResult)
+        public static void LinesShouldMatch(string message, string expected, string actual)
         {
-            actualResult.Errors.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-                .ShouldMatchInOrder(expectedResult.Errors.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries), LinesAreEqual, command + " Errors Lines");
+            IEnumerable<string> actualLines = NonEmptyLines(actual);
+            IEnumerable<string> expectedLines = NonEmptyLines(expected);
+            actualLines.ShouldMatchInOrder(expectedLines, LinesAreEqual, message);
+        }
+
+        private static IEnumerable<string> NonEmptyLines(string data)
+        {
+            return data
+                    .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Where(s => !string.IsNullOrWhiteSpace(s));
         }
 
         private static bool LinesAreEqual(string actualLine, string expectedLine)

--- a/Scalar.FunctionalTests/Tools/GitHelpers.cs
+++ b/Scalar.FunctionalTests/Tools/GitHelpers.cs
@@ -83,6 +83,7 @@ namespace Scalar.FunctionalTests.Tools
 
             Dictionary<string, string> environmentVariables = new Dictionary<string, string>();
             environmentVariables["GIT_QUIET"] = "true";
+            environmentVariables["GIT_COMMITTER_DATE"] = "Thu Feb 16 10:07:35 2017 -0700";
 
             ProcessResult expectedResult = GitProcess.InvokeProcess(controlRepoRoot, command, environmentVariables);
             ProcessResult actualResult = GitHelpers.InvokeGitAgainstScalarRepo(scalarRepoRoot, command, environmentVariables);

--- a/Scalar.TestInfrastructure/Should/EnumerableShouldExtensions.cs
+++ b/Scalar.TestInfrastructure/Should/EnumerableShouldExtensions.cs
@@ -136,12 +136,12 @@ namespace Scalar.Tests.Should
 
             foreach (T groupExtraItem in groupExtraItems)
             {
-                errorMessage.AppendLine(string.Format("Extra: {0}", groupExtraItem));
+                errorMessage.AppendLine(string.Format("Extra: '{0}'", groupExtraItem));
             }
 
             foreach (T groupMissingItem in groupMissingItems)
             {
-                errorMessage.AppendLine(string.Format("Missing: {0}", groupMissingItem));
+                errorMessage.AppendLine(string.Format("Missing: '{0}'", groupMissingItem));
             }
 
             if (shouldMatchInOrder)
@@ -150,7 +150,7 @@ namespace Scalar.Tests.Should
                 {
                     if (!equals(groupList[i], expectedValuesList[i]))
                     {
-                        errorMessage.AppendLine($"Items ordered differently, found: {groupList[i]} expected: {expectedValuesList[i]}");
+                        errorMessage.AppendLine($"Items ordered differently, found: '{groupList[i]}' expected: '{expectedValuesList[i]}'");
                     }
                 }
             }

--- a/Scalar.UnitTests/Mock/Common/MockPlatform.cs
+++ b/Scalar.UnitTests/Mock/Common/MockPlatform.cs
@@ -173,6 +173,11 @@ namespace Scalar.UnitTests.Mock.Common
             return true;
         }
 
+        public override string GetTemplateHooksDirectory()
+        {
+            throw new NotSupportedException();
+        }
+
         public class MockPlatformConstants : ScalarPlatformConstants
         {
             public override string ExecutableExtension


### PR DESCRIPTION
See microsoft/git#251 for details.

A few reaction items needed to happen:

1. We need to ignore whitespace lines when verifying Git commands. Some added an extra whitespace line.
2. The rebase backend changed, and it causes `git rebase --continue` to open an editor if the commit had conflicts. By changing `core.editor=true`, we can no-op the editor portion instead of running forever with an open `vi` editor.
3. With the updated rebase backend, the commit OID is written to output. This causes our output between the control repo and the Scalar repo to be different. Set `GIT_COMMITTER_DATE` to be constant to avoid this problem.
4. The `fsmonitor` hook version was updated, so we need to update our hook along with Git. By copying from the templates directory instead of the samples initialized in `.git/hooks`, we are future-proof and will always get the latest copy recommended by Git. Resolves #301.