### PR TITLE
Detect Git features (the GVFS Protocol) based on the version

### DIFF
--- a/Scalar.Common/Git/GitFeatureFlags.cs
+++ b/Scalar.Common/Git/GitFeatureFlags.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace Scalar.Common.Git
+{
+    /// <summary>
+    /// Identifies a set of features that Git may support that we are interested in.
+    /// </summary>
+    [Flags]
+    public enum GitFeatureFlags
+    {
+        None = 0,
+
+        /// <summary>
+        /// Support for the GVFS protocol.
+        /// </summary>
+        GvfsProtocol = 1 << 0,
+    }
+}

--- a/Scalar.Common/Git/GitVersion.cs
+++ b/Scalar.Common/Git/GitVersion.cs
@@ -21,6 +21,22 @@ namespace Scalar.Common.Git
         public int Revision { get; private set; }
         public int MinorRevision { get; private set; }
 
+        /// <summary>
+        /// Determine the set of Git features that are supported this version of Git.
+        /// </summary>
+        /// <returns>Set of Git features.</returns>
+        public GitFeatureFlags GetFeatures()
+        {
+            var flags = GitFeatureFlags.None;
+
+            if (StringComparer.OrdinalIgnoreCase.Equals(Platform, "vfs"))
+            {
+                flags |= GitFeatureFlags.GvfsProtocol;
+            }
+
+            return flags;
+        }
+
         public static bool TryParseGitVersionCommandResult(string input, out GitVersion version)
         {
             // git version output is of the form

--- a/Scalar.UnitTests/Common/GitVersionTests.cs
+++ b/Scalar.UnitTests/Common/GitVersionTests.cs
@@ -72,7 +72,31 @@ namespace Scalar.UnitTests.Common
         public void Version_Data_Valid_Returns_True()
         {
             GitVersion version;
+            bool success = GitVersion.TryParseVersion("2.0.1", out version);
+            success.ShouldEqual(true);
+        }
+
+        [TestCase]
+        public void Version_Data_Valid_With_RC_Returns_True()
+        {
+            GitVersion version;
+            bool success = GitVersion.TryParseVersion("2.0.1-rc3", out version);
+            success.ShouldEqual(true);
+        }
+
+        [TestCase]
+        public void Version_Data_Valid_With_Platform_Returns_True()
+        {
+            GitVersion version;
             bool success = GitVersion.TryParseVersion("2.0.1.test.1.2", out version);
+            success.ShouldEqual(true);
+        }
+
+        [TestCase]
+        public void Version_Data_Valid_With_RC_And_Platform_Returns_True()
+        {
+            GitVersion version;
+            bool success = GitVersion.TryParseVersion("2.0.1-rc3.test.1.2", out version);
             success.ShouldEqual(true);
         }
 
@@ -205,6 +229,7 @@ namespace Scalar.UnitTests.Common
             version.Major.ShouldEqual(1);
             version.Minor.ShouldEqual(2);
             version.Build.ShouldEqual(3);
+            version.ReleaseCandidate.ShouldEqual(null);
             version.Platform.ShouldEqual("test");
             version.Revision.ShouldEqual(4);
             version.MinorRevision.ShouldEqual(0);
@@ -219,8 +244,54 @@ namespace Scalar.UnitTests.Common
             version.Major.ShouldEqual(1);
             version.Minor.ShouldEqual(2);
             version.Build.ShouldEqual(3);
+            version.ReleaseCandidate.ShouldEqual(null);
             version.Platform.ShouldEqual("test");
             version.Revision.ShouldEqual(4);
+            version.MinorRevision.ShouldEqual(0);
+        }
+
+        [TestCase]
+        public void Allow_ReleaseCandidate()
+        {
+            GitVersion version;
+            GitVersion.TryParseVersion("1.2.3-rc4", out version).ShouldEqual(true);
+
+            version.Major.ShouldEqual(1);
+            version.Minor.ShouldEqual(2);
+            version.Build.ShouldEqual(3);
+            version.ReleaseCandidate.ShouldEqual(4);
+            version.Platform.ShouldBeNull();
+            version.Revision.ShouldEqual(0);
+            version.MinorRevision.ShouldEqual(0);
+        }
+
+        [TestCase]
+        public void Allow_ReleaseCandidate_Platform()
+        {
+            GitVersion version;
+            GitVersion.TryParseVersion("1.2.3-rc4.test", out version).ShouldEqual(true);
+
+            version.Major.ShouldEqual(1);
+            version.Minor.ShouldEqual(2);
+            version.Build.ShouldEqual(3);
+            version.ReleaseCandidate.ShouldEqual(4);
+            version.Platform.ShouldEqual("test");
+            version.Revision.ShouldEqual(0);
+            version.MinorRevision.ShouldEqual(0);
+        }
+
+        [TestCase]
+        public void Allow_LocalGitBuildVersion_ParseMajorMinorBuildOnly()
+        {
+            GitVersion version;
+            GitVersion.TryParseVersion("1.2.3.456.abcdefg.hijk", out version).ShouldEqual(true);
+
+            version.Major.ShouldEqual(1);
+            version.Minor.ShouldEqual(2);
+            version.Build.ShouldEqual(3);
+            version.ReleaseCandidate.ShouldEqual(null);
+            version.Platform.ShouldEqual("456");
+            version.Revision.ShouldEqual(0);
             version.MinorRevision.ShouldEqual(0);
         }
 
@@ -233,6 +304,7 @@ namespace Scalar.UnitTests.Common
             version.Major.ShouldEqual(1);
             version.Minor.ShouldEqual(2);
             version.Build.ShouldEqual(3);
+            version.ReleaseCandidate.ShouldEqual(null);
             version.Platform.ShouldEqual("scalar");
             version.Revision.ShouldEqual(4);
             version.MinorRevision.ShouldEqual(5);

