### PR TITLE
Mac install: use 'whoami' for user name

### DIFF
--- a/Scalar.Installer.Mac/InstallScalar.template.sh
+++ b/Scalar.Installer.Mac/InstallScalar.template.sh
@@ -36,6 +36,10 @@ echo "Welcome - running Scalar installation script"
 
 CURRENT_USER=$(/usr/bin/logname)
 
+if [ "$CURRENT_USER" = "root" ]; then
+	CURRENT_USER=$(/usr/bin/whoami)
+fi
+
 if [ -z GIT_INSTALLER_PKG ]; then
     echo "ERROR: GIT_INSTALLER_PKG environment variable not set - exiting"
     exit 1;


### PR DESCRIPTION
Resolves #336.

Since `sudo whoami` always returns "root", we should not just replace our use of `logname` with `whoami`. Instead, fall back to `whoami` only if `logname` returns "root".