### PR TITLE
Reduced fetch.unpackLimit to minimum

### DIFF
--- a/Scalar.Common/Maintenance/ConfigStep.cs
+++ b/Scalar.Common/Maintenance/ConfigStep.cs
@@ -124,6 +124,7 @@ namespace Scalar.Common.Maintenance
                 { "reset.quiet", "true" },
                 { "feature.manyFiles", "false" },
                 { "feature.experimental", "false" },
+                { "fetch.unpackLimit", "1" },
                 { "fetch.writeCommitGraph", "false" },
             };
 


### PR DESCRIPTION
Scalar has already been managing multiple pack files situation with
multi-pack-index. This means that adding packs to the git repo is
relatively low cost.

Reducing `fetch.unpackLimit` to 1 (from default value of 100) assures
that all the fetch will store transferred pack as-is on disk, instead
of spending computation to unpack data into loose objects. This
should make fetching a little bit faster for large fetch that could
be unpacked into many objects (i.e. 99 objects since the default ).
These objects, instead of being unpacked and written onto disk, is then
kept as packfile and get consolidated with incremental repack step using
multi-index-pack.

On a busy repo, this potentially might make incremental repack with
multi-pack-index works a bit harder. But I think this worth the
computation trade-off as this is a cost we pay at the background
maintenance, and it allows fetches to run faster to keep the repo
up-to-date.