### PR TITLE
[168 Blocker] Fix query-watchman hook installation

### DIFF
--- a/Scalar.Common/Maintenance/ConfigStep.cs
+++ b/Scalar.Common/Maintenance/ConfigStep.cs
@@ -237,9 +237,10 @@ namespace Scalar.Common.Maintenance
                     this.Context.Enlistment.WorkingDirectoryRoot,
                     ScalarConstants.DotGit.Hooks.QueryWatchmanPath);
 
+                // Double-check that the hook data uses LF not CRLF
                 this.Context.FileSystem.WriteAllText(
                     queryWatchmanPath,
-                    queryWatchmanHookData);
+                    queryWatchmanHookData.Replace("\r\n", "\n"));
 
                 string dotGitRoot = this.Context.Enlistment.DotGitRoot.Replace(Path.DirectorySeparatorChar, ScalarConstants.GitPathSeparator);
                 this.RunGitCommand(
@@ -434,6 +435,7 @@ sub get_working_dir {
 	}
 
 	return $working_dir;
-}";
+}
+";
     }
 }

--- a/Scalar.Common/Maintenance/ConfigStep.cs
+++ b/Scalar.Common/Maintenance/ConfigStep.cs
@@ -163,10 +163,7 @@ namespace Scalar.Common.Maintenance
                 return false;
             }
 
-            this.ConfigureWatchmanIntegration();
-
-            error = null;
-            return true;
+            return this.ConfigureWatchmanIntegration(out error);
         }
 
         protected override void PerformMaintenance()
@@ -224,38 +221,25 @@ namespace Scalar.Common.Maintenance
             return true;
         }
 
-        private void ConfigureWatchmanIntegration()
+        private bool ConfigureWatchmanIntegration(out string error)
         {
             string watchmanLocation = ProcessHelper.GetProgramLocation(ScalarPlatform.Instance.Constants.ProgramLocaterCommand, "watchman");
             if (string.IsNullOrEmpty(watchmanLocation))
             {
                 this.Context.Tracer.RelatedWarning("Watchman is not installed - skipping Watchman configuration.");
-                return;
+                error = null;
+                return true;
             }
 
             try
             {
-                string hooksDir = ScalarPlatform.Instance.GetTemplateHooksDirectory();
-
-                if (string.IsNullOrEmpty(hooksDir))
-                {
-                    this.Context.Tracer.RelatedError("Could not find hook templates directory. Skipping watchman integration.");
-                    return;
-                }
-
-                // Install query-watchman hook from latest Git path
-                string fsMonitorWatchmanSampleHookPath = Path.Combine(
-                    hooksDir,
-                    ScalarConstants.DotGit.Hooks.FsMonitorWatchmanSampleName);
-
                 string queryWatchmanPath = Path.Combine(
                     this.Context.Enlistment.WorkingDirectoryRoot,
                     ScalarConstants.DotGit.Hooks.QueryWatchmanPath);
 
-                this.Context.FileSystem.CopyFile(
-                    fsMonitorWatchmanSampleHookPath,
+                this.Context.FileSystem.WriteAllText(
                     queryWatchmanPath,
-                    overwrite: true);
+                    queryWatchmanHookData);
 
                 string dotGitRoot = this.Context.Enlistment.DotGitRoot.Replace(Path.DirectorySeparatorChar, ScalarConstants.GitPathSeparator);
                 this.RunGitCommand(
@@ -266,12 +250,190 @@ namespace Scalar.Common.Maintenance
                     "config");
 
                 this.Context.Tracer.RelatedInfo("Watchman configured!");
+                error = null;
+                return true;
             }
             catch (IOException ex)
             {
                 EventMetadata metadata = this.CreateEventMetadata(ex);
-                this.Context.Tracer.RelatedError(metadata, $"Failed to configure Watchman integration: {ex.Message}");
+                error = $"Failed to configure Watchman integration: {ex.Message}";
+                this.Context.Tracer.RelatedError(metadata, error);
+                return false;
             }
         }
