### PR TITLE
Setup GitHub Actions build and unit test CI jobs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,37 @@
+name: Scalar
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  validate_scalar:
+    name: "CI"
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, windows-2019, macos-10.15]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0 # Indicate full history so Nerdbank.GitVersioning works.
+
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.302
+
+    - name: Install Dependencies
+      run: dotnet restore
+      env:
+        DOTNET_NOLOGO: 1
+
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+
+    - name: Unit Test
+      run: dotnet test --no-restore


### PR DESCRIPTION
We define GitHub Actions YAML which runs a simplified version of the `BuildScalarFor*.{bat,sh}` and `RunUnitTests.{bat,sh}` scripts under `Scripts/`.  We run these jobs on all PRs to the `main` branch.

One difference is that we use a `Release` build configuration instead of using a `Build` configuration as our default.

We also do not define the `ScalarVersion` MSBuild property and instead rely on what is [set](https://github.com/microsoft/scalar/blob/ef5c1bc753d0e129a2ca27c0e4daee78a27d1d30/Directory.Build.props#L38) in `Directory.Build.props`.

We include builds on three Ubuntu versions to align with what [runs](https://github.com/microsoft/Git-Credential-Manager-Core/blob/2e9919d0b8017dcbde244d129d3b321effe1ab59/.github/workflows/continuous-integration.yml#L16) for GCM Core, and to support Linux functional test runs in the future.  These jobs should succeed as-is even without Linux-specific platform code; see https://github.com/chrisd8088/scalar/actions/runs/211493921 for an example run.

/cc @kyle-rader
/cc microsoft/Git-Credential-Manager-Core#157 from which this was derived