### PR TITLE
ControlGitRepo.cs: switch to 'git branch --set-upstream-to'

### DIFF
--- a/Scalar.FunctionalTests/Tools/ControlGitRepo.cs
+++ b/Scalar.FunctionalTests/Tools/ControlGitRepo.cs
@@ -62,7 +62,7 @@ namespace Scalar.FunctionalTests.Tools
             GitProcess.Invoke(this.RootPath, "config user.email \"functional@test.com\"");
             GitProcess.Invoke(this.RootPath, "remote add origin " + CachePath);
             this.Fetch(this.Commitish);
-            GitProcess.Invoke(this.RootPath, "branch --set-upstream " + this.Commitish + " origin/" + this.Commitish);
+            GitProcess.Invoke(this.RootPath, "branch --set-upstream-to " + this.Commitish + " origin/" + this.Commitish);
             GitProcess.Invoke(this.RootPath, "checkout " + this.Commitish);
             GitProcess.Invoke(this.RootPath, "branch --unset-upstream");
         }


### PR DESCRIPTION
Support for 'git branch --set-upstream' was finally dropped in v2.15 and
now causes Git to call die().  See 52668846ea2d41ffbd87cda7cb8e492dea9f2c4d.

Update our usage in the functional test suite to use the new form:
'git branch --set-upstream-to'.

This was causing 70+ Git commands to fail in the functional test suite
(from the error alone and an unknown number of tests to fail because
the worktree was not updated as expected).

Signed-off-by: Jeff Hostetler <jeffhost@microsoft.com>