### PR TITLE
[WIP] Add stress tests

### DIFF
--- a/.azure-pipelines/pull-request.yml
+++ b/.azure-pipelines/pull-request.yml
@@ -93,3 +93,29 @@ jobs:
       - template: templates/osx/functional-test.yml
         parameters:
           useWatchman: true
+
+  - job: win_stresstest
+    displayName: Windows Stress Tests
+    timeoutInMinutes: 45
+    variables:
+      configuration: Release
+    pool:
+      vmImage: windows-2019
+    dependsOn: win_build
+    condition: succeeded()
+    steps:
+      - checkout: none
+      - template: templates/win/stress-test.yml
+
+  - job: osx_stresstest
+    displayName: macOS Stress Tests
+    timeoutInMinutes: 45
+    variables:
+      configuration: Release
+    pool:
+      name: 'Hosted macOS'
+    dependsOn: osx_build
+    condition: succeeded()
+    steps:
+      - checkout: none
+      - template: templates/osx/stress-test.yml

--- a/.azure-pipelines/templates/osx/stress-test.yml
+++ b/.azure-pipelines/templates/osx/stress-test.yml
@@ -1,0 +1,57 @@
+steps:
+  - bash: mkdir -p $(Build.ArtifactStagingDirectory)/logs
+    displayName: Create logs directory
+
+  - task: UseDotNet@2
+    displayName: Use .NET Core SDK 3.1.101
+    inputs:
+      packageType: sdk
+      version: 3.1.101
+
+  - task: DownloadPipelineArtifact@2
+    displayName: Download functional tests drop
+    inputs:
+      artifact: FunctionalTests_macOS_$(configuration)
+      path: $(Build.BinariesDirectory)/ft
+
+  - task: DownloadPipelineArtifact@2
+    displayName: Download installers drop
+    inputs:
+      artifact: Installers_macOS_$(configuration)
+      path: $(Build.BinariesDirectory)/install
+
+  - bash: |
+      chmod +x $(Build.BinariesDirectory)/ft/src/Scripts/Mac/*.sh
+      chmod +x $(Build.BinariesDirectory)/install/*.sh
+    displayName: Ensure all scripts are executable
+
+  - bash: $(Build.BinariesDirectory)/install/InstallScalar.sh
+    displayName: Install product
+
+  - bash: $(Build.BinariesDirectory)/ft/src/Scripts/Mac/RunFunctionalTests.sh $(configuration) --test-scalar-on-path --stress --trace2-output=$(Build.ArtifactStagingDirectory)/logs/trace2-event.log
+    displayName: Run stress tests
+
+  - task: PublishTestResults@2
+    displayName: Publish stress tests results
+    inputs:
+      testRunner: NUnit
+      testResultsFiles: "**\\TestResult*.xml"
+      searchFolder: $(System.DefaultWorkingDirectory)
+      testRunTitle: macOS $(configuration) Stress Tests
+      publishRunAttachments: true
+    condition: succeededOrFailed()
+
+  - task: PublishPipelineArtifact@1
+    displayName: Publish test and installation logs
+    inputs:
+      targetPath: $(Build.ArtifactStagingDirectory)/logs
+      artifactName: Logs_macOS_Stress
+    condition: failed()
+
+  - bash: $(Build.BinariesDirectory)/ft/src/Scripts/Mac/CleanupFunctionalTests.sh
+    displayName: Cleanup
+    condition: always()
+
+  - bash: sudo rm -rf $(Build.BinariesDirectory)/ft
+    displayName: Cleanup phase 2
+    condition: always()

--- a/.azure-pipelines/templates/win/stress-test.yml
+++ b/.azure-pipelines/templates/win/stress-test.yml
@@ -1,0 +1,45 @@
+steps:
+
+  - task: UseDotNet@2
+    displayName: Use .NET Core SDK 3.1.101
+    inputs:
+      packageType: sdk
+      version: 3.1.101
+
+  - task: DownloadPipelineArtifact@2
+    displayName: Download functional tests drop
+    inputs:
+      artifact: FunctionalTests_Windows_$(configuration)
+      Path: $(Build.BinariesDirectory)\ft
+
+  - task: DownloadPipelineArtifact@2
+    displayName: Download installers drop
+    inputs:
+      artifact: Installers_Windows_$(configuration)
+      path: $(Build.BinariesDirectory)\install
+
+  - script: $(Build.BinariesDirectory)\install\InstallScalar.bat $(Build.ArtifactStagingDirectory)\logs
+    displayName: Install product
+
+  - script: git config --global credential.interactive never
+    displayName: Disable interactive auth
+
+  - script: $(Build.BinariesDirectory)\ft\src\Scripts\RunFunctionalTests.bat $(configuration) --test-scalar-on-path --stress "--trace2-output=$(Build.ArtifactStagingDirectory)\logs\trace2-event.log"
+    displayName: Run stress tests
+
+  - task: PublishTestResults@2
+    displayName: Publish stress tests results
+    inputs:
+      testRunner: NUnit
+      testResultsFiles: "**\\TestResult*.xml"
+      searchFolder: $(System.DefaultWorkingDirectory)
+      testRunTitle: Windows $(configuration) Stress Tests
+      publishRunAttachments: true
+    condition: succeededOrFailed()
+
+  - task: PublishPipelineArtifact@1
+    displayName: Publish test and installation logs
+    inputs:
+      targetPath: $(Build.ArtifactStagingDirectory)\logs
+      artifactName: Logs_Windows_Stress
+    condition: failed()

--- a/Scalar.FunctionalTests/Categories.cs
+++ b/Scalar.FunctionalTests/Categories.cs
@@ -10,6 +10,8 @@ namespace Scalar.FunctionalTests
 
         public const string GitRepository = "GitRepository";
 
+        public const string Stress = "Stress";
+
         public const string NeedsUpdatesForNonVirtualizedMode = "NeedsUpdatesForNonVirtualizedMode";
 
         public static class MacTODO

--- a/Scalar.FunctionalTests/Program.cs
+++ b/Scalar.FunctionalTests/Program.cs
@@ -39,7 +39,7 @@ namespace Scalar.FunctionalTests
             ScalarTestConfig.LocalCacheRoot = runner.GetCustomArgWithParam("--shared-scalar-cache-root");
 
             HashSet<string> includeCategories = new HashSet<string>();
-            HashSet<string> excludeCategories = new HashSet<string>();
+            HashSet<string> excludeCategories = new HashSet<string>() { Categories.Stress };
 
             // Run all GitRepoTests with sparse mode
             ScalarTestConfig.GitRepoTestsValidateWorkTree =
@@ -83,6 +83,12 @@ namespace Scalar.FunctionalTests
                 // RunTests unions all includeCategories.  Remove ExtraCoverage to
                 // ensure that we only run tests flagged as WindowsOnly
                 includeCategories.Remove(Categories.ExtraCoverage);
+            }
+
+            if (runner.HasCustomArg("--stress"))
+            {
+                includeCategories.Add(Categories.Stress);
+                excludeCategories.Remove(Categories.Stress);
             }
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))

--- a/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/MultiEnlistmentStressTests.cs
+++ b/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/MultiEnlistmentStressTests.cs
@@ -1,0 +1,115 @@
+﻿using NUnit.Framework;
+using Scalar.FunctionalTests.FileSystemRunners;
+using Scalar.FunctionalTests.Tools;
+using Scalar.Tests.Should;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
+{
+    [Category(Categories.Stress)]
+    public class MultiEnlistmentStressTests : TestsWithMultiEnlistment
+    {
+        private static readonly string MicrosoftScalarHttp = "https://github.com/microsoft/scalar";
+
+        private const int worktreeCount = 10;
+        private const int loopCount = 100;
+        private const int filesToCreate = 25;
+
+        private FileSystemRunner fileSystem;
+        private int numSuccesses;
+
+        public MultiEnlistmentStressTests()
+        {
+            this.fileSystem = new SystemIORunner();
+        }
+
+        [TestCase]
+        public void MultiWorktreeStatus()
+        {
+            Environment.SetEnvironmentVariable("GIT_TRACE2_EVENT", "C:\\_git\\scalar\\stress.txt");
+            ScalarFunctionalTestEnlistment enlistment = this.CreateNewEnlistment(
+                                                                url: MicrosoftScalarHttp,
+                                                                branch: "master",
+                                                                fullClone: false);
+
+            List<string> worktrees = new List<string>();
+            for (int i = 0; i < worktreeCount; i++)
+            {
+                string workdir = Path.Combine(enlistment.EnlistmentRoot, $"src-{i}");
+                this.VerifySuccessfulGitCommand(enlistment.RepoRoot, $"-c core.fsmonitor= worktree add {workdir} origin/master");
+                worktrees.Add(workdir);
+            }
+
+            TaskFactory factory = new TaskFactory();
+            List<Task> tasks = new List<Task>();
+            for (int i = 0; i < worktrees.Count; i++)
+            {
+                string worktree = worktrees[i];
+                tasks.Add(factory.StartNew(() => VerifyWorktreeBehaviorLoop(enlistment, worktree)));
+            }
+
+            for (int i = 0; i < tasks.Count; i++)
+            {
+                tasks[i].Wait();
+            }
+
+            this.numSuccesses.ShouldEqual(worktreeCount, "Not all threads succeeded");
+        }
+
+        private void VerifyWorktreeBehaviorLoop(ScalarFunctionalTestEnlistment enlistment, string worktree)
+        {
+            for (int i = 0; i < loopCount; i++)
+            {
+                this.VerifyWorktreeBehavior(enlistment, worktree, i);
+            }
+
+            Interlocked.Increment(ref this.numSuccesses);
+        }
+
+        private void VerifyWorktreeBehavior(ScalarFunctionalTestEnlistment enlistment, string worktree, int iteration)
+        {
+            string dirName = $"dir{iteration}";
+            string iterationDir = Path.Combine(worktree, dirName);
+
+            this.fileSystem.CreateDirectory(iterationDir);
+
+            for (int i = 0; i < filesToCreate; i++)
+            {
+                string nameI = $"file{i}.txt";
+                string localI = Path.Combine(dirName, nameI);
+                string fileI = Path.Combine(iterationDir, nameI);
+                this.fileSystem.WriteAllText(fileI, $"{iteration} {worktree} {i}\n");
+
+                for (int j = 0; j < i; j++)
+                {
+                    string fileJ = Path.Combine(iterationDir, $"file{j}.txt");
+                    this.fileSystem.AppendAllText(fileJ, $"{iteration} {worktree} {i} {j}\n");
+                }
+
+                this.VerifySuccessfulGitCommand(worktree, $"add {localI}");
+                this.VerifySuccessfulGitCommand(worktree, "status");
+                this.VerifySuccessfulGitCommand(worktree, $"commit -m staged{i}");
+                this.VerifySuccessfulGitCommand(worktree, "status");
+                this.VerifySuccessfulGitCommand(worktree, $"commit --allow-empty -a -m all{i}");
+                this.VerifySuccessfulGitCommand(worktree, "status");
+
+                // Disable fsmonitor and add all files, which should not do anything.
+                // If the "git commit" command succeeds, then we had some extra modified files
+                // that were not included in this run
+                this.VerifySuccessfulGitCommand(worktree, $"-c core.fsmonitor=\"\" add .");
+                ProcessResult result = GitProcess.InvokeProcess(worktree, "commit -m empty-should-fail");
+                result.ExitCode.ShouldNotEqual(0, $"'git commit -m empty-should-fail' succeeded?");
+            }
+        }
+
+        private void VerifySuccessfulGitCommand(string dir, string args)
+        {
+            ProcessResult result = GitProcess.InvokeProcess(dir, args);
+            result.ExitCode.ShouldEqual(0, $"'git {args}' in '{dir}' failed.\n\nOutput: {result.Output}\n\nErrors: {result.Errors}");
+        }
+    }
+}

--- a/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/MultiEnlistmentStressTests.cs
+++ b/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/MultiEnlistmentStressTests.cs
@@ -33,7 +33,6 @@ namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
         [TestCase]
         public void SingleEnlistmentStatus()
         {
-            Environment.SetEnvironmentVariable("GIT_TRACE2_EVENT", "C:\\_git\\scalar\\stress.txt");
             ScalarFunctionalTestEnlistment enlistment = this.CreateNewEnlistment(
                                                                 url: MicrosoftScalarHttp,
                                                                 branch: "main",
@@ -62,8 +61,6 @@ namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
         [TestCase]
         public void MultiEnlistmentStatus()
         {
-            Environment.SetEnvironmentVariable("GIT_TRACE2_EVENT", "C:\\_git\\scalar\\stress.txt");
-
             List<ScalarFunctionalTestEnlistment> enlistments = new List<ScalarFunctionalTestEnlistment>();
 
             for (int i = 0; i < enlistmentCount; i++)
@@ -95,7 +92,6 @@ namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
         [TestCase]
         public void MultiWorktreeStatus()
         {
-            Environment.SetEnvironmentVariable("GIT_TRACE2_EVENT", "C:\\_git\\scalar\\stress.txt");
             ScalarFunctionalTestEnlistment enlistment = this.CreateNewEnlistment(
                                                                 url: MicrosoftScalarHttp,
                                                                 branch: "main",

--- a/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/MultiEnlistmentStressTests.cs
+++ b/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/MultiEnlistmentStressTests.cs
@@ -19,7 +19,7 @@ namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
         private const int parallelCount = 3;
         private const int loopCount = 25;
         private const int filesToCreate = 25;
-        private const int timeout = 30;
+        private const int timeoutSeconds = 30;
 
         private FileSystemRunner fileSystem;
         private int numSuccesses;
@@ -185,14 +185,14 @@ namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
                 // that were not included in this run
                 this.VerifySuccessfulGitCommand(worktree, $"-c core.fsmonitor=\"\" add .");
                 string status = this.VerifySuccessfulGitCommand(worktree, "status");
-                ProcessResult result = GitProcess.InvokeProcess(worktree, "commit -m empty-should-fail", timeoutSeconds: timeout);
+                ProcessResult result = GitProcess.InvokeProcess(worktree, "commit -m empty-should-fail", timeoutSeconds: timeoutSeconds);
                 result.ExitCode.ShouldNotEqual(0, $"'git commit -m empty-should-fail' succeeded? Last edited {fileI}. Status:\n{status}");
             }
         }
 
         private string VerifySuccessfulGitCommand(string dir, string args)
         {
-            ProcessResult result = GitProcess.InvokeProcess(dir, args, timeoutSeconds: timeout);
+            ProcessResult result = GitProcess.InvokeProcess(dir, args, timeoutSeconds: timeoutSeconds);
             result.ExitCode.ShouldEqual(0, $"'git {args}' in '{dir}' failed.\n\nOutput: {result.Output}\n\nErrors: {result.Errors}");
             return result.Output;
         }

--- a/Scalar.FunctionalTests/Tools/GitProcess.cs
+++ b/Scalar.FunctionalTests/Tools/GitProcess.cs
@@ -32,7 +32,7 @@ namespace Scalar.FunctionalTests.Tools
             }
         }
 
-        public static ProcessResult InvokeProcess(string executionWorkingDirectory, string command, Dictionary<string, string> environmentVariables = null, Stream inputStream = null)
+        public static ProcessResult InvokeProcess(string executionWorkingDirectory, string command, Dictionary<string, string> environmentVariables = null, Stream inputStream = null, int? timeoutSeconds = null)
         {
             ProcessStartInfo processInfo = new ProcessStartInfo(Properties.Settings.Default.PathToGit);
             processInfo.WorkingDirectory = executionWorkingDirectory;
@@ -56,7 +56,7 @@ namespace Scalar.FunctionalTests.Tools
                 }
             }
 
-            return ProcessHelper.Run(processInfo, inputStream: inputStream);
+            return ProcessHelper.Run(processInfo, inputStream: inputStream, timeoutSeconds: timeoutSeconds);
         }
     }
 }

--- a/Scalar.FunctionalTests/Tools/ProcessHelper.cs
+++ b/Scalar.FunctionalTests/Tools/ProcessHelper.cs
@@ -116,7 +116,7 @@ namespace Scalar.FunctionalTests.Tools
                 output = executingProcess.StandardOutput.ReadToEnd();
             }
 
-            executingProcess.WaitForExit(timeoutSeconds.HasValue ? timeoutSeconds.Value * 1000 : 5 * 60 * 1000);
+            executingProcess.WaitForExit(timeoutSeconds.HasValue ? timeoutSeconds.Value * 1000 : 60 * 1000);
 
             if (!executingProcess.HasExited)
             {

--- a/Scalar.FunctionalTests/Tools/ProcessHelper.cs
+++ b/Scalar.FunctionalTests/Tools/ProcessHelper.cs
@@ -116,9 +116,7 @@ namespace Scalar.FunctionalTests.Tools
                 output = executingProcess.StandardOutput.ReadToEnd();
             }
 
-            executingProcess.WaitForExit(timeoutSeconds.HasValue ? timeoutSeconds.Value * 1000 : 60 * 1000);
-
-            if (!executingProcess.HasExited)
+            if (!executingProcess.WaitForExit(timeoutSeconds.HasValue ? timeoutSeconds.Value * 1000 : 60 * 1000))
             {
                 executingProcess.Kill();
                 throw new Exception("Command failed to exit on time");


### PR DESCRIPTION
Add a new category of functional test that does not run normally. These intend to check that commands like `git status` work well in parallel. There are three main situations covered here:

1. One thread changes a single repo, while other threads run `git status` in a loop. This checks the in-repo parallelism. Only one writer is supported, so this many-to-one split is necessary.
2. Multiple threads change multiple, independent repos. This verifies that the filesystem watcher works when bombarded with many independent requests. Watchman may struggle in this scenario, but the internal FSMonitor currently has a separate service process per repo.
3. Multiple threads change multiple worktrees for the same repo. This is an important, but advanced case. The object database is being modified in parallel (additively) but the indexes should be independent.

These tests are disabled by default, but are the only tests run when providing the `--stress` option to the functional tests.

These are duplicated on the internal FSMonitor in #389.