### PR TITLE
Update Git to v2.28.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
        VFS for Git (which is less flexible). Only update that version if we rely upon a
        new command-line interface in Git or if there is a truly broken interaction.
     -->
-    <GitPackageVersion>2.20200622.2</GitPackageVersion>
+    <GitPackageVersion>2.20200728.1</GitPackageVersion>
     <MinimumGitVersion>v2.25.0.vfs.1.1</MinimumGitVersion>
 
     <WatchmanPackageUrl>https://github.com/facebook/watchman/suites/307436006/artifacts/304557</WatchmanPackageUrl>

--- a/Scalar.Common/Maintenance/ConfigStep.cs
+++ b/Scalar.Common/Maintenance/ConfigStep.cs
@@ -155,6 +155,7 @@ namespace Scalar.Common.Maintenance
                 { "status.aheadbehind", "false" },
                 { "core.autocrlf", "false" },
                 { "core.safecrlf", "false" },
+                { "core.repositoryFormatVersion", "1" },
             };
 
             if (this.UseGvfsProtocol.Value)

--- a/Scalar.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
+++ b/Scalar.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
@@ -145,6 +145,9 @@ namespace Scalar.FunctionalTests.Tests.GitCommands
 
                 GitProcess.InvokeProcess(this.ControlGitRepo.RootPath, "sparse-checkout init --cone", string.Empty);
                 GitProcess.InvokeProcess(this.ControlGitRepo.RootPath, "sparse-checkout set --stdin", sb.ToString());
+
+                // This line shouldn't be necessary!
+                GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "sparse-checkout init --cone", string.Empty);
                 GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "sparse-checkout set --stdin", sb.ToString());
                 this.pathPrefixes = SparseModeFolders;
             }

--- a/Scalar.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
+++ b/Scalar.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
@@ -132,26 +132,6 @@ namespace Scalar.FunctionalTests.Tests.GitCommands
                 this.CreateEnlistment();
             }
 
-            if (this.validateWorkingTree == Settings.ValidateWorkingTreeMode.SparseMode)
-            {
-                StringBuilder sb = new StringBuilder();
-
-                foreach (string folder in SparseModeFolders)
-                {
-                    sb.Append(folder.Replace(Path.DirectorySeparatorChar, TestConstants.GitPathSeparator)
-                                    .Trim(TestConstants.GitPathSeparator));
-                    sb.Append("\n");
-                }
-
-                GitProcess.InvokeProcess(this.ControlGitRepo.RootPath, "sparse-checkout init --cone", string.Empty);
-                GitProcess.InvokeProcess(this.ControlGitRepo.RootPath, "sparse-checkout set --stdin", sb.ToString());
-
-                // This line shouldn't be necessary!
-                GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "sparse-checkout init --cone", string.Empty);
-                GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "sparse-checkout set --stdin", sb.ToString());
-                this.pathPrefixes = SparseModeFolders;
-            }
-
             this.ValidateGitCommand("checkout " + this.ControlGitRepo.Commitish);
 
             this.CheckHeadCommitTree();
@@ -221,6 +201,26 @@ namespace Scalar.FunctionalTests.Tests.GitCommands
             GitProcess.Invoke(this.Enlistment.RepoRoot, "config advice.statusUoption false");
             this.ControlGitRepo = ControlGitRepo.Create(commitish);
             this.ControlGitRepo.Initialize();
+
+            if (this.validateWorkingTree == Settings.ValidateWorkingTreeMode.SparseMode)
+            {
+                StringBuilder sb = new StringBuilder();
+
+                foreach (string folder in SparseModeFolders)
+                {
+                    sb.Append(folder.Replace(Path.DirectorySeparatorChar, TestConstants.GitPathSeparator)
+                                    .Trim(TestConstants.GitPathSeparator));
+                    sb.Append("\n");
+                }
+
+                GitProcess.InvokeProcess(this.ControlGitRepo.RootPath, "sparse-checkout init --cone", string.Empty);
+                GitProcess.InvokeProcess(this.ControlGitRepo.RootPath, "sparse-checkout set --stdin", sb.ToString());
+
+                // This line shouldn't be necessary!
+                GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "sparse-checkout init --cone", string.Empty);
+                GitProcess.InvokeProcess(this.Enlistment.RepoRoot, "sparse-checkout set --stdin", sb.ToString());
+                this.pathPrefixes = SparseModeFolders;
+            }
         }
 
         protected virtual void DeleteEnlistment()


### PR DESCRIPTION
See microsoft/git#283.

The new logic around `core.repositoryFormatVersion` and `extensions.*` config options causes problems in Scalar due to our use of sparse-checkout. This is resolved by some upstream fixes and some more careful config here.