### PR TITLE
Allow repositories without an 'origin' remote

### DIFF
--- a/Scalar.Common/Enlistment.cs
+++ b/Scalar.Common/Enlistment.cs
@@ -36,7 +36,23 @@ namespace Scalar.Common
                 GitProcess.ConfigResult originResult = gitProcess.GetOriginUrl();
                 if (!originResult.TryParseAsString(out string originUrl, out string error))
                 {
-                    throw new InvalidRepoException(this.WorkingDirectoryRoot, "Could not get origin url. git error: " + error);
+                    if (!gitProcess.TryGetRemotes(out string[] remotes, out error))
+                    {
+                        throw new InvalidRepoException(this.WorkingDirectoryRoot, $"Failed to load remotes with error: {error}");
+                    }
+
+                    if (remotes.Length == 0)
+                    {
+                        originUrl = string.Empty;
+                    }
+                    else
+                    {
+                        GitProcess.ConfigResult remoteResult = gitProcess.GetFromLocalConfig($"remote.{remotes[0]}.url");
+                        if (!remoteResult.TryParseAsString(out originUrl, out error))
+                        {
+                            originUrl = string.Empty;
+                        }
+                    }
                 }
 
                 if (originUrl == null)

--- a/Scalar.Common/Enlistment.cs
+++ b/Scalar.Common/Enlistment.cs
@@ -41,26 +41,17 @@ namespace Scalar.Common
                         throw new InvalidRepoException(this.WorkingDirectoryRoot, $"Failed to load remotes with error: {error}");
                     }
 
-                    if (remotes.Length == 0)
-                    {
-                        originUrl = string.Empty;
-                    }
-                    else
+                    if (remotes.Length > 0)
                     {
                         GitProcess.ConfigResult remoteResult = gitProcess.GetFromLocalConfig($"remote.{remotes[0]}.url");
                         if (!remoteResult.TryParseAsString(out originUrl, out error))
                         {
-                            originUrl = string.Empty;
+                            originUrl = null;
                         }
                     }
                 }
 
-                if (originUrl == null)
-                {
-                    throw new InvalidRepoException(this.WorkingDirectoryRoot, "Could not get origin url. remote 'origin' is not configured for this repo.'");
-                }
-
-                this.RepoUrl = originUrl.Trim();
+                this.RepoUrl = originUrl?.Trim() ?? string.Empty;
             }
 
             this.Authentication = authentication ?? new GitAuthentication(gitProcess, this.RepoUrl, this.WorkingDirectoryRoot);

--- a/Scalar.Common/InvalidRepoException.cs
+++ b/Scalar.Common/InvalidRepoException.cs
@@ -7,7 +7,7 @@ namespace Scalar.Common
         public string RepoPath { get; }
 
         public InvalidRepoException(string repoPath, string message)
-            : base(message)
+            : base($"path: '{repoPath}', message: '{message}'")
         {
             this.RepoPath = repoPath;
         }

--- a/Scalar.Common/ScalarEnlistment.cs
+++ b/Scalar.Common/ScalarEnlistment.cs
@@ -10,19 +10,7 @@ namespace Scalar.Common
         private string gitVersion;
         private string scalarVersion;
 
