### PR TITLE
ConfigStep: disable status.submoduleSummary when using GVFS protocol

### DIFF
--- a/Scalar.Common/Maintenance/ConfigStep.cs
+++ b/Scalar.Common/Maintenance/ConfigStep.cs
@@ -158,6 +158,15 @@ namespace Scalar.Common.Maintenance
                 { "status.aheadbehind", "false" },
             };
 
+            if (this.UseGvfsProtocol.Value)
+            {
+                // If a user's global config has "status.submoduleSummary=true", then
+                // that could slow "git status" significantly here, even though the
+                // GVFS protocol forbids submodules. Still, disable it optionally in
+                // case the user really wants it in their local config.
+                optionalSettings.Add("status.submoduleSummary", "false");
+            }
+
             if (!this.TrySetConfig(optionalSettings, isRequired: false, out error))
             {
                 error = $"Failed to set some optional settings: {error}";


### PR DESCRIPTION
A VFS for Git user noticed extremely slow "git status" times, and the
root cause was that they had set status.submoduleSummary=true in their
global config. This causes two "git submodule" subprocesses, which are
very slow. The GVFS protocol does not allow submodules, so disable the
setting when using that protocol.

I investigating fixing this in Git proper, but there is no efficient
way to detect that we can ignore this setting since there could be
an untracked submodule.