### PR TITLE
Add initial Linux platform and scripts

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,7 +25,7 @@
     <BaseIntermediateOutputPath>$(ProjectOutPath)obj\</BaseIntermediateOutputPath>
 
     <!-- Common build properties -->
-    <RuntimeIdentifiers>win10-x64;osx-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win10-x64;osx-x64;linux-x64</RuntimeIdentifiers>
     <Deterministic>true</Deterministic>
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <CodeAnalysisRuleSet>$(RepoPath)Scalar.ruleset</CodeAnalysisRuleSet>

--- a/Scalar.Common/Platforms/Linux/LinuxFileBasedLock.cs
+++ b/Scalar.Common/Platforms/Linux/LinuxFileBasedLock.cs
@@ -1,0 +1,133 @@
+using Scalar.Common;
+using Scalar.Common.FileSystem;
+using Scalar.Common.Tracing;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Scalar.Platform.Linux
+{
+    public class LinuxFileBasedLock : FileBasedLock
+    {
+        private int lockFileDescriptor;
+
+        public LinuxFileBasedLock(
+            PhysicalFileSystem fileSystem,
+            ITracer tracer,
+            string lockPath)
+            : base(fileSystem, tracer, lockPath)
+        {
+            this.lockFileDescriptor = NativeMethods.InvalidFileDescriptor;
+        }
+
+        public override bool TryAcquireLock()
+        {
+            if (this.lockFileDescriptor == NativeMethods.InvalidFileDescriptor)
+            {
+                this.FileSystem.CreateDirectory(Path.GetDirectoryName(this.LockPath));
+
+                this.lockFileDescriptor = NativeMethods.Open(
+                    this.LockPath,
+                    NativeMethods.OpenCreate | NativeMethods.OpenWriteOnly,
+                    NativeMethods.FileMode644);
+
+                if (this.lockFileDescriptor == NativeMethods.InvalidFileDescriptor)
+                {
+                    int errno = Marshal.GetLastWin32Error();
+                    EventMetadata metadata = this.CreateEventMetadata(errno);
+                    this.Tracer.RelatedWarning(
+                        metadata,
+                        $"{nameof(LinuxFileBasedLock)}.{nameof(this.TryAcquireLock)}: Failed to open lock file");
+
+                    return false;
+                }
+            }
+
+            if (NativeMethods.FLock(this.lockFileDescriptor, NativeMethods.LockEx | NativeMethods.LockNb) != 0)
+            {
+                int errno = Marshal.GetLastWin32Error();
+                if (errno != NativeMethods.EIntr && errno != NativeMethods.EWouldBlock)
+                {
+                    EventMetadata metadata = this.CreateEventMetadata(errno);
+                    this.Tracer.RelatedWarning(
+                        metadata,
+                        $"{nameof(LinuxFileBasedLock)}.{nameof(this.TryAcquireLock)}: Unexpected error when locking file");
+                }
+
+                return false;
+            }
+
+            return true;
+        }
+
+        public override void Dispose()
+        {
+            if (this.lockFileDescriptor != NativeMethods.InvalidFileDescriptor)
+            {
+                if (NativeMethods.Close(this.lockFileDescriptor) != 0)
+                {
+                    // Failures of close() are logged for diagnostic purposes only.
+                    // It's possible that errors from a previous operation (e.g. write(2))
+                    // are only reported in close().  We should *not* retry the close() if
+                    // it fails since it may cause a re-used file descriptor from another
+                    // thread to be closed.
+
+                    int errno = Marshal.GetLastWin32Error();
+                    EventMetadata metadata = this.CreateEventMetadata(errno);
+                    this.Tracer.RelatedWarning(
+                        metadata,
+                        $"{nameof(LinuxFileBasedLock)}.{nameof(this.Dispose)}: Error when closing lock fd");
+                }
+
+                this.lockFileDescriptor = NativeMethods.InvalidFileDescriptor;
+            }
+        }
+
+        private EventMetadata CreateEventMetadata(int errno = 0)
+        {
+            EventMetadata metadata = new EventMetadata();
+            metadata.Add("Area", nameof(LinuxFileBasedLock));
+            metadata.Add(nameof(this.LockPath), this.LockPath);
+            if (errno != 0)
+            {
+                metadata.Add(nameof(errno), errno);
+            }
+
+            return metadata;
+        }
+
+        private static class NativeMethods
+        {
+            // #define O_WRONLY    0x0001      /* open for writing only */
+            public const int OpenWriteOnly = 0x0001;
+
+            // #define O_CREAT     0x0200      /* create if nonexistant */
+            public const int OpenCreate = 0x0040;
+
+            // #define EINTR       4       /* Interrupted system call */
+            public const int EIntr = 4;
+
+            // #define EAGAIN      11      /* Resource temporarily unavailable */
+            // #define EWOULDBLOCK EAGAIN  /* Operation would block */
+            public const int EWouldBlock = 11;
+
+            public const int LockSh = 1; // #define LOCK_SH   1    /* shared lock */
+            public const int LockEx = 2; // #define LOCK_EX   2    /* exclusive lock */
+            public const int LockNb = 4; // #define LOCK_NB   4    /* don't block when locking */
+            public const int LockUn = 8; // #define LOCK_UN   8    /* unlock */
+
+            public const int InvalidFileDescriptor = -1;
+
+            public static readonly uint FileMode644 = Convert.ToUInt32("644", 8);
+
+            [DllImport("libc", EntryPoint = "open", SetLastError = true)]
+            public static extern int Open(string pathname, int flags, uint mode);
+
+            [DllImport("libc", EntryPoint = "close", SetLastError = true)]
+            public static extern int Close(int fd);
+
+            [DllImport("libc", EntryPoint = "flock", SetLastError = true)]
+            public static extern int FLock(int fd, int operation);
+        }
+    }
+}

