### PR TITLE
ScalarVerb: remove ValidateScalarVersion()

### DIFF
--- a/Scalar/CommandLine/CloneVerb.cs
+++ b/Scalar/CommandLine/CloneVerb.cs
@@ -236,8 +236,6 @@ namespace Scalar.CommandLine
 
             this.cacheServer = this.ResolveCacheServer(this.tracer, this.cacheServer, this.cacheServerResolver, this.serverScalarConfig);
 
-            this.ValidateClientVersions(this.tracer, this.enlistment, this.serverScalarConfig, showWarnings: true);
-
             using (this.objectRequestor = new GitObjectsHttpRequestor(this.tracer, this.enlistment, this.cacheServer, this.retryConfig))
             {
                 cloneResult = this.CreateScalarDirctories(resolvedLocalCacheRoot);

--- a/Scalar/CommandLine/RunVerb.cs
+++ b/Scalar/CommandLine/RunVerb.cs
@@ -247,8 +247,6 @@ namespace Scalar.CommandLine
                     cacheServer = cacheServerResolver.ResolveNameFromRemote(cacheServerUrl, serverScalarConfig);
                 }
 
-                this.ValidateClientVersions(tracer, enlistment, serverScalarConfig, showWarnings: false);
-
                 this.Output.WriteLine("Configured cache server: " + cacheServer);
             }
 


### PR DESCRIPTION
VFS for Git checks `gvfs/config` to see if the client version string matches the remote's configured minimum version. This part of the `gvfs/config` endpoint does not speak Scalar version numbers. Also, we don't need to force users to upgrade as much as we did in that scenario.

This also causes a warning during `scalar clone`:

> WARNING: Unable to validate your Scalar version
> Server not configured to provide supported Scalar versions

Delete this check, removing this noisy warning.