### PR TITLE
[WIP] Integrate with internal FSMonitor

### DIFF
--- a/.azure-pipelines/pull-request.yml
+++ b/.azure-pipelines/pull-request.yml
@@ -48,23 +48,6 @@ jobs:
     steps:
       - checkout: none
       - template: templates/win/functional-test.yml
-        parameters:
-          useWatchman: false
-
-  - job: win_functionaltest_watchman
-    displayName: Windows Functional Test (with Watchman)
-    timeoutInMinutes: 45
-    variables:
-      configuration: Release
-    pool:
-      vmImage: windows-2019
-    dependsOn: win_build
-    condition: succeeded()
-    steps:
-    - checkout: none
-    - template: templates/win/functional-test.yml
-      parameters:
-        useWatchman: true
 
   - job: osx_functionaltest
     displayName: macOS Functional Test
@@ -76,23 +59,6 @@ jobs:
     steps:
       - checkout: none
       - template: templates/osx/functional-test.yml
-        parameters:
-          useWatchman: false
-
-  - job: osx_functionaltest_watchman
-    displayName: macOS Functional Test (with Watchman)
-    variables:
-      configuration: Release
-    timeoutInMinutes: 30
-    pool:
-      name: 'Hosted macOS'
-    dependsOn: osx_build
-    condition: succeeded()
-    steps:
-      - checkout: none
-      - template: templates/osx/functional-test.yml
-        parameters:
-          useWatchman: true
 
   - job: win_stresstest
     displayName: Windows Stress Tests

--- a/.azure-pipelines/pull-request.yml
+++ b/.azure-pipelines/pull-request.yml
@@ -93,3 +93,29 @@ jobs:
       - template: templates/osx/functional-test.yml
         parameters:
           useWatchman: true
+
+  - job: win_stresstest
+    displayName: Windows Stress Tests
+    timeoutInMinutes: 45
+    variables:
+      configuration: Release
+    pool:
+      vmImage: windows-2019
+    dependsOn: win_build
+    condition: succeeded()
+    steps:
+      - checkout: none
+      - template: templates/win/stress-test.yml
+
+  - job: osx_stresstest
+    displayName: macOS Stress Tests
+    timeoutInMinutes: 45
+    variables:
+      configuration: Release
+    pool:
+      name: 'Hosted macOS'
+    dependsOn: osx_build
+    condition: succeeded()
+    steps:
+      - checkout: none
+      - template: templates/osx/stress-test.yml

--- a/.azure-pipelines/release.yml
+++ b/.azure-pipelines/release.yml
@@ -84,23 +84,6 @@ jobs:
     steps:
       - checkout: none
       - template: templates/win/functional-test.yml
-        parameters:
-          useWatchman: false
-
-  - job: win_functionaltest_watchman
-    displayName: Windows Functional Test (with Watchman)
-    timeoutInMinutes: 45
-    variables:
-      configuration: Release
-    pool:
-      vmImage: $(winImage)
-    dependsOn: win_build
-    condition: succeeded()
-    steps:
-      - checkout: none
-      - template: templates/win/functional-test.yml
-        parameters:
-          useWatchman: true
 
   - job: osx_functionaltest
     displayName: macOS Functional Test
@@ -112,20 +95,3 @@ jobs:
     steps:
       - checkout: none
       - template: templates/osx/functional-test.yml
-        parameters:
-          useWatchman: false
-
-  - job: osx_functionaltest_watchman
-    displayName: macOS Functional Test (with Watchman)
-    variables:
-      configuration: Release
-    timeoutInMinutes: 30
-    pool:
-      vmImage: $(osxImage)
-    dependsOn: osx_build_step5
-    condition: succeeded()
-    steps:
-      - checkout: none
-      - template: templates/osx/functional-test.yml
-        parameters:
-          useWatchman: true

--- a/.azure-pipelines/templates/osx/functional-test.yml
+++ b/.azure-pipelines/templates/osx/functional-test.yml
@@ -1,6 +1,3 @@
-parameters:
-  useWatchman: true
-
 steps:
   - bash: mkdir -p $(Build.ArtifactStagingDirectory)/logs
     displayName: Create logs directory
