### PR TITLE
Mac: fully root path to '/usr/local' for hook location

### DIFF
--- a/Scalar.Common/Platforms/Mac/MacPlatform.cs
+++ b/Scalar.Common/Platforms/Mac/MacPlatform.cs
@@ -148,7 +148,7 @@ namespace Scalar.Platform.Mac
 
         public override string GetTemplateHooksDirectory()
         {
-            return Path.Combine("usr", "local", ScalarConstants.InstalledGit.HookTemplateDir);
+            return Path.Combine("/usr", "local", "git", ScalarConstants.InstalledGit.HookTemplateDir);
         }
 
         public class MacPlatformConstants : POSIXPlatformConstants

--- a/Scalar.Installer.Mac/InstallScalar.template.sh
+++ b/Scalar.Installer.Mac/InstallScalar.template.sh
@@ -109,6 +109,7 @@ if [ $INSTALL_WATCHMAN -eq 1 ]; then
     echo "=============================="
     echo "Installing watchman as: $CURRENT_USER"
 
+    sudo chown -R $CURRENT_USER /usr/local/Cellar
     sudo -u $CURRENT_USER brew update
     sudo -u $CURRENT_USER brew unlink python@2 || echo "Python 2 was not installed"
     sudo -u $CURRENT_USER brew install watchman


### PR DESCRIPTION
In #349, we updated where the hooks were being copied from. Instead of
the local .git/hooks directory, we copy from the installed templates
directory. This allowws us to grab the latest hook associated with our
Git version.

However, I neglected testing thoroughly on Mac, and the path was not
rooted. This causes the config step to log an error because the path
starts at the current working directory, not from root.

Adjust the ConfigStep to return a 'false' result when this step fails,
which will cause the RunVerbTests to fail if we cannot set the hook as
expected.

The test does not verify the hook is placed because we only place it if
Watchman is installed.

Also, I noticed that the templates directory was wrong! Our installer
puts the templates in a different place than another version of Git.
Perhaps that version was installed by XCode or something, but that
caused the confusion.

(Replaced #359)