### PR TITLE
StatusStep: run status (and update-index) in the background

### DIFF
--- a/Scalar.Common/Git/GitProcess.cs
+++ b/Scalar.Common/Git/GitProcess.cs
@@ -641,6 +641,11 @@ namespace Scalar.Common.Git
             return this.InvokeGitAgainstDotGitFolder("symbolic-ref " + refToUpdate + " " + targetRef);
         }
 
+        public Result UpdateUntrackedCache()
+        {
+            return this.InvokeGitInWorkingDirectoryRoot("update-index --untracked-cache", fetchMissingObjects: true);
+        }
+
         public Result UpdateBranchSha(string refToUpdate, string targetSha)
         {
             // If oldCommitResult doesn't fail, then the branch exists and update-ref will want the old sha

--- a/Scalar.Common/Maintenance/MaintenanceTasks.cs
+++ b/Scalar.Common/Maintenance/MaintenanceTasks.cs
@@ -12,6 +12,7 @@ namespace Scalar.Common.Maintenance
             PackFiles,
             CommitGraph,
             Config,
+            Status,
         }
 
         public static string GetVerbTaskName(Task task)

--- a/Scalar.Common/Maintenance/StatusStep.cs
+++ b/Scalar.Common/Maintenance/StatusStep.cs
@@ -1,0 +1,26 @@
+﻿namespace Scalar.Common.Maintenance
+{
+    public class StatusStep : GitMaintenanceStep
+    {
+        public StatusStep(ScalarContext context)
+            : base(context, false, null)
+        {
+        }
+
+        public override string Area => nameof(StatusStep);
+
+        public override string ProgressMessage => "Running 'git status'";
+
+        protected override void PerformMaintenance()
+        {
+            if (ScalarPlatform.Instance.FileSystem.SupportsUntrackedCache)
+            {
+                this.RunGitCommand(process => process.UpdateUntrackedCache(),
+                                   gitCommand: "update-index");
+            }
+
+            this.RunGitCommand(process => process.Status(allowObjectDownloads: true, useStatusCache: false, showUntracked: true),
+                               gitCommand: "status");
+        }
+    }
+}

--- a/Scalar.Common/ScalarConstants.cs
+++ b/Scalar.Common/ScalarConstants.cs
@@ -204,6 +204,7 @@ namespace Scalar.Common
                 public const string FetchTaskName = "fetch";
                 public const string LooseObjectsTaskName = "loose-objects";
                 public const string PackFilesTaskName = "pack-files";
+                public const string StatusTaskName = "status";
 
                 public const string BatchSizeOptionName = "batch-size";
             }

--- a/Scalar.Service/MaintenanceTaskScheduler.cs
+++ b/Scalar.Service/MaintenanceTaskScheduler.cs
@@ -27,6 +27,9 @@ namespace Scalar.Service
         private readonly TimeSpan configDueTime = TimeSpan.FromSeconds(0);
         private readonly TimeSpan configPeriod = TimeSpan.FromHours(24);
 
+        private readonly TimeSpan statusDueTime = TimeSpan.FromSeconds(5);
+        private readonly TimeSpan statusPeriod = TimeSpan.FromHours(1);
+
         private readonly ITracer tracer;
         private readonly PhysicalFileSystem fileSystem;
         private readonly IScalarVerbRunner scalarVerb;
@@ -110,6 +113,11 @@ namespace Scalar.Service
                     MaintenanceTasks.Task.Config,
                     dueTime: this.configDueTime,
                     period: this.configPeriod,
+                    ignorePause: true),
+                new MaintenanceSchedule(
+                    MaintenanceTasks.Task.Status,
+                    dueTime: this.statusDueTime,
+                    period: this.statusPeriod,
                     ignorePause: true),
             };
 

--- a/Scalar/CommandLine/RunVerb.cs
+++ b/Scalar/CommandLine/RunVerb.cs
@@ -162,6 +162,11 @@ namespace Scalar.CommandLine
                                 steps.Add(new ConfigStep(context));
                                 break;
 
+                            case ScalarConstants.VerbParameters.Maintenance.StatusTaskName:
+                                this.FailIfBatchSizeSet(tracer);
+                                steps.Add(new StatusStep(context));
+                                break;
+
                             default:
                                 this.ReportErrorAndExit($"Unknown maintenance task requested: '{this.MaintenanceTask}'");
                                 break;


### PR DESCRIPTION
By running this occasionally, we will get users out of bad states
where their untracked cache is not updated or their status is a
bit slow. Unlike the status cache in VFS for Git, this does not
trigger in response to file modifications. Instead, it runs every
hour to prevent a user being in a bad state for too long.

Users can also get themselves out of the bad state by running
`scalar run status`.