### PR TITLE
[DO NOT MERGE] Test with updates from 'next'

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
        VFS for Git (which is less flexible). Only update that version if we rely upon a
        new command-line interface in Git or if there is a truly broken interaction.
     -->
-    <GitPackageVersion>2.20200323.8</GitPackageVersion>
+    <GitPackageVersion>2.20200326.1-pr</GitPackageVersion>
     <MinimumGitVersion>v2.25.0.vfs.1.1</MinimumGitVersion>
 
     <WatchmanPackageUrl>https://github.com/facebook/watchman/suites/307436006/artifacts/304557</WatchmanPackageUrl>


### PR DESCRIPTION
This PR is only intended to be used as a testbed for checking if updates from git/git's next branch will break Scalar's functional tests. This should assist in finding breaking changes early, and possibly to send upstream patches that fix these issues before they become part of a release candidate.

While the process is currently very manual, I am pursuing as much automation in this process as possible.

Currently, this branch includes #349 to avoid those issues already resolved, but this will eventually have only one commit on top of `master` at any given time.