+
+        private const string queryWatchmanHookData = @"#!/usr/bin/perl
+
+use strict;
+use warnings;
+use IPC::Open2;
+
+# An example hook script to integrate Watchman
+# (https://facebook.github.io/watchman/) with git to speed up detecting
+# new and modified files.
+#
+# The hook is passed a version (currently 2) and last update token
+# formatted as a string and outputs to stdout a new update token and
+# all files that have been modified since the update token. Paths must
+# be relative to the root of the working tree and separated by a single NUL.
+#
+# To enable this hook, rename this file to ""query-watchman"" and set
+# 'git config core.fsmonitor .git/hooks/query-watchman'
+#
+my ($version, $last_update_token) = @ARGV;
+
+# Uncomment for debugging
+# print STDERR ""$0 $version $last_update_token\n"";
+
+# Check the hook interface version
+if ($version ne 2) {
+	die ""Unsupported query-fsmonitor hook version '$version'.\n"" .
+	    ""Falling back to scanning...\n"";
+}
+
+my $git_work_tree = get_working_dir();
+
+my $retry = 1;
+
+my $json_pkg;
+eval {
+	require JSON::XS;
+	$json_pkg = ""JSON::XS"";
+	1;
+} or do {
+	require JSON::PP;
+	$json_pkg = ""JSON::PP"";
+};
+
+launch_watchman();
+
+sub launch_watchman {
+	my $o = watchman_query();
+	if (is_work_tree_watched($o)) {
+		output_result($o->{clock}, @{$o->{files}});
+	}
+}
+
+sub output_result {
+	my ($clockid, @files) = @_;
+
+	# Uncomment for debugging watchman output
+	# open (my $fh, "">"", "".git/watchman-output.out"");
+	# binmode $fh, "":utf8"";
+	# print $fh ""$clockid\n@files\n"";
+	# close $fh;
+
+	binmode STDOUT, "":utf8"";
+	print $clockid;
+	print ""\0"";
+	local $, = ""\0"";
+	print @files;
+}
+
+sub watchman_clock {
+	my $response = qx/watchman clock ""$git_work_tree""/;
+	die ""Failed to get clock id on '$git_work_tree'.\n"" .
+		""Falling back to scanning...\n"" if $? != 0;
+
+	return $json_pkg->new->utf8->decode($response);
+}
+
+sub watchman_query {
+	my $pid = open2(\*CHLD_OUT, \*CHLD_IN, 'watchman -j --no-pretty')
+	or die ""open2() failed: $!\n"" .
+	""Falling back to scanning...\n"";
+
+	# In the query expression below we're asking for names of files that
+	# changed since $last_update_token but not from the .git folder.
+	#
+	# To accomplish this, we're using the ""since"" generator to use the
+	# recency index to select candidate nodes and ""fields"" to limit the
+	# output to file names only. Then we're using the ""expression"" term to
+	# further constrain the results.
+	if (substr($last_update_token, 0, 1) eq ""c"") {
+		$last_update_token = ""\""$last_update_token\"""";
+	}
+	my $query = <<""	END"";
+		[""query"", ""$git_work_tree"", {
+			""since"": $last_update_token,
+			""fields"": [""name""],
+			""expression"": [""not"", [""dirname"", "".git""]]
+		}]
+	END
+
+	# Uncomment for debugging the watchman query
+	# open (my $fh, "">"", "".git/watchman-query.json"");
+	# print $fh $query;
+	# close $fh;
+
+	print CHLD_IN $query;
+	close CHLD_IN;
+	my $response = do {local $/; <CHLD_OUT>};
+
+	# Uncomment for debugging the watch response
+	# open ($fh, "">"", "".git/watchman-response.json"");
+	# print $fh $response;
+	# close $fh;
+
+	die ""Watchman: command returned no output.\n"" .
+	""Falling back to scanning...\n"" if $response eq """";
+	die ""Watchman: command returned invalid output: $response\n"" .
+	""Falling back to scanning...\n"" unless $response =~ /^\{/;
+
+	return $json_pkg->new->utf8->decode($response);
+}
+
+sub is_work_tree_watched {
+	my ($output) = @_;
+	my $error = $output->{error};
+	if ($retry > 0 and $error and $error =~ m/unable to resolve root .* directory (.*) is not watched/) {
+		$retry--;
+		my $response = qx/watchman watch ""$git_work_tree""/;
+		die ""Failed to make watchman watch '$git_work_tree'.\n"" .
+		    ""Falling back to scanning...\n"" if $? != 0;
+		$output = $json_pkg->new->utf8->decode($response);
+		$error = $output->{error};
+		die ""Watchman: $error.\n"" .
+		""Falling back to scanning...\n"" if $error;
+
+		# Uncomment for debugging watchman output
+		# open (my $fh, "">"", "".git/watchman-output.out"");
+		# close $fh;
+
+		# Watchman will always return all files on the first query so
+		# return the fast ""everything is dirty"" flag to git and do the
+		# Watchman query just to get it over with now so we won't pay
+		# the cost in git to look up each individual file.
+		my $o = watchman_clock();
+		$error = $output->{error};
+
+		die ""Watchman: $error.\n"" .
+		""Falling back to scanning...\n"" if $error;
+
+		output_result($o->{clock}, (""/""));
+		$last_update_token = $o->{clock};
+
+		eval { launch_watchman() };
+		return 0;
+	}
+
+	die ""Watchman: $error.\n"" .
+	""Falling back to scanning...\n"" if $error;
+
+	return 1;
+}
+
+sub get_working_dir {
+	my $working_dir;
+	if ($^O =~ 'msys' || $^O =~ 'cygwin') {
+		$working_dir = Win32::GetCwd();
+		$working_dir =~ tr/\\/\//;
+	} else {
+		require Cwd;
+		$working_dir = Cwd::cwd();
+	}
+
+	return $working_dir;
+}";
     }
 }