--- a/Scalar.Common/Platforms/Linux/LinuxFileSystem.cs
+++ b/Scalar.Common/Platforms/Linux/LinuxFileSystem.cs
@@ -1,0 +1,110 @@
+using Scalar.Common;
+using Scalar.Platform.POSIX;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Scalar.Platform.Linux
+{
+    public class LinuxFileSystem : POSIXFileSystem
+    {
+        public override bool IsExecutable(string fileName)
+        {
+            NativeStat.StatBuffer statBuffer = this.StatFile(fileName);
+            return NativeStat.IsExecutable(statBuffer.Mode);
+        }
+
+        public override bool IsSocket(string fileName)
+        {
+            NativeStat.StatBuffer statBuffer = this.StatFile(fileName);
+            return NativeStat.IsSock(statBuffer.Mode);
+        }
+
+        public override bool IsFileSystemSupported(string path, out string error)
+        {
+            error = null;
+            return true;
+        }
+
+        private NativeStat.StatBuffer StatFile(string fileName)
+        {
+            if (NativeStat.Stat(fileName, out NativeStat.StatBuffer statBuffer) != 0)
+            {
+                NativeMethods.ThrowLastWin32Exception($"Failed to stat {fileName}");
+            }
+
+            return statBuffer;
+        }
+
+        private static class NativeStat
+        {
+            // #define  S_IFMT      0170000     /* [XSI] type of file mask */
+            private static readonly uint IFMT = Convert.ToUInt32("170000", 8);
+
+            // #define  S_IFSOCK    0140000     /* [XSI] socket */
+            private static readonly uint IFSOCK = Convert.ToUInt32("0140000", 8);
+
+            // #define S_IXUSR     0000100     /* [XSI] X for owner */
+            private static readonly uint IXUSR = Convert.ToUInt32("100", 8);
+
+            // #define S_IXGRP     0000010     /* [XSI] X for group */
+            private static readonly uint IXGRP = Convert.ToUInt32("10", 8);
+
+            // #define S_IXOTH     0000001     /* [XSI] X for other */
+            private static readonly uint IXOTH = Convert.ToUInt32("1", 8);
+
+            // #define _STAT_VER   1
+            private static readonly int STAT_VER = 1;
+
+            public static bool IsSock(uint mode)
+            {
+                // #define  S_ISSOCK(m) (((m) & S_IFMT) == S_IFSOCK)    /* socket */
+                return (mode & IFMT) == IFSOCK;
+            }
+
+            public static bool IsExecutable(uint mode)
+            {
+                return (mode & (IXUSR | IXGRP | IXOTH)) != 0;
+            }
+
+            public static int Stat(string path, [Out] out StatBuffer buf)
+            {
+                return __XStat64(STAT_VER, path, out buf);
+            }
+
+            // TODO(Linux): assumes recent GNU libc or ABI-compatible libc
+            [DllImport("libc", EntryPoint = "__xstat64", SetLastError = true)]
+            private static extern int __XStat64(int vers, string path, [Out] out StatBuffer buf);
+
+            [StructLayout(LayoutKind.Sequential)]
+            public struct TimeSpec
+            {
+                public long Sec;
+                public long Nsec;
+            }
+
+            // TODO(Linux): assumes stat64 field layout of x86-64 architecture
+            [StructLayout(LayoutKind.Sequential)]
+            public struct StatBuffer
+            {
+                public ulong Dev;           /* ID of device containing file */
+                public ulong Ino;           /* File serial number */
+                public ulong NLink;         /* Number of hard links */
+                public uint Mode;           /* Mode of file (see below) */
+                public uint UID;            /* User ID of the file */
+                public uint GID;            /* Group ID of the file */
+                public uint Padding;        /* RESERVED: DO NOT USE! */
+                public ulong RDev;          /* Device ID if special file */
+                public long Size;           /* file size, in bytes */
+                public long BlkSize;        /* optimal blocksize for I/O */
+                public long Blocks;         /* blocks allocated for file */
+                public TimeSpec ATimespec;  /* time of last access */
+                public TimeSpec MTimespec;  /* time of last data modification */
+                public TimeSpec CTimespec;  /* time of last status change */
+
+                [MarshalAs(UnmanagedType.ByValArray, SizeConst = 3)]
+                private long[] reserved;     /* RESERVED: DO NOT USE! */
+            }
+        }
+    }
+}