-        // New enlistment
-        public ScalarEnlistment(string enlistmentRoot, string repoUrl, string gitBinPath, GitAuthentication authentication)
-            : this(
-                  enlistmentRoot,
-                  Path.Combine(enlistmentRoot, ScalarConstants.WorkingDirectoryRootName),
-                  repoUrl,
-                  gitBinPath,
-                  authentication)
-        {
-        }
-
-        // Existing, configured enlistment
-        private ScalarEnlistment(string enlistmentRoot, string workingDirectory, string repoUrl, string gitBinPath, GitAuthentication authentication)
+        public ScalarEnlistment(string enlistmentRoot, string workingDirectory, string repoUrl, string gitBinPath, GitAuthentication authentication)
             : base(
                   enlistmentRoot,
                   workingDirectory,
@@ -74,7 +62,7 @@ namespace Scalar.Common
 
                 if (createWithoutRepoURL)
                 {
-                    return new ScalarEnlistment(enlistmentRoot, string.Empty, gitBinRoot, authentication);
+                    return new ScalarEnlistment(enlistmentRoot, workingDirectory, string.Empty, gitBinRoot, authentication);
                 }
 
                 return new ScalarEnlistment(enlistmentRoot, workingDirectory, null, gitBinRoot, authentication);

--- a/Scalar.UnitTests/Common/ScalarEnlistmentTests.cs
+++ b/Scalar.UnitTests/Common/ScalarEnlistmentTests.cs
@@ -102,7 +102,7 @@ namespace Scalar.UnitTests.Common
             private MockGitProcess gitProcess;
 
             public TestScalarEnlistment()
-                : base("mock:\\path", "mock://repoUrl", "mock:\\git", authentication: null)
+                : base("mock:\\path", "mock:\\path", "mock://repoUrl", "mock:\\git", authentication: null)
             {
                 this.gitProcess = new MockGitProcess();
                 this.gitProcess.SetExpectedCommandResult(

--- a/Scalar.UnitTests/Mock/Common/MockScalarEnlistment.cs
+++ b/Scalar.UnitTests/Mock/Common/MockScalarEnlistment.cs
@@ -10,7 +10,7 @@ namespace Scalar.UnitTests.Mock.Common
         private MockGitProcess gitProcess;
 
         public MockScalarEnlistment()
-            : base(Path.Combine("mock:", "path"), "mock://repoUrl", Path.Combine("mock:", "git"), authentication: null)
+            : base(Path.Combine("mock:", "path"), Path.Combine("mock:", "path"), "mock://repoUrl", Path.Combine("mock:", "git"), authentication: null)
         {
             this.GitObjectsRoot = Path.Combine("mock:", "path", ".git", "objects");
             this.LocalObjectsRoot = this.GitObjectsRoot;
@@ -18,7 +18,7 @@ namespace Scalar.UnitTests.Mock.Common
         }
 
         public MockScalarEnlistment(string enlistmentRoot, string repoUrl, string gitBinPath, MockGitProcess gitProcess)
-            : base(enlistmentRoot, repoUrl, gitBinPath, authentication: null)
+            : base(enlistmentRoot, enlistmentRoot, repoUrl, gitBinPath, authentication: null)
         {
             this.gitProcess = gitProcess;
         }

--- a/Scalar/CommandLine/CloneVerb.cs
+++ b/Scalar/CommandLine/CloneVerb.cs
@@ -427,6 +427,7 @@ namespace Scalar.CommandLine
             {
                 enlistment = new ScalarEnlistment(
                     normalizedEnlistementRootPath,
+                    Path.Combine(normalizedEnlistementRootPath, ScalarConstants.WorkingDirectoryRootName),
                     this.RepositoryURL,
                     gitBinPath,
                     authentication: null);

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -19,9 +19,10 @@ tasks are:
   commits. After writing a new file, verify the file was computed successfully.
   This drastically improves the performance of commands like `git log --graph`.
 
-* `fetch`: Fetch the latest data from the remote server. If using the GVFS
+* `fetch`: Fetch the latest data from the remote servers. If using the GVFS
    protocol, download the latest set of commit and tree packs from
-   the cache server or the origin remote. This will not update your local
+   the cache server or the origin remote. Otherwise, this step will fetch
+   the latest objects from each remote. This will not update your local
    refs, so your `git fetch` commands will report all ref updates. Those
    `git fetch` commands will be much faster as they will require much less
    data transfer.


### PR DESCRIPTION
Resolves #350 

While playing around with an empty repository, I found that `scalar diagnose` was failing because it was adding `src` to the working directory. Turns out there is a missed path that happens depending on the verb options, and now it is fixed.

While doing that, improve the message for `InvalidRepoException`.