### PR TITLE
Minor cleanups

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,7 +46,7 @@
     <GitPackageVersion>2.20200728.1</GitPackageVersion>
     <MinimumGitVersion>v2.25.0.vfs.1.1</MinimumGitVersion>
 
-    <WatchmanPackageUrl>https://github.com/facebook/watchman/suites/307436006/artifacts/304557</WatchmanPackageUrl>
+    <WatchmanPackageUrl>https://github.com/facebook/watchman/releases/download/v2020.08.03.00/watchman-v2020.08.03.00-windows.zip</WatchmanPackageUrl>
     <GcmCoreOSXPackageUrl>https://github.com/microsoft/Git-Credential-Manager-Core/releases/download/v2.0.79-beta/gcmcore-osx-2.0.79.64449.pkg</GcmCoreOSXPackageUrl>
 
     <!-- Signing certificates -->

--- a/Scalar.Common/Git/GitProcess.cs
+++ b/Scalar.Common/Git/GitProcess.cs
@@ -624,7 +624,7 @@ namespace Scalar.Common.Git
 
             if (gitObjectsDirectory != null)
             {
-                gitObjectsDirectory = gitObjectsDirectory.Replace(Path.DirectorySeparatorChar, '/');
+                gitObjectsDirectory = Paths.ConvertPathToGitFormat(gitObjectsDirectory);
                 processInfo.EnvironmentVariables["GIT_OBJECT_DIRECTORY"] = gitObjectsDirectory;
             }
 

--- a/Scalar.Common/Git/GitProcess.cs
+++ b/Scalar.Common/Git/GitProcess.cs
@@ -341,11 +341,12 @@ namespace Scalar.Common.Git
             return this.InvokeGitAgainstDotGitFolder("config --local --unset-all " + settingName);
         }
 
-        public Result SetInLocalConfig(string settingName, string value, bool replaceAll = false)
+        public Result SetInLocalConfig(string settingName, string value, bool replaceAll = false, bool add = false)
         {
             return this.InvokeGitAgainstDotGitFolder(string.Format(
-                "config --local {0} \"{1}\" \"{2}\"",
+                "config --local {0} {1} \"{2}\" \"{3}\"",
                  replaceAll ? "--replace-all " : string.Empty,
+                 add ? "--add" : string.Empty,
                  settingName,
                  value));
         }
@@ -376,6 +377,12 @@ namespace Scalar.Common.Git
             }
 
             return result;
+        }
+
+        public Result GetMultiConfig(string settingName)
+        {
+            string command = $"config --local --get-all {settingName}";
+            return this.InvokeGitAgainstDotGitFolder(command);
         }
 
         /// <summary>
@@ -950,6 +957,18 @@ namespace Scalar.Common.Git
                 }
 
                 return true;
+            }
+        }
+
+        public class MultiConfigResult
+        {
+            public Result Result { get; }
+            public HashSet<string> Values { get; }
+
+            public MultiConfigResult(Result result)
+            {
+                this.Result = result;
+                this.Values = new HashSet<string>(this.Result.Output.Split("\n", StringSplitOptions.RemoveEmptyEntries));
             }
         }
     }

--- a/Scalar.Common/Git/GitProcess.cs
+++ b/Scalar.Common/Git/GitProcess.cs
@@ -624,6 +624,7 @@ namespace Scalar.Common.Git
 
             if (gitObjectsDirectory != null)
             {
+                gitObjectsDirectory = gitObjectsDirectory.Replace(Path.DirectorySeparatorChar, '/');
                 processInfo.EnvironmentVariables["GIT_OBJECT_DIRECTORY"] = gitObjectsDirectory;
             }
 

--- a/Scalar.Common/Maintenance/ConfigStep.cs
+++ b/Scalar.Common/Maintenance/ConfigStep.cs
@@ -113,7 +113,6 @@ namespace Scalar.Common.Maintenance
                 { "gui.gcwarning", "false" },
                 { "index.threads", "true" },
                 { "index.version", "4" },
-                { "log.excludeDecoration", "refs/scalar/*" },
                 { "merge.stat", "false" },
                 { "merge.renames", "false" },
                 { "pack.useBitmaps", "false" },
@@ -174,6 +173,20 @@ namespace Scalar.Common.Maintenance
                 return false;
             }
 
+            string excludeDecoration = "log.excludeDecoration";
+            List<string> excludeValues = new List<string>
+            {
+                "refs/scalar/*",
+                "refs/prefetch/*",
+            };
+
+            if (!this.TrySetMultiConfig(excludeDecoration, excludeValues, out error))
+            {
+                error = $"Failed to set some multi-value settings: {error}";
+                this.Context.Tracer.RelatedError(error);
+                return false;
+            }
+
             return this.ConfigureWatchmanIntegration(out error);
         }
 
@@ -182,7 +195,7 @@ namespace Scalar.Common.Maintenance
             this.TrySetConfig(out _);
         }
 