--- a/Scalar.Common/Platforms/Linux/LinuxPlatform.Shared.cs
+++ b/Scalar.Common/Platforms/Linux/LinuxPlatform.Shared.cs
@@ -1,0 +1,37 @@
+using System;
+using System.IO;
+using Scalar.Common;
+using Scalar.Platform.POSIX;
+
+namespace Scalar.Platform.Linux
+{
+    public partial class LinuxPlatform
+    {
+        public static string GetDataRootForScalarImplementation()
+        {
+            // TODO(Linux): determine installation location and data path
+            string path = Environment.GetEnvironmentVariable("SCALAR_DATA_PATH");
+            return path ?? "/var/run/scalar";
+        }
+
+        public static string GetDataRootForScalarComponentImplementation(string componentName)
+        {
+            return Path.Combine(GetDataRootForScalarImplementation(), componentName);
+        }
+
+        public static string GetUpgradeHighestAvailableVersionDirectoryImplementation()
+        {
+            return GetUpgradeNonProtectedDirectoryImplementation();
+        }
+
+        public static string GetUpgradeNonProtectedDirectoryImplementation()
+        {
+            return Path.Combine(GetDataRootForScalarImplementation(), ProductUpgraderInfo.UpgradeDirectoryName);
+        }
+
+        private string GetUpgradeNonProtectedDataDirectory()
+        {
+            return GetUpgradeNonProtectedDirectoryImplementation();
+        }
+    }
+}