--- a/Scalar.UnitTests/Common/GitVersionTests.cs
+++ b/Scalar.UnitTests/Common/GitVersionTests.cs
@@ -17,8 +17,12 @@ namespace Scalar.UnitTests.Common
         }
 
         [TestCase]
-        public void GetFeatureFlags_NormalGitVersion_ReturnsGvfsProtocolSupported()
+        public void GetFeatureFlags_NormalGitVersion_ReturnsGvfsProtocolNotSupported()
         {
+            var gitGitVersion = new GitVersion(2, 28, 0);
+            GitFeatureFlags gitGitFeatures = gitGitVersion.GetFeatures();
+            gitGitFeatures.HasFlag(GitFeatureFlags.GvfsProtocol).ShouldBeFalse();
+
             var winGitVersion = new GitVersion(2, 28, 0, "windows", 1, 1);
             GitFeatureFlags winGitFeatures = winGitVersion.GetFeatures();
             winGitFeatures.HasFlag(GitFeatureFlags.GvfsProtocol).ShouldBeFalse();
@@ -52,7 +56,7 @@ namespace Scalar.UnitTests.Common
         public void Version_Data_Not_Enough_Numbers_Returns_False()
         {
             GitVersion version;
-            bool success = GitVersion.TryParseVersion("2.0.1.test", out version);
+            bool success = GitVersion.TryParseVersion("2.0", out version);
             success.ShouldEqual(false);
         }
 

--- a/Scalar.UnitTests/Common/GitVersionTests.cs
+++ b/Scalar.UnitTests/Common/GitVersionTests.cs
@@ -295,6 +295,21 @@ namespace Scalar.UnitTests.Common
             version.MinorRevision.ShouldEqual(0);
         }
 
+        [TestCase]
+        public void Allow_GarbageBuildVersion_ParseMajorMinorBuildOnly()
+        {
+            GitVersion version;
+            GitVersion.TryParseVersion("1.2.3.test.4.5.6.7.g1234abcd.8.9.😀.10.11.dirty.MSVC", out version).ShouldEqual(true);
+
+            version.Major.ShouldEqual(1);
+            version.Minor.ShouldEqual(2);
+            version.Build.ShouldEqual(3);
+            version.ReleaseCandidate.ShouldEqual(null);
+            version.Platform.ShouldEqual("test");
+            version.Revision.ShouldEqual(4);
+            version.MinorRevision.ShouldEqual(5);
+        }
+
         private void ParseAndValidateInstallerVersion(string installerName)
         {
             GitVersion version;

--- a/Scalar.UnitTests/Common/GitVersionTests.cs
+++ b/Scalar.UnitTests/Common/GitVersionTests.cs
@@ -9,6 +9,22 @@ namespace Scalar.UnitTests.Common
     public class GitVersionTests
     {
         [TestCase]
+        public void GetFeatureFlags_VfsGitVersion_ReturnsGvfsProtocolSupported()
+        {
+            var version = new GitVersion(2, 28, 0, "vfs", 1, 0);
+            GitFeatureFlags features = version.GetFeatures();
+            features.HasFlag(GitFeatureFlags.GvfsProtocol).ShouldBeTrue();
+        }
+
+        [TestCase]
+        public void GetFeatureFlags_NormalGitVersion_ReturnsGvfsProtocolSupported()
+        {
+            var winGitVersion = new GitVersion(2, 28, 0, "windows", 1, 1);
+            GitFeatureFlags winGitFeatures = winGitVersion.GetFeatures();
+            winGitFeatures.HasFlag(GitFeatureFlags.GvfsProtocol).ShouldBeFalse();
+        }
+
+        [TestCase]
         public void TryParseInstallerName()
         {
             this.ParseAndValidateInstallerVersion("Git-1.2.3.scalar.4.5.gb16030b-64-bit" + ScalarPlatform.Instance.Constants.InstallerExtension);

--- a/Scalar/CommandLine/CloneVerb.cs
+++ b/Scalar/CommandLine/CloneVerb.cs
@@ -227,13 +227,13 @@ namespace Scalar.CommandLine
             }
 
             // Do not try GVFS authentication on SSH URLs or when we don't have Git support for the GVFS protocol
-            bool isSshRemote = this.enlistment.RepoUrl.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
+            bool isHttpsRemote = this.enlistment.RepoUrl.StartsWith("https://", StringComparison.OrdinalIgnoreCase);
             bool supportsGvfsProtocol = (gitFeatures & GitFeatureFlags.GvfsProtocol) != 0;
-            if (isSshRemote || !supportsGvfsProtocol)
+            if (!isHttpsRemote || !supportsGvfsProtocol)
             {
                 // Perform a normal Git clone because we cannot use the GVFS protocol
-                this.tracer.RelatedInfo("Skipping GVFS protocol check (isSshRemote={0}, supportsGvfsProtocol={1})",
-                    isSshRemote, supportsGvfsProtocol);
+                this.tracer.RelatedInfo("Skipping GVFS protocol check (isHttpsRemote={0}, supportsGvfsProtocol={1})",
+                    isHttpsRemote, supportsGvfsProtocol);
                 this.Output.WriteLine("Skipping GVFS protocol check...");
                 return this.GitClone();
             }


### PR DESCRIPTION
Add a way to get a list of features that a version of Git supports, such as support for the GVFS protocol.
With this we can better handle and support users of Scalar that are not using Azure DevOps or the Microsoft fork of Git.

In the future we can also gate behaviour on other features such as `--changed-paths`.

Implements #380

**TODO:**
- [x] Modify the `CloneVerb` to respond to a lack of GVFS protocol support
- [ ] TESTS!