### PR TITLE
Change default branch to `main`

### DIFF
--- a/.azure-pipelines/pull-request.yml
+++ b/.azure-pipelines/pull-request.yml
@@ -1,9 +1,9 @@
 trigger:
-  - master
+  - main
   - releases/*
 
 pr:
-  - master
+  - main
   - milestones/*
   - releases/*
   - servicing/*

--- a/AuthoringTests.md
+++ b/AuthoringTests.md
@@ -112,7 +112,7 @@ as the base class, because NUnit treats namespaces like test suites, and we have
 
 ## Updating the Remote Test Branch
 
-By default, the functional tests clone `master`, check out the branch "FunctionalTests/YYYYMMDD" (with the day the FunctionalTests branch was created), 
+By default, the functional tests clone `main`, check out the branch "FunctionalTests/YYYYMMDD" (with the day the FunctionalTests branch was created), 
 and then remove all remote tracking information. This is done to guarantee that remote changes to tip cannot break functional tests. If you need to update 
 the functional tests to use a new FunctionalTests branch, you'll need to create a new "FunctionalTests/YYYYMMDD" branch and update the `Commitish` setting in `Settings.cs` to have this new branch name.  
 Once you have verified your scenarios locally you can push the new FunctionalTests branch and then your changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,7 +284,7 @@ The design review process is as follows:
 
 - *Add new unit and functional tests when making changes*
 
-  Comprehensive tests are essential for maintaining the health and quality of the product.  For more details on writing tests see [Authoring Tests](https://github.com/Microsoft/Scalar/blob/master/AuthoringTests.md).
+  Comprehensive tests are essential for maintaining the health and quality of the product.  For more details on writing tests see [Authoring Tests](https://github.com/Microsoft/Scalar/blob/main/AuthoringTests.md).
 
 - *Functional tests are black-box tests and should not build against any Scalar product code*
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # Scalar
 
-[![Build Status](https://dev.azure.com/mseng/Scalar/_apis/build/status/microsoft.scalar?branchName=master)](https://dev.azure.com/mseng/Scalar/_build/latest?definitionId=9297&branchName=master)
+[![Build Status](https://dev.azure.com/mseng/Scalar/_apis/build/status/microsoft.scalar?branchName=main)](https://dev.azure.com/mseng/Scalar/_build/latest?definitionId=9297&branchName=main)
 
 ## What is Scalar?
 
@@ -10,7 +10,7 @@ Run `scalar register` in an existing Git repo to enable recommended config
 settings and start background maintenance.
 
 If your repo is hosted on a service that supports the
-[GVFS Protocol](https://github.com/microsoft/VFSForGit/blob/master/Protocol.md),
+[GVFS Protocol](https://github.com/microsoft/VFSForGit/blob/main/Protocol.md),
 such as Azure Repos, then `scalar clone <url>` will create a local enlistment with
 abilities like on-demand object retrieval, background maintenance tasks, and
 automatically sets Git config values and hooks that enable performance enhancements.

--- a/Scalar.Common/Git/GitRefs.cs
+++ b/Scalar.Common/Git/GitRefs.cs
@@ -65,7 +65,7 @@ namespace Scalar.Common.Git
 
             if (headRefMatches.Count() == 0 || headRefMatches.Count(reference => reference.Key == (OriginRemoteRefPrefix + Master)) > 0)
             {
-                // Default to master if no HEAD or if the commit ID or the dafult branch matches master (this is
+                // Default to master if no HEAD or if the commit ID or the default branch matches master (this is
                 //  the same behavior as git.exe)
                 return Master;
             }

--- a/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/SparseSetTests.cs
+++ b/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/SparseSetTests.cs
@@ -277,7 +277,7 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
             GitProcess.Invoke(this.Enlistment.RepoRoot, "checkout " + this.Enlistment.Commitish);
             this.fileSystem.WriteAllText(fileToConflict, "DEF");
             GitProcess.Invoke(this.Enlistment.RepoRoot, "add " + conflictFilename);
-            GitProcess.Invoke(this.Enlistment.RepoRoot, "commit -m \"conflict on master\"");
+            GitProcess.Invoke(this.Enlistment.RepoRoot, "commit -m \"conflict on main\"");
 
             // Attempt to cherry-pick the commit we know will result in a merge conflict
             GitProcess.Invoke(this.Enlistment.RepoRoot, "cherry-pick " + commitId);

--- a/Scalar.FunctionalTests/Tests/GitRepoPerFixture/RunVerbTests.cs
+++ b/Scalar.FunctionalTests/Tests/GitRepoPerFixture/RunVerbTests.cs
@@ -128,7 +128,7 @@ namespace Scalar.FunctionalTests.Tests.GitRepoPerFixture
             this.fileSystem.DirectoryExists(refsHeads).ShouldBeFalse("background fetch should not have created refs/heads/*");
             this.fileSystem.DirectoryExists(refsRemotesOrigin).ShouldBeFalse("background fetch should not have created refs/remotes/origin/*");
 
-            // This is the SHA-1 for the master branch
+            // This is the SHA-1 for the main branch
             string sha1 = Settings.Default.CommitId;
             this.fileSystem.WriteAllText(refsHiddenOriginFake, sha1);
 

--- a/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/ScalarCloneFromGithub.cs
+++ b/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/ScalarCloneFromGithub.cs
@@ -26,7 +26,7 @@ namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
         {
             ScalarFunctionalTestEnlistment enlistment = this.CreateNewEnlistment(
                                                                 url: MicrosoftScalarHttp,
-                                                                branch: "master",
+                                                                branch: "main",
                                                                 fullClone: false);
 
             VerifyPartialCloneBehavior(enlistment);

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,7 +18,7 @@ Creating a new Scalar clone using the GVFS Protocol
 ---------------------------------------------------
 
 The `clone` verb creates a local enlistment of a remote repository using the
-[GVFS protocol](https://github.com/microsoft//VFSForGit/blob/master/Protocol.md).
+[GVFS protocol](https://github.com/microsoft//VFSForGit/blob/main/Protocol.md).
 
 ```
 scalar clone [options] <url> [<dir>]

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ these features for that repo and start running suggested maintenance in the
 background.
 
 Repos cloned with the `scalar clone` command use the
-[GVFS protocol](https://github.com/microsoft//VFSForGit/blob/master/Protocol.md)
+[GVFS protocol](https://github.com/microsoft//VFSForGit/blob/main/Protocol.md)
 to significantly reduce the amount of data required to get started
 using a repository. By delaying all blob downloads until they are required,
 Scalar allows you to work with very large repositories quickly. This protocol


### PR DESCRIPTION
I updated the default branch to `main`, so this is the work required to get builds and things going against that branch.

There is more work to be done to update the default branch for repos _cloned_ by Scalar, but that will be a behavior change that we should handle after Git has a clear way forward.