--- a/Scalar.Common/Platforms/Linux/LinuxPlatform.cs
+++ b/Scalar.Common/Platforms/Linux/LinuxPlatform.cs
@@ -1,0 +1,194 @@
+using Scalar.Common;
+using Scalar.Common.FileSystem;
+using Scalar.Common.Tracing;
+using Scalar.Platform.POSIX;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+using System.Xml.XPath;
+
+namespace Scalar.Platform.Linux
+{
+    public partial class LinuxPlatform : POSIXPlatform
+    {
+        // TODO(Linux): determine installation location and upgrader path
+        private const string UpgradeProtectedDataDirectory = "/usr/local/scalar_upgrader";
+
+        public LinuxPlatform() : base(
+             underConstruction: new UnderConstructionFlags(
+                supportsScalarUpgrade: false,
+                supportsScalarConfig: true,
+                supportsNuGetEncryption: false,
+                supportsNuGetVerification: false))
+        {
+        }
+
+        public override string Name { get => "Linux"; }
+        public override ScalarPlatformConstants Constants { get; } = new LinuxPlatformConstants();
+        public override IPlatformFileSystem FileSystem { get; } = new LinuxFileSystem();
+
+        public override string ScalarConfigPath
+        {
+            get
+            {
+                return Path.Combine(this.Constants.ScalarBinDirectoryPath, LocalScalarConfig.FileName);
+            }
+        }
+
+        public override string GetOSVersionInformation()
+        {
+            ProcessResult result = ProcessHelper.Run("uname", args: "-srv", redirectOutput: true);
+            return string.IsNullOrWhiteSpace(result.Output) ? result.Errors : result.Output;
+        }
+
+        public override string GetCommonAppDataRootForScalar()
+        {
+            return LinuxPlatform.GetDataRootForScalarImplementation();
+        }
+
+        public override string GetCommonAppDataRootForScalarComponent(string componentName)
+        {
+            return LinuxPlatform.GetDataRootForScalarComponentImplementation(componentName);
+        }
+
+        public override string GetSecureDataRootForScalar()
+        {
+            // SecureDataRoot is Windows only. On Linux, it is the same as CommoAppDataRoot
+            return this.GetCommonAppDataRootForScalar();
+        }
+
+        public override string GetSecureDataRootForScalarComponent(string componentName)
+        {
+            // SecureDataRoot is Windows only. On Linux, it is the same as CommoAppDataRoot
+            return this.GetCommonAppDataRootForScalarComponent(componentName);
+        }
+
+        public override string GetLogsDirectoryForGVFSComponent(string componentName)
+        {
+            return Path.Combine(this.GetCommonAppDataRootForScalarComponent(componentName), "Logs");
+        }
+
+        public override FileBasedLock CreateFileBasedLock(
+            PhysicalFileSystem fileSystem,
+            ITracer tracer,
+            string lockPath)
+        {
+            return new LinuxFileBasedLock(fileSystem, tracer, lockPath);
+        }
+
+        public override string GetUpgradeProtectedDataDirectory()
+        {
+            return UpgradeProtectedDataDirectory;
+        }
+
+        public override string GetUpgradeHighestAvailableVersionDirectory()
+        {
+            return GetUpgradeHighestAvailableVersionDirectoryImplementation();
+        }
+
+        /// <summary>
+        /// This is the directory in which the upgradelogs directory should go.
+        /// There can be multiple logs directories, so here we return the containing
+        /// directory.
+        /// </summary>
+        public override string GetUpgradeLogDirectoryParentDirectory()
+        {
+            return this.GetUpgradeNonProtectedDataDirectory();
+        }
+
+        public override ProductUpgraderPlatformStrategy CreateProductUpgraderPlatformInteractions(
+            PhysicalFileSystem fileSystem,
+            ITracer tracer)
+        {
+            return new LinuxProductUpgraderPlatformStrategy(fileSystem, tracer);
+        }
+
+        public override void IsServiceInstalledAndRunning(string name, out bool installed, out bool running)
+        {
+            installed = false;
+            running = false;
+        }
+
+        public override string GetTemplateHooksDirectory()
+        {
+            string gitExecPath = GitInstallation.GetInstalledGitBinPath();
+
+            // Resolve symlinks
+            string resolvedExecPath = NativeMethods.ResolveSymlink(gitExecPath);
+
+            // Get the containing bin directory
+            string gitBinDir = Path.GetDirectoryName(resolvedExecPath);
+
+            // Compute the base installation path (../)
+            string installBaseDir = Path.GetDirectoryName(gitBinDir);
+            installBaseDir = Path.GetFullPath(installBaseDir);
+
+            return Path.Combine(installBaseDir, ScalarConstants.InstalledGit.HookTemplateDir);
+        }
+
+        public class LinuxPlatformConstants : POSIXPlatformConstants
+        {
+            public override string InstallerExtension
+            {
+                get { return ".deb"; }
+            }
+
+            public override string ScalarBinDirectoryPath
+            {
+                get { return Path.Combine("/usr", "local", this.ScalarBinDirectoryName); }
+            }
+
+            public override string ScalarBinDirectoryName
+            {
+                get { return "scalar"; }
+            }
+
+            // Documented here (in the addressing section): https://www.unix.com/man-page/linux/7/unix/
+            public override int MaxPipePathLength => 108;
+        }
+
+        private static class NativeMethods
+        {
+            // Definitions from
+            // /Library/Developer/CommandLineTools/SDKs/LinuxOSX.sdk
+
+            // stdlib.h
+            [DllImport("libc", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)]
+            private static extern IntPtr realpath([In] IntPtr file_name, [In, Out] IntPtr resolved_name);
+
+            public static string ResolveSymlink(string path)
+            {
+                // Defined in linux/limits.h
+                const int PATH_MAX = 4096;
+
+                IntPtr pathBuf = IntPtr.Zero;
+                IntPtr resolvedBuf = IntPtr.Zero;
+
+                try
+                {
+                    pathBuf = Marshal.StringToHGlobalAuto(path);
+                    resolvedBuf = Marshal.AllocHGlobal(PATH_MAX + 1);
+                    IntPtr result = realpath(pathBuf, resolvedBuf);
+
+                    if (result == IntPtr.Zero)
+                    {
+                        // Failed!
+                        return null;
+                    }
+
+                    return Marshal.PtrToStringUTF8(resolvedBuf);
+                }
+                finally
+                {
+                    if (pathBuf != IntPtr.Zero) Marshal.FreeHGlobal(pathBuf);
+                    if (resolvedBuf != IntPtr.Zero) Marshal.FreeHGlobal(resolvedBuf);
+                }
+            }
+        }
+    }
+}

