### PR TITLE
CheckGitVersion: improve error messages

### DIFF
--- a/Scalar/CommandLine/ScalarVerb.cs
+++ b/Scalar/CommandLine/ScalarVerb.cs
@@ -492,24 +492,30 @@ You can specify a URL, a name of a configured cache server, or the special names
         private void CheckGitVersion(ITracer tracer, ScalarEnlistment enlistment, out string version)
         {
             GitVersion gitVersion = null;
-            if (string.IsNullOrEmpty(enlistment.GitBinPath) || !GitProcess.TryGetVersion(enlistment.GitBinPath, out gitVersion, out string _))
+            if (string.IsNullOrEmpty(enlistment.GitBinPath))
             {
-                this.ReportErrorAndExit(tracer, "Error: Unable to retrieve the git version");
+                this.ReportErrorAndExit(tracer, "Unable to find Git version on PATH");
+            }
+
+            if (!GitProcess.TryGetVersion(enlistment.GitBinPath, out gitVersion, out string error))
+            {
+                this.ReportErrorAndExit(tracer, $"Unable to parse Git version at '{enlistment.GitBinPath}':\n{error}");
             }
 
             version = gitVersion.ToString();
 
             if (gitVersion.Platform != ScalarConstants.SupportedGitVersion.Platform)
             {
-                this.ReportErrorAndExit(tracer, "Error: Invalid version of git {0}.  Must use scalar version.", version);
+                this.ReportErrorAndExit(tracer, "Error: Invalid version of git {0} at {1}.  Must use scalar version.", version, enlistment.GitBinPath);
             }
 
             if (gitVersion.IsLessThan(ScalarConstants.SupportedGitVersion))
             {
                 this.ReportErrorAndExit(
                     tracer,
-                    "Error: Installed git version {0} is less than the supported version of {1}.",
+                    "Error: Installed git version {0} at {1} is less than the supported version of {2}.",
                     gitVersion,
+                    enlistment.GitBinPath,
                     ScalarConstants.SupportedGitVersion);
             }
         }


### PR DESCRIPTION
A user reported issues with parsing our Git version when cloning. Our
best guess of what happened is that the build machine already had a
version of Git, but it was in a different location whan where our `brew`
formula placed our version of Git. This led the parser to not see a
`.vfs.` in the version string and fail.

Let's make this error more informative. While we are here, split the
failure condition into two distinct cases:

1. We can't find Git anywhere.
2. We can't parse the Git version.

Signed-off-by: Derrick Stolee <dstolee@microsoft.com>