### PR TITLE
[TEST] Use untracked cache unconditionally

### DIFF
--- a/Scalar.Common/FileSystem/IPlatformFileSystem.cs
+++ b/Scalar.Common/FileSystem/IPlatformFileSystem.cs
@@ -5,7 +5,6 @@ namespace Scalar.Common.FileSystem
     public interface IPlatformFileSystem
     {
         bool SupportsFileMode { get; }
-        bool SupportsUntrackedCache { get; }
         void FlushFileBuffers(string path);
         void MoveAndOverwriteFile(string sourceFileName, string destinationFilename);
         bool TryGetNormalizedPath(string path, out string normalizedPath, out string errorMessage);

--- a/Scalar.Common/Maintenance/ConfigStep.cs
+++ b/Scalar.Common/Maintenance/ConfigStep.cs
@@ -105,7 +105,7 @@ namespace Scalar.Common.Maintenance
                 { "core.multiPackIndex", "true" },
                 { "core.preloadIndex", "true" },
                 { "core.safecrlf", "false" },
-                { "core.untrackedCache", ScalarPlatform.Instance.FileSystem.SupportsUntrackedCache ? "true" : "false" },
+                { "core.untrackedCache", "true" },
                 { "core.filemode", ScalarPlatform.Instance.FileSystem.SupportsFileMode ? "true" : "false" },
                 { "core.bare", "false" },
                 { "core.logallrefupdates", "true" },

--- a/Scalar.Common/Platforms/POSIX/POSIXFileSystem.cs
+++ b/Scalar.Common/Platforms/POSIX/POSIXFileSystem.cs
@@ -27,8 +27,6 @@ namespace Scalar.Platform.POSIX
 
         public bool SupportsFileMode { get; } = true;
 
-        public bool SupportsUntrackedCache { get; } = true;
-
         public void FlushFileBuffers(string path)
         {
             // TODO(#1057): Use native API to flush file

--- a/Scalar.Common/Platforms/Windows/WindowsFileSystem.cs
+++ b/Scalar.Common/Platforms/Windows/WindowsFileSystem.cs
@@ -14,8 +14,6 @@ namespace Scalar.Platform.Windows
     {
         public bool SupportsFileMode { get; } = false;
 
-        public bool SupportsUntrackedCache { get; } = false;
-
         /// <summary>
         /// Adds a new FileSystemAccessRule granting read (and optionally modify) access for all users.
         /// </summary>

--- a/Scalar.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
+++ b/Scalar.UnitTests/Mock/FileSystem/MockPlatformFileSystem.cs
@@ -8,8 +8,6 @@ namespace Scalar.UnitTests.Mock.FileSystem
     {
         public bool SupportsFileMode { get; } = true;
 
-        public bool SupportsUntrackedCache { get; } = true;
-
         public void FlushFileBuffers(string path)
         {
             throw new NotSupportedException();


### PR DESCRIPTION
Checking if the v2 fsmonitor makes the untracked cache more reliable on Windows.