--- a/Scalar.Common/Platforms/Linux/LinuxProductUpgraderPlatformStrategy.cs
+++ b/Scalar.Common/Platforms/Linux/LinuxProductUpgraderPlatformStrategy.cs
@@ -1,0 +1,62 @@
+using Scalar.Common;
+using Scalar.Common.FileSystem;
+using Scalar.Common.Tracing;
+using System;
+using System.IO;
+
+namespace Scalar.Platform.Linux
+{
+    public class LinuxProductUpgraderPlatformStrategy : ProductUpgraderPlatformStrategy
+    {
+        public LinuxProductUpgraderPlatformStrategy(PhysicalFileSystem fileSystem, ITracer tracer)
+        : base(fileSystem, tracer)
+        {
+        }
+
+        public override bool TryPrepareLogDirectory(out string error)
+        {
+            error = null;
+            return true;
+        }
+
+        public override bool TryPrepareApplicationDirectory(out string error)
+        {
+            string upgradeApplicationDirectory = ProductUpgraderInfo.GetUpgradeApplicationDirectory();
+
+            Exception deleteDirectoryException;
+            if (this.FileSystem.DirectoryExists(upgradeApplicationDirectory) &&
+                !this.FileSystem.TryDeleteDirectory(upgradeApplicationDirectory, out deleteDirectoryException))
+            {
+                error = $"Failed to delete {upgradeApplicationDirectory} - {deleteDirectoryException.Message}";
+
+                this.TraceException(deleteDirectoryException, nameof(this.TryPrepareApplicationDirectory), $"Error deleting {upgradeApplicationDirectory}.");
+                return false;
+            }
+
+            this.FileSystem.CreateDirectory(upgradeApplicationDirectory);
+
+            error = null;
+            return true;
+        }
+
+        public override bool TryPrepareDownloadDirectory(out string error)
+        {
+            string directory = ProductUpgraderInfo.GetAssetDownloadsPath();
+
+            Exception deleteDirectoryException;
+            if (this.FileSystem.DirectoryExists(directory) &&
+                !this.FileSystem.TryDeleteDirectory(directory, out deleteDirectoryException))
+            {
+                error = $"Failed to delete {directory} - {deleteDirectoryException.Message}";
+
+                this.TraceException(deleteDirectoryException, nameof(this.TryPrepareDownloadDirectory), $"Error deleting {directory}.");
+                return false;
+            }
+
+            this.FileSystem.CreateDirectory(directory);
+
+            error = null;
+            return true;
+        }
+    }
+}

--- a/Scalar.Common/Platforms/PlatformLoader.cs
+++ b/Scalar.Common/Platforms/PlatformLoader.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 using Scalar.Common;
+using Scalar.Platform.Linux;
 using Scalar.Platform.Mac;
 using Scalar.Platform.Windows;
 