@@ -28,63 +25,28 @@ steps:
       chmod +x $(Build.BinariesDirectory)/install/*.sh
     displayName: Ensure all scripts are executable
 
-  - ${{ if eq(parameters.useWatchman, 'true') }}:
-    - bash: $(Build.BinariesDirectory)/install/InstallScalar.sh
-      displayName: Install product (with watchman)
-
-  - ${{ if ne(parameters.useWatchman, 'true') }}:
-    - bash: $(Build.BinariesDirectory)/install/InstallScalar.sh --no-watchman
-      displayName: Install product (without watchman)
-
-  - ${{ if eq(parameters.useWatchman, 'true') }}:
-    - bash: watchman log-level debug
-      displayName: Set watchman log level to debug
+  - bash: $(Build.BinariesDirectory)/install/InstallScalar.sh
+    displayName: Install product
 
   - bash: $(Build.BinariesDirectory)/ft/src/Scripts/Mac/RunFunctionalTests.sh $(configuration) --test-scalar-on-path --trace2-output=$(Build.ArtifactStagingDirectory)/logs/trace2-event.log
     displayName: Run functional tests
 
-  - ${{ if eq(parameters.useWatchman, 'true') }}:
-    - task: PublishTestResults@2
-      displayName: Publish functional tests results
-      inputs:
-        testRunner: NUnit
-        testResultsFiles: "**\\TestResult*.xml"
-        searchFolder: $(System.DefaultWorkingDirectory)
-        testRunTitle: macOS $(configuration) Functional Tests (with watchman)
-        publishRunAttachments: true
-      condition: succeededOrFailed()
+  - task: PublishTestResults@2
+    displayName: Publish functional tests results
+    inputs:
+      testRunner: NUnit
+      testResultsFiles: "**\\TestResult*.xml"
+      searchFolder: $(System.DefaultWorkingDirectory)
+      testRunTitle: macOS $(configuration) Functional Tests
+      publishRunAttachments: true
+    condition: succeededOrFailed()
 
-  - ${{ if ne(parameters.useWatchman, 'true') }}:
-    - task: PublishTestResults@2
-      displayName: Publish functional tests results
-      inputs:
-        testRunner: NUnit
-        testResultsFiles: "**\\TestResult*.xml"
-        searchFolder: $(System.DefaultWorkingDirectory)
-        testRunTitle: macOS $(configuration) Functional Tests (without watchman)
-        publishRunAttachments: true
-      condition: succeededOrFailed()
-
-  - ${{ if eq(parameters.useWatchman, 'true') }}:
-    - bash: cp -pf '/usr/local/var/run/watchman/runner-state/log' '$(Build.ArtifactStagingDirectory)/logs/watchman-log'
-      displayName: Copy watchman logs
-      condition: failed()
-
-  - ${{ if eq(parameters.useWatchman, 'true') }}:
-    - task: PublishPipelineArtifact@1
-      displayName: Publish test and installation logs
-      inputs:
-        targetPath: $(Build.ArtifactStagingDirectory)/logs
-        artifactName: Logs_macOS_Watchman
-      condition: failed()
-
-  - ${{ if ne(parameters.useWatchman, 'true') }}:
-    - task: PublishPipelineArtifact@1
-      displayName: Publish test and installation logs
-      inputs:
-        targetPath: $(Build.ArtifactStagingDirectory)/logs
-        artifactName: Logs_macOS
-      condition: failed()
+  - task: PublishPipelineArtifact@1
+    displayName: Publish test and installation logs
+    inputs:
+      targetPath: $(Build.ArtifactStagingDirectory)/logs
+      artifactName: Logs_macOS
+    condition: failed()
 
   - bash: $(Build.BinariesDirectory)/ft/src/Scripts/Mac/CleanupFunctionalTests.sh
     displayName: Cleanup

--- a/.azure-pipelines/templates/osx/stress-test.yml
+++ b/.azure-pipelines/templates/osx/stress-test.yml
@@ -1,0 +1,57 @@
+steps:
+  - bash: mkdir -p $(Build.ArtifactStagingDirectory)/logs
+    displayName: Create logs directory
+
+  - task: UseDotNet@2
+    displayName: Use .NET Core SDK 3.1.101
+    inputs:
+      packageType: sdk
+      version: 3.1.101
+
+  - task: DownloadPipelineArtifact@2
+    displayName: Download functional tests drop
+    inputs:
+      artifact: FunctionalTests_macOS_$(configuration)
+      path: $(Build.BinariesDirectory)/ft
+
+  - task: DownloadPipelineArtifact@2
+    displayName: Download installers drop
+    inputs:
+      artifact: Installers_macOS_$(configuration)
+      path: $(Build.BinariesDirectory)/install
+
+  - bash: |
+      chmod +x $(Build.BinariesDirectory)/ft/src/Scripts/Mac/*.sh
+      chmod +x $(Build.BinariesDirectory)/install/*.sh
+    displayName: Ensure all scripts are executable
+
+  - bash: $(Build.BinariesDirectory)/install/InstallScalar.sh
+    displayName: Install product
+
+  - bash: $(Build.BinariesDirectory)/ft/src/Scripts/Mac/RunFunctionalTests.sh $(configuration) --test-scalar-on-path --stress --trace2-output=$(Build.ArtifactStagingDirectory)/logs/trace2-event.log
+    displayName: Run stress tests
+
+  - task: PublishTestResults@2
+    displayName: Publish stress tests results
+    inputs:
+      testRunner: NUnit
+      testResultsFiles: "**\\TestResult*.xml"
+      searchFolder: $(System.DefaultWorkingDirectory)
+      testRunTitle: macOS $(configuration) Stress Tests
+      publishRunAttachments: true
+    condition: succeededOrFailed()
+
+  - task: PublishPipelineArtifact@1
+    displayName: Publish test and installation logs
+    inputs:
+      targetPath: $(Build.ArtifactStagingDirectory)/logs
+      artifactName: Logs_macOS_Stress
+    condition: failed()
+
+  - bash: $(Build.BinariesDirectory)/ft/src/Scripts/Mac/CleanupFunctionalTests.sh
+    displayName: Cleanup
+    condition: always()
+
+  - bash: sudo rm -rf $(Build.BinariesDirectory)/ft
+    displayName: Cleanup phase 2
+    condition: always()

--- a/.azure-pipelines/templates/win/functional-test.yml
+++ b/.azure-pipelines/templates/win/functional-test.yml
@@ -1,6 +1,3 @@
-parameters:
-  useWatchman: true
-
 steps:
 
   - task: UseDotNet@2
@@ -21,13 +18,8 @@ steps:
       artifact: Installers_Windows_$(configuration)
       path: $(Build.BinariesDirectory)\install
 
-  - ${{ if eq(parameters.useWatchman, 'true') }}:
-    - script: $(Build.BinariesDirectory)\install\InstallScalar.bat --watchman $(Build.ArtifactStagingDirectory)\logs
-      displayName: Install product (with watchman)
-
-  - ${{ if ne(parameters.useWatchman, 'true') }}:
-    - script: $(Build.BinariesDirectory)\install\InstallScalar.bat --no-watchman $(Build.ArtifactStagingDirectory)\logs
-      displayName: Install product (without watchman)
+  - script: $(Build.BinariesDirectory)\install\InstallScalar.bat $(Build.ArtifactStagingDirectory)\logs
+    displayName: Install product
 
   - script: git config --global credential.interactive never
     displayName: Disable interactive auth
@@ -35,40 +27,19 @@ steps:
   - script: $(Build.BinariesDirectory)\ft\src\Scripts\RunFunctionalTests.bat $(configuration) --test-scalar-on-path "--trace2-output=$(Build.ArtifactStagingDirectory)\logs\trace2-event.log"
     displayName: Run functional tests
 
-  - ${{ if eq(parameters.useWatchman, 'true') }}:
-    - task: PublishTestResults@2
-      displayName: Publish functional tests results
-      inputs:
-        testRunner: NUnit
-        testResultsFiles: "**\\TestResult*.xml"
-        searchFolder: $(System.DefaultWorkingDirectory)
-        testRunTitle: Windows $(configuration) Functional Tests (with watchman)
-        publishRunAttachments: true
-      condition: succeededOrFailed()
+  - task: PublishTestResults@2
+    displayName: Publish functional tests results
+    inputs:
+      testRunner: NUnit
+      testResultsFiles: "**\\TestResult*.xml"
+      searchFolder: $(System.DefaultWorkingDirectory)
+      testRunTitle: Windows $(configuration) Functional Tests
+      publishRunAttachments: true
+    condition: succeededOrFailed()
 
-  - ${{ if eq(parameters.useWatchman, 'true') }}:
-    - task: PublishPipelineArtifact@1
-      displayName: Publish test and installation logs
-      inputs:
-        targetPath: $(Build.ArtifactStagingDirectory)\logs
-        artifactName: Logs_Windows_Watchman
-      condition: failed()
-
-  - ${{ if ne(parameters.useWatchman, 'true') }}:
-    - task: PublishTestResults@2
-      displayName: Publish functional tests results
-      inputs:
-        testRunner: NUnit
-        testResultsFiles: "**\\TestResult*.xml"
-        searchFolder: $(System.DefaultWorkingDirectory)
-        testRunTitle: Windows $(configuration) Functional Tests (without watchman)
-        publishRunAttachments: true
-      condition: succeededOrFailed()
-
-  - ${{ if ne(parameters.useWatchman, 'true') }}:
-    - task: PublishPipelineArtifact@1
-      displayName: Publish test and installation logs
-      inputs:
-        targetPath: $(Build.ArtifactStagingDirectory)\logs
-        artifactName: Logs_Windows
-      condition: failed()
+  - task: PublishPipelineArtifact@1
+    displayName: Publish test and installation logs
+    inputs:
+      targetPath: $(Build.ArtifactStagingDirectory)\logs
+      artifactName: Logs_Windows
+    condition: failed()

--- a/.azure-pipelines/templates/win/stress-test.yml
+++ b/.azure-pipelines/templates/win/stress-test.yml
@@ -1,0 +1,45 @@
+steps:
+
+  - task: UseDotNet@2
+    displayName: Use .NET Core SDK 3.1.101
+    inputs:
+      packageType: sdk
+      version: 3.1.101
+
+  - task: DownloadPipelineArtifact@2
+    displayName: Download functional tests drop
+    inputs:
+      artifact: FunctionalTests_Windows_$(configuration)
+      Path: $(Build.BinariesDirectory)\ft
+
+  - task: DownloadPipelineArtifact@2
+    displayName: Download installers drop
+    inputs:
+      artifact: Installers_Windows_$(configuration)
+      path: $(Build.BinariesDirectory)\install
+
+  - script: $(Build.BinariesDirectory)\install\InstallScalar.bat $(Build.ArtifactStagingDirectory)\logs
+    displayName: Install product
+
+  - script: git config --global credential.interactive never
+    displayName: Disable interactive auth
+
+  - script: $(Build.BinariesDirectory)\ft\src\Scripts\RunFunctionalTests.bat $(configuration) --test-scalar-on-path --stress "--trace2-output=$(Build.ArtifactStagingDirectory)\logs\trace2-event.log"
+    displayName: Run stress tests
+
+  - task: PublishTestResults@2
+    displayName: Publish stress tests results
+    inputs:
+      testRunner: NUnit
+      testResultsFiles: "**\\TestResult*.xml"
+      searchFolder: $(System.DefaultWorkingDirectory)
+      testRunTitle: Windows $(configuration) Stress Tests
+      publishRunAttachments: true
+    condition: succeededOrFailed()
+
+  - task: PublishPipelineArtifact@1
+    displayName: Publish test and installation logs
+    inputs:
+      targetPath: $(Build.ArtifactStagingDirectory)\logs
+      artifactName: Logs_Windows_Stress
+    condition: failed()

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,7 +46,6 @@
     <GitPackageVersion>2.20200622.2</GitPackageVersion>
     <MinimumGitVersion>v2.25.0.vfs.1.1</MinimumGitVersion>
 
-    <WatchmanPackageUrl>https://github.com/facebook/watchman/suites/307436006/artifacts/304557</WatchmanPackageUrl>
     <GcmCoreOSXPackageUrl>https://github.com/microsoft/Git-Credential-Manager-Core/releases/download/v2.0.79-beta/gcmcore-osx-2.0.79.64449.pkg</GcmCoreOSXPackageUrl>
 
     <!-- Signing certificates -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
        VFS for Git (which is less flexible). Only update that version if we rely upon a
        new command-line interface in Git or if there is a truly broken interaction.
     -->
-    <GitPackageVersion>2.20200622.2</GitPackageVersion>
+    <GitPackageVersion>2.20200612.1-pr</GitPackageVersion>
     <MinimumGitVersion>v2.25.0.vfs.1.1</MinimumGitVersion>
 
     <GcmCoreOSXPackageUrl>https://github.com/microsoft/Git-Credential-Manager-Core/releases/download/v2.0.79-beta/gcmcore-osx-2.0.79.64449.pkg</GcmCoreOSXPackageUrl>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
        VFS for Git (which is less flexible). Only update that version if we rely upon a
        new command-line interface in Git or if there is a truly broken interaction.
     -->
-    <GitPackageVersion>2.20200612.1-pr</GitPackageVersion>
+    <GitPackageVersion>2.20200709.2-pr</GitPackageVersion>
     <MinimumGitVersion>v2.25.0.vfs.1.1</MinimumGitVersion>
 
     <GcmCoreOSXPackageUrl>https://github.com/microsoft/Git-Credential-Manager-Core/releases/download/v2.0.79-beta/gcmcore-osx-2.0.79.64449.pkg</GcmCoreOSXPackageUrl>

--- a/Readme.md
+++ b/Readme.md
@@ -36,7 +36,6 @@ The script may prompt for your password as it installs the following components:
 * [Git](https://github.com/microsoft/git) (with custom patches)
 * [Git Credential Manager Core](https://github.com/microsoft/Git-Credential-Manager-Core)
 * Scalar
-* [Watchman](https://github.com/facebook/watchman), unless you use the `--no-watchman` argument.
 
 Installing on Windows
 --------------------
@@ -48,7 +47,6 @@ run `InstallScalar.bat`. This will install the following components:
 
 * [Git for Windows](https://github.com/microsoft/git) (with custom patches)
 * Scalar
-* [Watchman](https://github.com/facebook/watchman), if you use the `--watchman` argument.
 
 ## Quick start
 
@@ -72,7 +70,7 @@ Querying remote for config...Succeeded
 Using cache server: None (https://dev.azure.com/gvfs/ci/_git/ForTests)
 Cloning...Succeeded
 Fetching commits and trees from origin (no cache server)...Succeeded
-Configuring Watchman...Succeeded.
+Configuring FSMonitor...Succeeded.
 Validating repo...Succeeded
 
 $ cd ForTests/src

--- a/Scalar.Common/ScalarConstants.cs
+++ b/Scalar.Common/ScalarConstants.cs
@@ -125,12 +125,7 @@ namespace Scalar.Common
 
             public static class Hooks
             {
-                public const string QueryWatchmanName = "query-watchman";
-                public const string FsMonitorWatchmanSampleName = "fsmonitor-watchman.sample";
-
                 public static readonly string Root = Path.Combine(DotGit.Root, "hooks");
-                public static readonly string QueryWatchmanPath = Path.Combine(Hooks.Root, QueryWatchmanName);
-                public static readonly string FsMonitorWatchmanSamplePath = Path.Combine(Hooks.Root, FsMonitorWatchmanSampleName);
             }
 
             public static class Info

--- a/Scalar.FunctionalTests/Categories.cs
+++ b/Scalar.FunctionalTests/Categories.cs
@@ -10,6 +10,8 @@ namespace Scalar.FunctionalTests
 
         public const string GitRepository = "GitRepository";
 
+        public const string Stress = "Stress";
+
         public const string NeedsUpdatesForNonVirtualizedMode = "NeedsUpdatesForNonVirtualizedMode";
 
         public static class MacTODO

--- a/Scalar.FunctionalTests/Program.cs
+++ b/Scalar.FunctionalTests/Program.cs
@@ -39,7 +39,7 @@ namespace Scalar.FunctionalTests
             ScalarTestConfig.LocalCacheRoot = runner.GetCustomArgWithParam("--shared-scalar-cache-root");
 
             HashSet<string> includeCategories = new HashSet<string>();
-            HashSet<string> excludeCategories = new HashSet<string>();
+            HashSet<string> excludeCategories = new HashSet<string>() { Categories.Stress };
 
             // Run all GitRepoTests with sparse mode
             ScalarTestConfig.GitRepoTestsValidateWorkTree =
@@ -83,6 +83,12 @@ namespace Scalar.FunctionalTests
                 // RunTests unions all includeCategories.  Remove ExtraCoverage to
                 // ensure that we only run tests flagged as WindowsOnly
                 includeCategories.Remove(Categories.ExtraCoverage);
+            }
+
+            if (runner.HasCustomArg("--stress"))
+            {
+                includeCategories.Add(Categories.Stress);
+                excludeCategories.Remove(Categories.Stress);
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))

--- a/Scalar.FunctionalTests/Program.cs
+++ b/Scalar.FunctionalTests/Program.cs
@@ -119,17 +119,6 @@ namespace Scalar.FunctionalTests
             RunBeforeAnyTests();
             Environment.ExitCode = runner.RunTests(includeCategories, excludeCategories);
 
-            try
-            {
-                // Shutdown the watchman server now that the tests are complete.
-                // Allows deleting the unwatched directories.
-                ProcessHelper.Run("watchman", "shudown-server");
-            }
-            catch (Exception)
-            {
-                // This is non-critical, and watchman may not be installed.
-            }
-
             if (Debugger.IsAttached)
             {
                 Console.WriteLine("Tests completed. Press Enter to exit.");

--- a/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/MultiEnlistmentStressTests.cs
+++ b/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/MultiEnlistmentStressTests.cs
@@ -1,0 +1,115 @@
+﻿using NUnit.Framework;
+using Scalar.FunctionalTests.FileSystemRunners;
+using Scalar.FunctionalTests.Tools;
+using Scalar.Tests.Should;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
+{
+    [Category(Categories.Stress)]
+    public class MultiEnlistmentStressTests : TestsWithMultiEnlistment
+    {
+        private static readonly string MicrosoftScalarHttp = "https://github.com/microsoft/scalar";
+
+        private const int worktreeCount = 10;
+        private const int loopCount = 100;
+        private const int filesToCreate = 25;
+
+        private FileSystemRunner fileSystem;
+        private int numSuccesses;
+
+        public MultiEnlistmentStressTests()
+        {
+            this.fileSystem = new SystemIORunner();
+        }
+
+        [TestCase]
+        public void MultiWorktreeStatus()
+        {
+            Environment.SetEnvironmentVariable("GIT_TRACE2_EVENT", "C:\\_git\\scalar\\stress.txt");
+            ScalarFunctionalTestEnlistment enlistment = this.CreateNewEnlistment(
+                                                                url: MicrosoftScalarHttp,
+                                                                branch: "master",
+                                                                fullClone: false);
+
+            List<string> worktrees = new List<string>();
+            for (int i = 0; i < worktreeCount; i++)
+            {
+                string workdir = Path.Combine(enlistment.EnlistmentRoot, $"src-{i}");
+                this.VerifySuccessfulGitCommand(enlistment.RepoRoot, $"-c core.fsmonitor= worktree add {workdir} origin/master");
+                worktrees.Add(workdir);
+            }
+
+            TaskFactory factory = new TaskFactory();
+            List<Task> tasks = new List<Task>();
+            for (int i = 0; i < worktrees.Count; i++)
+            {
+                string worktree = worktrees[i];
+                tasks.Add(factory.StartNew(() => VerifyWorktreeBehaviorLoop(enlistment, worktree)));
+            }
+
+            for (int i = 0; i < tasks.Count; i++)
+            {
+                tasks[i].Wait();
+            }
+
+            this.numSuccesses.ShouldEqual(worktreeCount, "Not all threads succeeded");
+        }
+
+        private void VerifyWorktreeBehaviorLoop(ScalarFunctionalTestEnlistment enlistment, string worktree)
+        {
+            for (int i = 0; i < loopCount; i++)
+            {
+                this.VerifyWorktreeBehavior(enlistment, worktree, i);
+            }
+
+            Interlocked.Increment(ref this.numSuccesses);
+        }
+
+        private void VerifyWorktreeBehavior(ScalarFunctionalTestEnlistment enlistment, string worktree, int iteration)
+        {
+            string dirName = $"dir{iteration}";
+            string iterationDir = Path.Combine(worktree, dirName);
+
+            this.fileSystem.CreateDirectory(iterationDir);
+
+            for (int i = 0; i < filesToCreate; i++)
+            {
+                string nameI = $"file{i}.txt";
+                string localI = Path.Combine(dirName, nameI);
+                string fileI = Path.Combine(iterationDir, nameI);
+                this.fileSystem.WriteAllText(fileI, $"{iteration} {worktree} {i}\n");
+
+                for (int j = 0; j < i; j++)
+                {
+                    string fileJ = Path.Combine(iterationDir, $"file{j}.txt");
+                    this.fileSystem.AppendAllText(fileJ, $"{iteration} {worktree} {i} {j}\n");
+                }
+
+                this.VerifySuccessfulGitCommand(worktree, $"add {localI}");
+                this.VerifySuccessfulGitCommand(worktree, "status");
+                this.VerifySuccessfulGitCommand(worktree, $"commit -m staged{i}");
+                this.VerifySuccessfulGitCommand(worktree, "status");
+                this.VerifySuccessfulGitCommand(worktree, $"commit --allow-empty -a -m all{i}");
+                this.VerifySuccessfulGitCommand(worktree, "status");
+
+                // Disable fsmonitor and add all files, which should not do anything.
+                // If the "git commit" command succeeds, then we had some extra modified files
+                // that were not included in this run
+                this.VerifySuccessfulGitCommand(worktree, $"-c core.fsmonitor=\"\" add .");
+                ProcessResult result = GitProcess.InvokeProcess(worktree, "commit -m empty-should-fail");
+                result.ExitCode.ShouldNotEqual(0, $"'git commit -m empty-should-fail' succeeded?");
+            }
+        }
+
+        private void VerifySuccessfulGitCommand(string dir, string args)
+        {
+            ProcessResult result = GitProcess.InvokeProcess(dir, args);
+            result.ExitCode.ShouldEqual(0, $"'git {args}' in '{dir}' failed.\n\nOutput: {result.Output}\n\nErrors: {result.Errors}");
+        }
+    }
+}

--- a/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/MultiEnlistmentStressTests.cs
+++ b/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/MultiEnlistmentStressTests.cs
@@ -33,7 +33,6 @@ namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
         [TestCase]
         public void SingleEnlistmentStatus()
         {
-            Environment.SetEnvironmentVariable("GIT_TRACE2_EVENT", "C:\\_git\\scalar\\stress.txt");
             ScalarFunctionalTestEnlistment enlistment = this.CreateNewEnlistment(
                                                                 url: MicrosoftScalarHttp,
                                                                 branch: "main",
@@ -62,8 +61,6 @@ namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
         [TestCase]
         public void MultiEnlistmentStatus()
         {
-            Environment.SetEnvironmentVariable("GIT_TRACE2_EVENT", "C:\\_git\\scalar\\stress.txt");
-
             List<ScalarFunctionalTestEnlistment> enlistments = new List<ScalarFunctionalTestEnlistment>();
 
             for (int i = 0; i < enlistmentCount; i++)
@@ -95,7 +92,6 @@ namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
         [TestCase]
         public void MultiWorktreeStatus()
         {
-            Environment.SetEnvironmentVariable("GIT_TRACE2_EVENT", "C:\\_git\\scalar\\stress.txt");
             ScalarFunctionalTestEnlistment enlistment = this.CreateNewEnlistment(
                                                                 url: MicrosoftScalarHttp,
                                                                 branch: "main",

--- a/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/MultiEnlistmentStressTests.cs
+++ b/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/MultiEnlistmentStressTests.cs
@@ -19,7 +19,7 @@ namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
         private const int parallelCount = 3;
         private const int loopCount = 25;
         private const int filesToCreate = 25;
-        private const int timeout = 30;
+        private const int timeoutSeconds = 30;
 
         private FileSystemRunner fileSystem;
         private int numSuccesses;
@@ -185,14 +185,14 @@ namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
                 // that were not included in this run
                 this.VerifySuccessfulGitCommand(worktree, $"-c core.fsmonitor=\"\" add .");
                 string status = this.VerifySuccessfulGitCommand(worktree, "status");
-                ProcessResult result = GitProcess.InvokeProcess(worktree, "commit -m empty-should-fail", timeoutSeconds: timeout);
+                ProcessResult result = GitProcess.InvokeProcess(worktree, "commit -m empty-should-fail", timeoutSeconds: timeoutSeconds);
                 result.ExitCode.ShouldNotEqual(0, $"'git commit -m empty-should-fail' succeeded? Last edited {fileI}. Status:\n{status}");
             }
         }
 
         private string VerifySuccessfulGitCommand(string dir, string args)
         {
-            ProcessResult result = GitProcess.InvokeProcess(dir, args, timeoutSeconds: timeout);
+            ProcessResult result = GitProcess.InvokeProcess(dir, args, timeoutSeconds: timeoutSeconds);
             result.ExitCode.ShouldEqual(0, $"'git {args}' in '{dir}' failed.\n\nOutput: {result.Output}\n\nErrors: {result.Errors}");
             return result.Output;
         }

--- a/Scalar.FunctionalTests/Tools/GitProcess.cs
+++ b/Scalar.FunctionalTests/Tools/GitProcess.cs
@@ -32,7 +32,7 @@ namespace Scalar.FunctionalTests.Tools
             }
         }
 
-        public static ProcessResult InvokeProcess(string executionWorkingDirectory, string command, Dictionary<string, string> environmentVariables = null, Stream inputStream = null)
+        public static ProcessResult InvokeProcess(string executionWorkingDirectory, string command, Dictionary<string, string> environmentVariables = null, Stream inputStream = null, int? timeoutSeconds = null)
         {
             ProcessStartInfo processInfo = new ProcessStartInfo(Properties.Settings.Default.PathToGit);
             processInfo.WorkingDirectory = executionWorkingDirectory;
@@ -56,7 +56,7 @@ namespace Scalar.FunctionalTests.Tools
                 }
             }
 
-            return ProcessHelper.Run(processInfo, inputStream: inputStream);
+            return ProcessHelper.Run(processInfo, inputStream: inputStream, timeoutSeconds: timeoutSeconds);
         }
     }
 }

--- a/Scalar.FunctionalTests/Tools/ProcessHelper.cs
+++ b/Scalar.FunctionalTests/Tools/ProcessHelper.cs
@@ -116,7 +116,7 @@ namespace Scalar.FunctionalTests.Tools
                 output = executingProcess.StandardOutput.ReadToEnd();
             }
 
-            executingProcess.WaitForExit(timeoutSeconds.HasValue ? timeoutSeconds.Value * 1000 : 5 * 60 * 1000);
+            executingProcess.WaitForExit(timeoutSeconds.HasValue ? timeoutSeconds.Value * 1000 : 60 * 1000);
 
             if (!executingProcess.HasExited)
             {

--- a/Scalar.FunctionalTests/Tools/ProcessHelper.cs
+++ b/Scalar.FunctionalTests/Tools/ProcessHelper.cs
@@ -116,9 +116,7 @@ namespace Scalar.FunctionalTests.Tools
                 output = executingProcess.StandardOutput.ReadToEnd();
             }
 
-            executingProcess.WaitForExit(timeoutSeconds.HasValue ? timeoutSeconds.Value * 1000 : 60 * 1000);
-
-            if (!executingProcess.HasExited)
+            if (!executingProcess.WaitForExit(timeoutSeconds.HasValue ? timeoutSeconds.Value * 1000 : 60 * 1000))
             {
                 executingProcess.Kill();
                 throw new Exception("Command failed to exit on time");

--- a/Scalar.FunctionalTests/Tools/ScalarFunctionalTestEnlistment.cs
+++ b/Scalar.FunctionalTests/Tools/ScalarFunctionalTestEnlistment.cs
@@ -155,25 +155,6 @@ namespace Scalar.FunctionalTests.Tools
             return Path.Combine(ScalarHelpers.GetObjectsRootFromGitConfig(this.RepoRoot), "pack");
         }
 
-        public void DeleteEnlistment()
-        {
-            string watchmanLocation = ProcessHelper.GetProgramLocation("watchman");
-            if (!string.IsNullOrEmpty(watchmanLocation))
-            {
-                try
-                {
-                    ProcessHelper.Run(Path.Combine(watchmanLocation, "watchman"), $"watch-del {this.RepoRoot}");
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine($"Failed to delete watch on {this.RepoRoot}. {ex.ToString()}");
-                }
-            }
-
-            TestResultsHelper.OutputScalarLogs(this);
-            RepositoryHelpers.DeleteTestDirectory(this.EnlistmentRoot);
-        }
-
         public void Clone(bool skipFetchCommitsAndTrees)
         {
             this.scalarProcess.Clone(this.RepoUrl, this.Commitish, skipFetchCommitsAndTrees, fullClone: this.fullClone);

--- a/Scalar.FunctionalTests/Tools/ScalarFunctionalTestEnlistment.cs
+++ b/Scalar.FunctionalTests/Tools/ScalarFunctionalTestEnlistment.cs
@@ -211,7 +211,6 @@ namespace Scalar.FunctionalTests.Tools
 
         public void DeleteAll()
         {
-            this.DeleteEnlistment();
         }
 
         public string GetSourcePath(string path)

--- a/Scalar.Installer.Mac/InstallScalar.template.sh
+++ b/Scalar.Installer.Mac/InstallScalar.template.sh
@@ -14,23 +14,6 @@ SCALAR_INSTALLER_PKG="##SCALAR_INSTALLER_PKG_PLACEHOLDER##"
 
 SCALAR_DISTRIBUTION_ROOT="$(dirname ${BASH_SOURCE[0]})"
 
-# Default installation flags
-INSTALL_WATCHMAN=1
-
-# Check the presence of known installation flags
-for arg in "$@"
-do
-    if [ "$arg" = "--no-watchman" ]; then
-        INSTALL_WATCHMAN=0
-    fi
-done
-
-# Check if any of the installation options require Homebrew
-REQUIRE_HOMEBREW=0
-if [ $INSTALL_WATCHMAN -eq 1 ]; then
-    REQUIRE_HOMEBREW=1
-fi
-
 echo ""
 echo "Welcome - running Scalar installation script"
 
@@ -60,31 +43,6 @@ echo "Git installer pkg: $GIT_INSTALLER_PKG"
 echo "GCM installer pkg: $GCM_CORE_INSTALLER_PKG"
 echo "Scalar installer pkg: $SCALAR_INSTALLER_PKG"
 
-echo ""
-echo "=============================="
-echo "Checking prerequisites..."
-
-if [ $REQUIRE_HOMEBREW -eq 1 ]; then
-    ## Check for brew installation
-    BREW_INSTALLED=0
-
-    if which -s brew; then
-        BREW_INSTALLED=1
-    else
-        BREW_INSTALLED=0
-    fi
-
-    if [ $BREW_INSTALLED -eq 0 ]; then
-        echo ""
-        echo "Homebrew is required to install watchman. Please install Homebrew with the following command and run the installation script again:"
-        echo "/usr/bin/ruby -e \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)\""
-        exit 1
-    else
-        echo "Homebrew already installed!"
-    fi
-fi
-
-
 # Install Git
 echo ""
 echo "=============================="
@@ -102,23 +60,6 @@ echo ""
 echo "=============================="
 echo "Installing Scalar"
 sudo /usr/sbin/installer -pkg "$SCALAR_DISTRIBUTION_ROOT/Scalar/$SCALAR_INSTALLER_PKG" -target /
-
-# Install Watchman
-if [ $INSTALL_WATCHMAN -eq 1 ]; then
-    echo ""
-    echo "=============================="
-    echo "Installing watchman as: $CURRENT_USER"
-
-    sudo chown -R $CURRENT_USER /usr/local/Cellar
-    sudo -u $CURRENT_USER brew update
-    sudo -u $CURRENT_USER brew unlink python@2 || echo "Python 2 was not installed"
-    sudo -u $CURRENT_USER brew install watchman
-else
-    echo ""
-    echo "=============================="
-    echo "Skipping watchman installation"
-    echo "(--no-watchman was specified)"
-fi
 
 # Install optional package if specified
 if [ ! -z "$OPTIONAL_INSTALLER_PKG" ]; then

--- a/Scalar/CommandLine/DeleteVerb.cs
+++ b/Scalar/CommandLine/DeleteVerb.cs
@@ -46,60 +46,7 @@ namespace Scalar.CommandLine
 
         private void StopFileSystemWatcher()
         {
-            try
-            {
-                string watchmanProcess = "watchman";
-                string watchmanLocation = ProcessHelper.GetProgramLocation(ScalarPlatform.Instance.Constants.ProgramLocaterCommand, watchmanProcess);
-
-                if (!string.IsNullOrEmpty(watchmanLocation))
-                {
-                    string watchmanPath = Path.Combine(watchmanLocation, watchmanProcess);
-                    string workDir = Path.Combine(this.enlistmentRoot, ScalarConstants.WorkingDirectoryRootName);
-
-                    // Check the existing list
-                    string listArgument = $"watch-list";
-                    ProcessResult listResult = ProcessHelper.Run(watchmanPath, listArgument);
-
-                    // Watchman always uses slashes, not backslashes
-                    string normalizedWorkDir = workDir.Replace(Path.DirectorySeparatorChar, '/');
-                    if (!listResult.Output.Contains(normalizedWorkDir))
-                    {
-                        Console.Error.WriteLine($"Watchman is not watching '{workDir}'");
-                        return;
-                    }
-
-                    // Remove workDir from watchman's watch-list.
-                    string deleteArgument = $"watch-del {workDir}";
-                    ProcessResult result = ProcessHelper.Run(watchmanPath, deleteArgument);
-
-                    if (result.ExitCode != 0)
-                    {
-                        Console.Error.WriteLine($"Errors during 'watchman {deleteArgument}':");
-                        Console.Error.WriteLine(result.Errors);
-                    }
-
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                    {
-                        // We MUST shutdown the server on Windows to close the handles.
-                        // We MUST NOT shutdown the server on Mac or we could lose events.
-                        // Shutdown server, clearing handles (it will restart on a new query)
-                        string shutdownArgument = "shutdown-server";
-                        result = ProcessHelper.Run(watchmanPath, shutdownArgument);
-
-                        if (result.ExitCode != 0)
-                        {
-                            Console.Error.WriteLine($"Errors during 'watchman {shutdownArgument}':");
-                            Console.Error.WriteLine(result.Errors);
-                        }
-                    }
-                }
-            }
-            catch (Win32Exception ex)
-            {
-                // Probably watchman is not on PATH
-                Console.Error.WriteLine($"Exception while stopping filesystme watcher. Is is on the PATH?");
-                Console.Error.WriteLine(ex.Message);
-            }
+            // TODO: Integrate with Git's internal FSMonitor, if required.
         }
 
         private void DeleteEnlistment()

--- a/Scripts/RunFunctionalTests.bat
+++ b/Scripts/RunFunctionalTests.bat
@@ -4,7 +4,7 @@ CALL %~dp0\InitializeEnvironment.bat || EXIT /b 10
 IF "%1"=="" (SET "Configuration=Debug") ELSE (SET "Configuration=%1")
 
 SETLOCAL
-SET PATH=C:\Program Files\Scalar;C:\Program Files\watchman;C:\Program Files\Git\cmd;%PATH%
+SET PATH=C:\Program Files\Scalar;C:\Program Files\Git\cmd;%PATH%
 
 SET publishFragment=bin\%Configuration%\netcoreapp3.1\win10-x64\publish
 SET functionalTestsDir=%SCALAR_OUTPUTDIR%\Scalar.FunctionalTests\%publishFragment%

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,6 @@ The script may prompt for your password as it installs the following components:
 * [Git](https://github.com/microsoft/git) (with custom patches)
 * [Git Credential Manager Core](https://github.com/microsoft/Git-Credential-Manager-Core)
 * Scalar
-* [Watchman](https://github.com/facebook/watchman), unless you use the `--no-watchman` argument.
 
 Installing on Windows
 --------------------
@@ -52,7 +51,7 @@ run `InstallScalar.bat`. This will install the following components:
 
 * [Git for Windows](https://github.com/microsoft/git) (with custom patches)
 * Scalar
-* [Watchman](https://github.com/facebook/watchman), if you use the `--watchman` argument.
+
 Documentation
 -------------
 


### PR DESCRIPTION
See microsoft/git#273 for the latest WIP change in Git.

This PR is only for running builds and trying to find new errors in that work.

The goal is to drop our dependence on facebook/watchman and instead use a Git-aware FSMonitor within Git itself. If the FSMonitor portion has the same performance, then we will have improved performance if only because we no longer work through a hook.