### PR TITLE
Update Git to include en/sparse-checkout

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
        VFS for Git (which is less flexible). Only update that version if we rely upon a
        new command-line interface in Git or if there is a truly broken interaction.
     -->
-    <GitPackageVersion>2.20200420.2</GitPackageVersion>
+    <GitPackageVersion>2.20200514.1</GitPackageVersion>
     <MinimumGitVersion>v2.25.0.vfs.1.1</MinimumGitVersion>
 
     <WatchmanPackageUrl>https://github.com/facebook/watchman/suites/307436006/artifacts/304557</WatchmanPackageUrl>

--- a/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/SparseSetTests.cs
+++ b/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/SparseSetTests.cs
@@ -14,7 +14,7 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
     [Category(Categories.GitCommands)]
     public class SparseSetTests : TestsWithEnlistmentPerFixture
     {
-        private const string SetOverwriteMessage = "would be overwritten by sparse checkout update";
+        private const string SetOverwriteMessage = "The following paths were already present and thus not updated despite sparse patterns";
         private const string SetIndexStateMessage = "you need to resolve your current index first";
 
         private const string FolderDotGit = ".git";
@@ -292,28 +292,9 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
             // Attempt to cherry-pick the commit we know will result in a merge conflict
             GitProcess.Invoke(this.Enlistment.RepoRoot, "cherry-pick " + commitId);
 
-            // Should not be able to add which we have a merge conflict
+            // This should succeed!
             this.currentFolderList.Add(FolderTrailingSlashTests);
             string result = this.SparseSet();
-            result.ShouldContain(SetIndexStateMessage);
-
-            // New directory should not be listed because of the error
-            this.VerifyDirectory(this.Enlistment.RepoRoot, new List<string>
-            {
-                FolderDotGit,
-                FolderEnumerateAndReadTestFiles,
-                FolderFileNameEncoding,
-                FolderGitCommandsTests,
-                FolderGVFS,
-                FolderScripts,
-                FolderTest_MoveRenameFileTests,
-                FolderTest_MoveRenameFileTests2
-             });
-
-            // Fix the error, switch to the new branch, and switch back and we should have all directories
-            GitProcess.Invoke(this.Enlistment.RepoRoot, "cherry-pick --abort");
-
-            result = this.SparseSet();
             result.ShouldNotContain(true, SetIndexStateMessage);
 
             GitProcess.Invoke(this.Enlistment.RepoRoot, "checkout branch_with_conflict");

--- a/Scalar.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
+++ b/Scalar.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
@@ -143,6 +143,8 @@ namespace Scalar.FunctionalTests.Tests.GitCommands
                     sb.Append("\n");
                 }
 
+                GitProcess.InvokeProcess(this.ControlGitRepo.RootPath, "sparse-checkout init --cone", string.Empty);
+                GitProcess.InvokeProcess(this.ControlGitRepo.RootPath, "sparse-checkout set --stdin", sb.ToString());
                 GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "sparse-checkout set --stdin", sb.ToString());
                 this.pathPrefixes = SparseModeFolders;
             }

--- a/Scalar/CommandLine/CloneVerb.cs
+++ b/Scalar/CommandLine/CloneVerb.cs
@@ -329,11 +329,7 @@ namespace Scalar.CommandLine
 
             if (!this.FullClone)
             {
-                git.SetInLocalConfig($"core.sparseCheckout", "true");
-                git.SetInLocalConfig($"core.sparseCheckoutCone", "true");
-
-                this.fileSystem.CreateDirectory(Path.Combine(this.enlistment.DotGitRoot, "info"));
-                this.fileSystem.WriteAllText(Path.Combine(this.enlistment.DotGitRoot, "info", "sparse-checkout"), "/*\n!/*/");
+                GitProcess.SparseCheckoutInit(this.enlistment);
             }
 
             this.context = new ScalarContext(this.tracer, this.fileSystem, this.enlistment);

--- a/Scalar/CommandLine/CloneVerb.cs
+++ b/Scalar/CommandLine/CloneVerb.cs
@@ -333,7 +333,7 @@ namespace Scalar.CommandLine
                 git.SetInLocalConfig($"core.sparseCheckoutCone", "true");
 
                 this.fileSystem.CreateDirectory(Path.Combine(this.enlistment.DotGitRoot, "info"));
-                this.fileSystem.WriteAllText(Path.Combine(this.enlistment.DotGitRoot, "info", "sparse-checkout"), "/*\n!/*/*");
+                this.fileSystem.WriteAllText(Path.Combine(this.enlistment.DotGitRoot, "info", "sparse-checkout"), "/*\n!/*/");
             }
 
             this.context = new ScalarContext(this.tracer, this.fileSystem, this.enlistment);


### PR DESCRIPTION
Also fixes a bug when running `scalar clone` followed by `git sparse-checkout disable`.

See microsoft/git#267.