### PR TITLE
Small cleanups

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@ Run `scalar register` in an existing Git repo to enable recommended config
 settings and start background maintenance.
 
 If your repo is hosted on a service that supports the
-[GVFS Protocol](https://github.com/microsoft/VFSForGit/blob/main/Protocol.md),
+[GVFS Protocol](https://github.com/microsoft/VFSForGit/blob/HEAD/Protocol.md),
 such as Azure Repos, then `scalar clone <url>` will create a local enlistment with
 abilities like on-demand object retrieval, background maintenance tasks, and
 automatically sets Git config values and hooks that enable performance enhancements.

--- a/Scalar.Common/Maintenance/ConfigStep.cs
+++ b/Scalar.Common/Maintenance/ConfigStep.cs
@@ -100,7 +100,6 @@ namespace Scalar.Common.Maintenance
             {
                 { "am.keepcr", "true" },
                 { "core.autocrlf", "false" },
-                { "checkout.optimizenewbranch", "true" },
                 { "core.fscache", "true" },
                 { "core.multiPackIndex", "true" },
                 { "core.preloadIndex", "true" },

--- a/Scalar.Common/Maintenance/ConfigStep.cs
+++ b/Scalar.Common/Maintenance/ConfigStep.cs
@@ -99,11 +99,9 @@ namespace Scalar.Common.Maintenance
             Dictionary<string, string> requiredSettings = new Dictionary<string, string>
             {
                 { "am.keepcr", "true" },
-                { "core.autocrlf", "false" },
                 { "core.fscache", "true" },
                 { "core.multiPackIndex", "true" },
                 { "core.preloadIndex", "true" },
-                { "core.safecrlf", "false" },
                 { "core.untrackedCache", ScalarPlatform.Instance.FileSystem.SupportsUntrackedCache ? "true" : "false" },
                 { "core.filemode", ScalarPlatform.Instance.FileSystem.SupportsFileMode ? "true" : "false" },
                 { "core.bare", "false" },
@@ -155,6 +153,8 @@ namespace Scalar.Common.Maintenance
             Dictionary<string, string> optionalSettings = new Dictionary<string, string>
             {
                 { "status.aheadbehind", "false" },
+                { "core.autocrlf", "false" },
+                { "core.safecrlf", "false" },
             };
 
             if (this.UseGvfsProtocol.Value)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,7 +18,7 @@ Creating a new Scalar clone using the GVFS Protocol
 ---------------------------------------------------
 
 The `clone` verb creates a local enlistment of a remote repository using the
-[GVFS protocol](https://github.com/microsoft//VFSForGit/blob/main/Protocol.md).
+[GVFS protocol](https://github.com/microsoft/VFSForGit/blob/HEAD/Protocol.md).
 
 ```
 scalar clone [options] <url> [<dir>]

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ these features for that repo and start running suggested maintenance in the
 background.
 
 Repos cloned with the `scalar clone` command use the
-[GVFS protocol](https://github.com/microsoft//VFSForGit/blob/main/Protocol.md)
+[GVFS protocol](https://github.com/microsoft/VFSForGit/blob/HEAD/Protocol.md)
 to significantly reduce the amount of data required to get started
 using a repository. By delaying all blob downloads until they are required,
 Scalar allows you to work with very large repositories quickly. This protocol


### PR DESCRIPTION
1. @fornever [reported a doc bug](https://github.com/microsoft/scalar/commit/da87cb27c22c6a1b4c470c03738ade1450c1210a#r40061740) with the `main` branch which doesn't exist in microsoft/vfsforgit.
2. @sluongng pointed out that `checkout.optimizeNewBranch` doesn't exist anymore. Resolves #388.
3. @nikola-sh requested that `core.autocrlf` and `core.safecrlf` be optional. Resolves #391.