### PR TITLE
ScalarCloneFromGitHub: drop SSH string

### DIFF
--- a/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/ScalarCloneFromGithub.cs
+++ b/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/ScalarCloneFromGithub.cs
@@ -12,7 +12,6 @@ namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
     public class ScalarCloneFromGithub : TestsWithMultiEnlistment
     {
         private static readonly string MicrosoftScalarHttp = "https://github.com/microsoft/scalar";
-        private static readonly string MicrosoftScalarSsh = "git@github.com:microsoft/scalar.git";
 
         private FileSystemRunner fileSystem;
 


### PR DESCRIPTION
This string was added when toying with testing SSH URLs in the
functional tests. However, there was an issue with using SSH inside the
build machines, so it was never used. It's now creating pain for the
GitHub Actions workflows that will build Scalar. Drop it.

(This was noticed by the warnings in #413.)