--- a/Scalar.Common/Platforms/Mac/MacPlatform.cs
+++ b/Scalar.Common/Platforms/Mac/MacPlatform.cs
@@ -148,7 +148,7 @@ namespace Scalar.Platform.Mac
 
         public override string GetTemplateHooksDirectory()
         {
-            return Path.Combine("usr", "local", ScalarConstants.InstalledGit.HookTemplateDir);
+            return Path.Combine("/usr", "local", ScalarConstants.InstalledGit.HookTemplateDir);
         }
 
         public class MacPlatformConstants : POSIXPlatformConstants

--- a/Scalar.Common/Platforms/Mac/MacPlatform.cs
+++ b/Scalar.Common/Platforms/Mac/MacPlatform.cs
@@ -146,11 +146,6 @@ namespace Scalar.Platform.Mac
             running = installed && scalarService.IsRunning;
         }
 
-        public override string GetTemplateHooksDirectory()
-        {
-            return Path.Combine("/usr", "local", ScalarConstants.InstalledGit.HookTemplateDir);
-        }
-
         public class MacPlatformConstants : POSIXPlatformConstants
         {
             public override string InstallerExtension

--- a/Scalar.Common/Platforms/Windows/WindowsPlatform.cs
+++ b/Scalar.Common/Platforms/Windows/WindowsPlatform.cs
@@ -337,20 +337,6 @@ namespace Scalar.Platform.Windows
             return new WindowsProductUpgraderPlatformStrategy(fileSystem, tracer);
         }
 
-        public override string GetTemplateHooksDirectory()
-        {
-            string gitBinPath = GitInstallation.GetInstalledGitBinPath();
-
-            string tail = Path.Combine("cmd", "git.exe");
-            if (gitBinPath.EndsWith(tail))
-            {
-                string gitBasePath = gitBinPath.Substring(0, gitBinPath.Length - tail.Length);
-                return Path.Combine(gitBasePath, "mingw64", ScalarConstants.InstalledGit.HookTemplateDir);
-            }
-
-            return null;
-        }
-
         public override bool TryGetDefaultLocalCacheRoot(string enlistmentRoot, out string localCacheRoot, out string localCacheRootError)
         {
             string pathRoot;

--- a/Scalar.Common/ScalarPlatform.cs
+++ b/Scalar.Common/ScalarPlatform.cs
@@ -114,8 +114,6 @@ namespace Scalar.Common
             PhysicalFileSystem fileSystem,
             ITracer tracer);
 
-        public abstract string GetTemplateHooksDirectory();
-
         public bool TryGetNormalizedPathRoot(string path, out string pathRoot, out string errorMessage)
         {
             pathRoot = null;

--- a/Scalar.UnitTests/Mock/Common/MockPlatform.cs
+++ b/Scalar.UnitTests/Mock/Common/MockPlatform.cs
@@ -173,11 +173,6 @@ namespace Scalar.UnitTests.Mock.Common
             return true;
         }
 
-        public override string GetTemplateHooksDirectory()
-        {
-            throw new NotSupportedException();
-        }
-
         public class MockPlatformConstants : ScalarPlatformConstants
         {
             public override string ExecutableExtension


### PR DESCRIPTION
In #349, we updated where the hooks were being copied from. Instead of
the local .git/hooks directory, we copy from the installed templates
directory. This allowws us to grab the latest hook associated with our
Git version.

However, I neglected testing thoroughly on Mac, and the path was not
rooted. This causes the config step to log an error because the path
starts at the current working directory, not from root.

Adjust the ConfigStep to return a 'false' result when this step fails,
which will cause the RunVerbTests to fail if we cannot set the hook as
expected.

The test does not verify the hook is placed because we only place it if
Watchman is installed.

**But that's not all!** It turns out that our Git installer on Mac does
not update the templates directory with the new hook! So we must
rely on the raw data being shipped with Scalar instead.