@@ -17,6 +18,10 @@ namespace Scalar.PlatformLoader
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 ScalarPlatform.Register(new MacPlatform());
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                ScalarPlatform.Register(new LinuxPlatform());
             }
             else
             {

--- a/Scripts/Linux/BuildScalarForLinux.sh
+++ b/Scripts/Linux/BuildScalarForLinux.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+. "$(dirname ${BASH_SOURCE[0]})/InitializeEnvironment.sh"
+
+CONFIGURATION=$1
+if [ -z $CONFIGURATION ]; then
+  CONFIGURATION=Debug
+fi
+
+VERSION=$2
+if [ -z $VERSION ]; then
+  VERSION="0.2.173.2"
+fi
+
+# If we're building the Profiling(Release) configuration, remove Profiling() for building .NET code
+if [ "$CONFIGURATION" == "Profiling(Release)" ]; then
+  CONFIGURATION=Release
+fi
+
+dotnet publish $SCALAR_SRCDIR/Scalar.sln --runtime linux-x64 -p:ScalarVersion=$VERSION --configuration $CONFIGURATION || exit 1

--- a/Scripts/Linux/BuildScalarForLinux.sh
+++ b/Scripts/Linux/BuildScalarForLinux.sh
@@ -12,6 +12,22 @@ if [ -z $VERSION ]; then
   VERSION="0.2.173.2"
 fi
 
+ARCH=$(uname -m)
+if test "$ARCH" != "x86_64"; then
+  >&2 echo "architecture must be x86_64 for struct stat; stopping"
+  exit 1
+fi
+
+CC=${CC:-cc}
+
+echo 'main(){int i=1;const char *n="n";struct stat b;i=__xstat64(i,n,&b);}' | \
+  cc -xc -include sys/stat.h -o /dev/null - 2>/dev/null
+
+if test $? != 0; then
+  >&2 echo "__xstat64() not found in libc ABI; stopping"
+  exit 1
+fi
+
 # If we're building the Profiling(Release) configuration, remove Profiling() for building .NET code
 if [ "$CONFIGURATION" == "Profiling(Release)" ]; then
   CONFIGURATION=Release

--- a/Scripts/Linux/InitializeEnvironment.sh
+++ b/Scripts/Linux/InitializeEnvironment.sh
@@ -1,0 +1,11 @@
+SCRIPTDIR="$(dirname ${BASH_SOURCE[0]})"
+
+# convert to an absolute path because it is required by `dotnet publish`
+pushd $SCRIPTDIR &>/dev/null
+export SCALAR_SCRIPTSDIR="$(pwd)"
+popd &>/dev/null
+
+export SCALAR_SRCDIR=$SCALAR_SCRIPTSDIR/../..
+
+export SCALAR_ENLISTMENTDIR=$SCALAR_SRCDIR/..
+export SCALAR_OUTPUTDIR=$SCALAR_ENLISTMENTDIR/out

--- a/Scripts/Linux/NukeBuildOutputs.sh
+++ b/Scripts/Linux/NukeBuildOutputs.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+. "$(dirname ${BASH_SOURCE[0]})/InitializeEnvironment.sh"
+
+sudo rm -Rf $SCALAR_OUTPUTDIR
+
+echo git --work-tree=$SCALAR_SRCDIR clean -Xdf -n
+git --work-tree=$SCALAR_SRCDIR clean -Xdf -n

--- a/Scripts/Linux/RunUnitTests.sh
+++ b/Scripts/Linux/RunUnitTests.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+. "$(dirname ${BASH_SOURCE[0]})/InitializeEnvironment.sh"
+
+CONFIGURATION=$1
+if [ -z $CONFIGURATION ]; then
+  CONFIGURATION=Debug
+fi
+
+TESTRESULTSDIR=$2
+if [ -z $TESTRESULTSDIR ]; then
+  TESTRESULTSDIR=$SCALAR_OUTPUTDIR/TestResults
+fi
+
+dotnet test $SCALAR_SRCDIR/Scalar.sln --configuration $CONFIGURATION --logger trx --results-directory $TESTRESULTSDIR || exit 1


### PR DESCRIPTION
This is an initial port of the `GVFS.Platform.Linux` classes and the `Scripts/Linux` scripts from both the Mac equivalents in this repository as well as the corresponding classes in the VFSForGit repository.

Note that some useful refactoring which exists in the VFSForGit `features/linuxprototype` [branch](https://github.com/microsoft/VFSForGit/tree/features/linuxprototype), such as microsoft/VFSForGit@7b708506165aaa39783f9bc4d193e9cf39ebc85f, has not yet been ported; this would (re-)eliminate some of the duplication between the Mac and Linux platforms and move common code into the POSIX one.

This PR also does not include the case-sensitive filename support in VFSForGit's `master` branch from microsoft/VFSForGit#1412.

Quoting from the primary VFSForGit commit microsoft/VFSForGit@b304cf7 from which this work was derived:
```
    We add the core GVFS.Platform.Linux classes, derived from their
    GVFS.Platform.Mac equivalents but with appropriate changes for
    syscall argument signatures and flag values, type definitions,
    and structure fields (e.g., mode_t is a uint, and the layout of
    struct stat is quite different).
```

Running `Scripts/Linux/RunUnitTests.sh` on my system with .NET Core 3.1.302 reports:
```
Test Run Successful.
Total tests: 267
     Passed: 267
```

(With the still draft-only work in #422, all functional tests which aren't marked `WindowsOnly` or otherwise excluded on macOS also pass on Linux when using these initial platform classes.  However, that points to some possible gaps in the test coverage, as case-insensitive path comparisons appear to not be causing test failures.)