### PR TITLE
PackfileMaintenanceStep: Use second-largest pack-size for batch size

### DIFF
--- a/Scalar.Common/Maintenance/GitMaintenanceStep.cs
+++ b/Scalar.Common/Maintenance/GitMaintenanceStep.cs
@@ -142,11 +142,12 @@ namespace Scalar.Common.Maintenance
         }
 
         // public only for unit tests
-        public void GetPackFilesInfo(out int count, out long size, out long maxSize, out bool hasKeep)
+        public void GetPackFilesInfo(out int count, out long size, out long secondLargestSize, out bool hasKeep)
         {
             count = 0;
             size = 0;
-            maxSize = 0;
+            long maxSize = 0;
+            secondLargestSize = 0;
             hasKeep = false;
 
             foreach (DirectoryItemInfo info in this.Context.FileSystem.ItemsInDirectory(this.Context.Enlistment.GitPackRoot))
@@ -160,6 +161,7 @@ namespace Scalar.Common.Maintenance
 
                     if (info.Length > maxSize)
                     {
+                        secondLargestSize = maxSize;
                         maxSize = info.Length;
                     }
                 }

--- a/Scalar.Common/Maintenance/LooseObjectsStep.cs
+++ b/Scalar.Common/Maintenance/LooseObjectsStep.cs
@@ -189,13 +189,13 @@ namespace Scalar.Common.Maintenance
                     }
 
                     this.CountLooseObjects(out int beforeLooseObjectsCount, out long beforeLooseObjectsSize);
-                    this.GetPackFilesInfo(out int beforePackCount, out long beforePackSize, out long beforeMaxSize, out bool _);
+                    this.GetPackFilesInfo(out int beforePackCount, out long beforePackSize, out long beforeSize2, out bool _);
 
                     GitProcess.Result gitResult = this.RunGitCommand((process) => process.PrunePacked(this.Context.Enlistment.GitObjectsRoot), nameof(GitProcess.PrunePacked));
                     CreatePackResult createPackResult = this.TryCreateLooseObjectsPackFile(out int objectsAddedToPack);
 
                     this.CountLooseObjects(out int afterLooseObjectsCount, out long afterLooseObjectsSize);
-                    this.GetPackFilesInfo(out int afterPackCount, out long afterPackSize, out long afterMaxSize, out bool _);
+                    this.GetPackFilesInfo(out int afterPackCount, out long afterPackSize, out long afterSize2, out bool _);
 
                     EventMetadata metadata = new EventMetadata();
                     metadata.Add("GitObjectsRoot", this.Context.Enlistment.GitObjectsRoot);
@@ -210,8 +210,8 @@ namespace Scalar.Common.Maintenance
                     metadata.Add("EndingSize", afterLooseObjectsSize);
                     metadata.Add("StartingPackSize", beforePackSize);
                     metadata.Add("EndingPackSize", afterPackSize);
-                    metadata.Add("StartingMaxSize", beforeMaxSize);
-                    metadata.Add("EndingMaxSize", afterMaxSize);
+                    metadata.Add("StartingSize2", beforeSize2);
+                    metadata.Add("EndingSize2", afterSize2);
 
                     metadata.Add("RemovedCount", beforeLooseObjectsCount - afterLooseObjectsCount);
                     metadata.Add("LooseObjectsPutIntoPackFile", objectsAddedToPack);

--- a/Scalar.UnitTests/Maintenance/PackfileMaintenanceStepTests.cs
+++ b/Scalar.UnitTests/Maintenance/PackfileMaintenanceStepTests.cs
@@ -26,7 +26,7 @@ namespace Scalar.UnitTests.Maintenance
         private string ExpireCommand => $"multi-pack-index expire --object-dir=\"{this.context.Enlistment.GitObjectsRoot}\"";
         private string VerifyCommand => $"-c core.multiPackIndex=true multi-pack-index verify --object-dir=\"{this.context.Enlistment.GitObjectsRoot}\"";
         private string WriteCommand => $"-c core.multiPackIndex=true multi-pack-index write --object-dir=\"{this.context.Enlistment.GitObjectsRoot}\"";
-        private string RepackCommand => $"-c pack.threads=1 -c repack.packKeptObjects=true multi-pack-index repack --object-dir=\"{this.context.Enlistment.GitObjectsRoot}\" --batch-size=5";
+        private string RepackCommand => $"-c pack.threads=1 -c repack.packKeptObjects=true multi-pack-index repack --object-dir=\"{this.context.Enlistment.GitObjectsRoot}\" --batch-size=3";
 
         [TestCase]
         public void PackfileMaintenanceIgnoreTimeRestriction()
@@ -149,18 +149,18 @@ namespace Scalar.UnitTests.Maintenance
 
             PackfileMaintenanceStep step = new PackfileMaintenanceStep(this.context, requireObjectCacheLock: false, forceRun: true);
 
-            step.GetPackFilesInfo(out int count, out long size, out long maxSize, out bool hasKeep);
+            step.GetPackFilesInfo(out int count, out long size, out long secondSmallestSize, out bool hasKeep);
             count.ShouldEqual(3);
             size.ShouldEqual(11);
-            maxSize.ShouldEqual(5);
+            secondSmallestSize.ShouldEqual(3);
             hasKeep.ShouldEqual(true);
 
             this.context.FileSystem.DeleteFile(Path.Combine(this.context.Enlistment.GitPackRoot, KeepName));
 
-            step.GetPackFilesInfo(out count, out size, out maxSize, out hasKeep);
+            step.GetPackFilesInfo(out count, out size, out secondSmallestSize, out hasKeep);
             count.ShouldEqual(3);
             size.ShouldEqual(11);
-            maxSize.ShouldEqual(5);
+            secondSmallestSize.ShouldEqual(3);
             hasKeep.ShouldEqual(false);
         }
 


### PR DESCRIPTION
When the total size of all pack-files is larger than 2 gigabytes, then
we currently use a strange mechanism for trying to repack everything
else into a single pack.

The "estimated output size" that we use for predicting the batch size
will under-count pack sizes when there are duplicates. This means that
the current model will actually no-op most of the time! By picking the
second-largest file size, the `repack` command will have a high
likelihood of doing _something_, and that size will grow geometrically
as we go. This strategy was recommended by @sluongng and it seems
to work better.

This only affects "small" repos. We will use 2 gigabytes as the
default batch-size for large repos.