### PR TITLE
[DO NOT MERGE] Test Git with updates from 'next'

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
        VFS for Git (which is less flexible). Only update that version if we rely upon a
        new command-line interface in Git or if there is a truly broken interaction.
     -->
-    <GitPackageVersion>2.20200622.2</GitPackageVersion>
+    <GitPackageVersion>2.20200624.1-pr</GitPackageVersion>
     <MinimumGitVersion>v2.25.0.vfs.1.1</MinimumGitVersion>
 
     <WatchmanPackageUrl>https://github.com/facebook/watchman/suites/307436006/artifacts/304557</WatchmanPackageUrl>


### PR DESCRIPTION
Junio asked that more people install and test the `next` branch to catch things before they are in `master` or an RC. This is our attempt to add additional testing by merging `next` with our `vfs-2.X` branch.