### PR TITLE
Fix commit-graph expiration

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
        VFS for Git (which is less flexible). Only update that version if we rely upon a
        new command-line interface in Git or if there is a truly broken interaction.
     -->
-    <GitPackageVersion>2.20200323.8</GitPackageVersion>
+    <GitPackageVersion>2.20200402.1</GitPackageVersion>
     <MinimumGitVersion>v2.25.0.vfs.1.1</MinimumGitVersion>
 
     <WatchmanPackageUrl>https://github.com/facebook/watchman/suites/307436006/artifacts/304557</WatchmanPackageUrl>

--- a/Scalar.Common/Git/GitProcess.cs
+++ b/Scalar.Common/Git/GitProcess.cs
@@ -13,6 +13,24 @@ namespace Scalar.Common.Git
 {
     public class GitProcess : ICredentialStore
     {
+        /// <remarks>
+        /// For UnitTest purposes
+        /// </remarks>
+        public static string ExpireTimeDateString
+        {
+            get
+            {
+                if (expireTimeDateString == null)
+                {
+                    expireTimeDateString = DateTime.Now.Subtract(TimeSpan.FromDays(1)).ToShortDateString();
+                }
+
+                return expireTimeDateString;
+            }
+        }
+
+        private static string expireTimeDateString;
+
         private const int HResultEHANDLE = -2147024890; // 0x80070006 E_HANDLE
 
         private static readonly Encoding UTF8NoBOM = new UTF8Encoding(false);
@@ -572,9 +590,10 @@ namespace Scalar.Common.Git
         {
             // Do not expire commit-graph files that have been modified in the last hour.
             // This will prevent deleting any commit-graph files that are currently in the commit-graph-chain.
-            string command = $"commit-graph write --reachable --split --size-multiple=4 --expire-time={1 * 60 * 60} --object-dir \"{objectDir}\"";
+            string command = $"commit-graph write --reachable --split --size-multiple=4 --expire-time={ExpireTimeDateString} --object-dir \"{objectDir}\"";
             return this.InvokeGitInWorkingDirectoryRoot(command, fetchMissingObjects: true);
         }
+
 
         public Result VerifyCommitGraph(string objectDir)
         {

--- a/Scalar.UnitTests/Maintenance/CommitGraphStepTests.cs
+++ b/Scalar.UnitTests/Maintenance/CommitGraphStepTests.cs
@@ -18,7 +18,8 @@ namespace Scalar.UnitTests.Maintenance
         private MockGitProcess gitProcess;
         private ScalarContext context;
 
-        private string CommitGraphWriteCommand => $"commit-graph write --reachable --split --size-multiple=4 --expire-time=3600 --object-dir \"{this.context.Enlistment.GitObjectsRoot}\"";
+        private string CommitGraphWriteCommand => $"commit-graph write --reachable --split --size-multiple=4 --expire-time={GitProcess.ExpireTimeDateString} --object-dir \"{this.context.Enlistment.GitObjectsRoot}\"";
+
         private string CommitGraphVerifyCommand => $"commit-graph verify --shallow --object-dir \"{this.context.Enlistment.GitObjectsRoot}\"";
 
         [TestCase]


### PR DESCRIPTION
Wow, this was really not working as expected.

See microsoft/git#255 for how broken the `--expire-time` argument was.

Fix this by using the fixed argument and passing a datetime instead of an offset by seconds. This will provide a longer window for old commit-graph files, but apparently we've been leaving turd files around for a long time without anyone noticing.