### PR TITLE
Update Git to include v2.26.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
        VFS for Git (which is less flexible). Only update that version if we rely upon a
        new command-line interface in Git or if there is a truly broken interaction.
     -->
-    <GitPackageVersion>2.20200402.1</GitPackageVersion>
+    <GitPackageVersion>2.20200414.2</GitPackageVersion>
     <MinimumGitVersion>v2.25.0.vfs.1.1</MinimumGitVersion>
 
     <WatchmanPackageUrl>https://github.com/facebook/watchman/suites/307436006/artifacts/304557</WatchmanPackageUrl>


### PR DESCRIPTION
Re-pushed to include the correct version number after pushing the `v2.26.1.vfs.1.1` tag.