### PR TITLE
Update Git to v2.27.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
        VFS for Git (which is less flexible). Only update that version if we rely upon a
        new command-line interface in Git or if there is a truly broken interaction.
     -->
-    <GitPackageVersion>2.20200514.1</GitPackageVersion>
+    <GitPackageVersion>2.20200601.2</GitPackageVersion>
     <MinimumGitVersion>v2.25.0.vfs.1.1</MinimumGitVersion>
 
     <WatchmanPackageUrl>https://github.com/facebook/watchman/suites/307436006/artifacts/304557</WatchmanPackageUrl>

--- a/Scalar.Common/Git/GitProcess.cs
+++ b/Scalar.Common/Git/GitProcess.cs
@@ -670,7 +670,7 @@ namespace Scalar.Common.Git
 
         public Result MultiPackIndexRepack(string gitObjectDirectory, string batchSize)
         {
-            return this.InvokeGitAgainstDotGitFolder($"-c pack.threads=1 multi-pack-index repack --object-dir=\"{gitObjectDirectory}\" --batch-size={batchSize}");
+            return this.InvokeGitAgainstDotGitFolder($"-c pack.threads=1 -c repack.packKeptObjects=true multi-pack-index repack --object-dir=\"{gitObjectDirectory}\" --batch-size={batchSize}");
         }
 
         public Process GetGitProcess(

--- a/Scalar.Common/Maintenance/ConfigStep.cs
+++ b/Scalar.Common/Maintenance/ConfigStep.cs
@@ -116,6 +116,7 @@ namespace Scalar.Common.Maintenance
                 { "gui.gcwarning", "false" },
                 { "index.threads", "true" },
                 { "index.version", "4" },
+                { "log.excludeDecoration", "refs/scalar/*" },
                 { "merge.stat", "false" },
                 { "merge.renames", "false" },
                 { "pack.useBitmaps", "false" },

--- a/Scalar.UnitTests/Maintenance/PackfileMaintenanceStepTests.cs
+++ b/Scalar.UnitTests/Maintenance/PackfileMaintenanceStepTests.cs
@@ -26,7 +26,7 @@ namespace Scalar.UnitTests.Maintenance
         private string ExpireCommand => $"multi-pack-index expire --object-dir=\"{this.context.Enlistment.GitObjectsRoot}\"";
         private string VerifyCommand => $"-c core.multiPackIndex=true multi-pack-index verify --object-dir=\"{this.context.Enlistment.GitObjectsRoot}\"";
         private string WriteCommand => $"-c core.multiPackIndex=true multi-pack-index write --object-dir=\"{this.context.Enlistment.GitObjectsRoot}\"";
-        private string RepackCommand => $"-c pack.threads=1 multi-pack-index repack --object-dir=\"{this.context.Enlistment.GitObjectsRoot}\" --batch-size=5";
+        private string RepackCommand => $"-c pack.threads=1 -c repack.packKeptObjects=true multi-pack-index repack --object-dir=\"{this.context.Enlistment.GitObjectsRoot}\" --batch-size=5";
 
         [TestCase]
         public void PackfileMaintenanceIgnoreTimeRestriction()


### PR DESCRIPTION
See microsoft/git#271.

Updates necessary here:

* The `multi-pack-index` builtin started honoring `repack.packKeptObjects`, which is `false` by default. We want to repack the `.keep` pack because that is just the most-recent prefetch pack-file. We don't expire it, but we want to repack it.

* Upstream now has the `log.excludeDecoration` config option. This allows us to hide the `refs/scalar/hidden/*` refs from the history views, de-cluttering the history for our Scalar enlistments.