-        private bool TrySetConfig(Dictionary<string, string> configSettings, bool isRequired, out string error)
+        private bool TrySetConfig(Dictionary<string, string> configSettings, bool isRequired, out string error, bool add = false)
         {
             Dictionary<string, GitConfigSetting> existingConfigSettings = null;
 
@@ -208,7 +221,7 @@ namespace Scalar.Common.Maintenance
                     {
                         this.Context.Tracer.RelatedInfo($"Setting config value {setting.Key}={setting.Value}");
                         GitProcess.Result setConfigResult = this.RunGitCommand(
-                                                                    process => process.SetInLocalConfig(setting.Key, setting.Value),
+                                                                    process => process.SetInLocalConfig(setting.Key, setting.Value, add: add),
                                                                     nameof(GitProcess.SetInLocalConfig));
                         if (setConfigResult.ExitCodeIsFailure)
                         {
@@ -224,6 +237,34 @@ namespace Scalar.Common.Maintenance
                         this.RunGitCommand(
                                 process => process.DeleteFromLocalConfig(setting.Key),
                                 nameof(GitProcess.DeleteFromLocalConfig));
+                    }
+                }
+            }
+
+            error = null;
+            return true;
+        }
+
+        private bool TrySetMultiConfig(string key, List<string> values, out string error)
+        {
+            GitProcess.Result result = this.RunGitCommand(process => process.GetMultiConfig(key),
+                                                                     nameof(GitProcess.GetMultiConfig));
+
+            // Note: if the result fails, then it means there are no matching values.
+            GitProcess.MultiConfigResult configResult = new GitProcess.MultiConfigResult(result);
+
+            foreach (string value in values)
+            {
+                if (!configResult.Values.Contains(value))
+                {
+                    this.Context.Tracer.RelatedInfo($"Adding config value {key}={value}");
+                    GitProcess.Result setConfigResult = this.RunGitCommand(
+                                                                process => process.SetInLocalConfig(key, value, add: true),
+                                                                nameof(GitProcess.SetInLocalConfig));
+                    if (setConfigResult.ExitCodeIsFailure)
+                    {
+                        error = setConfigResult.Errors;
+                        return false;
                     }
                 }
             }

--- a/Scalar.Common/Maintenance/ConfigStep.cs
+++ b/Scalar.Common/Maintenance/ConfigStep.cs
@@ -308,7 +308,7 @@ namespace Scalar.Common.Maintenance
                     queryWatchmanPath,
                     overwrite: true);
 
-                string dotGitRoot = this.Context.Enlistment.DotGitRoot.Replace(Path.DirectorySeparatorChar, ScalarConstants.GitPathSeparator);
+                string dotGitRoot = Paths.ConvertPathToGitFormat(this.Context.Enlistment.DotGitRoot);
                 this.RunGitCommand(
                     process => process.SetInLocalConfig("core.fsmonitor", dotGitRoot + "/hooks/query-watchman"),
                     "config");

--- a/Scalar.Common/Maintenance/GitMaintenanceStep.cs
+++ b/Scalar.Common/Maintenance/GitMaintenanceStep.cs
@@ -91,6 +91,7 @@ namespace Scalar.Common.Maintenance
                         metadata: this.CreateEventMetadata(e),
                         message: "Exception while running action: " + e.Message,
                         keywords: Keywords.Telemetry);
+                    throw e;
                 }
                 else
                 {
@@ -98,8 +99,6 @@ namespace Scalar.Common.Maintenance
                         metadata: this.CreateEventMetadata(e),
                         message: "Exception while running action inside a repo that's not ready: " + e.Message);
                 }
-
-                Environment.Exit((int)ReturnCode.GenericError);
             }
         }
 

--- a/Scalar.Installer.Windows/InstallScalar.template.bat
+++ b/Scalar.Installer.Windows/InstallScalar.template.bat
@@ -43,9 +43,20 @@ IF "%1"=="--watchman" (
 	ECHO ===============================
 	ECHO Installing Watchman for Windows
 	curl -s -L %WATCHMAN_CI_URL% >watchman.zip
-	unzip watchman.zip
+
+	rem clear existing watchman dir, if necessary
+	rd /s /q watchman
+	powershell -command "Expand-Archive watchman.zip"
+
+	rem Move to consistent directory name
+	rd /s /q watchman-zip
+	ren watchman watchman-zip
+	move watchman-zip\watchman-* watchman
+
+	REM Kill 'watchman' process, if it is running, and reinstall
+	taskkill /IM "watchman.exe" /F
 	mkdir "C:\Program Files\watchman"
-	copy watchman\windows\bin\* "C:\Program Files\watchman\"
+	copy /y watchman\bin\* "C:\Program Files\watchman\"
 	setx /m PATH "C:\Program Files\watchman\;%PATH%"
 )
 

--- a/Scalar/CommandLine/ScalarVerb.cs
+++ b/Scalar/CommandLine/ScalarVerb.cs
@@ -417,7 +417,17 @@ You can specify a URL, a name of a configured cache server, or the special names
             GitProcess process = new GitProcess(enlistment);
             GitProcess.Result downloadResult = process.GvfsHelperDownloadCommit(commitId);
 
-            error = downloadResult.Errors;
+            if (downloadResult.ExitCodeIsFailure)
+            {
+                error = string.IsNullOrEmpty(downloadResult.Errors)
+                            ? "Error while downloading tip commit"
+                            : "Error while downloading tip commit:\n" + downloadResult.Errors;
+            }
+            else
+            {
+                error = null;
+            }
+
             return downloadResult.ExitCodeIsSuccess;
         }
 


### PR DESCRIPTION
These cleanups were discovered while working on #398:

1. Update Watchman download to get newer version. (Link was broken by recent change in release process.)
2. Use a better error when downloading the tip commit fails.
3. Use multi-valued config for `log.excludeDecoration` since it will need multiple values.
4. Do a better job interacting with `GIT_OBJECT_DIRECTORY` in `GitProcess`.
5. Stop exiting on an unknown exception during `GitMaintenanceStep`.