### PR TITLE
Allow functional tests to use Git from $PATH

### DIFF
--- a/Scalar.FunctionalTests/Program.cs
+++ b/Scalar.FunctionalTests/Program.cs
@@ -23,6 +23,12 @@ namespace Scalar.FunctionalTests
                 ScalarTestConfig.NoSharedCache = true;
             }
 
+            if (runner.HasCustomArg("--test-git-on-path"))
+            {
+                Console.WriteLine("Running tests against Git on path");
+                ScalarTestConfig.TestGitOnPath = true;
+            }
+
             if (runner.HasCustomArg("--test-scalar-on-path"))
             {
                 Console.WriteLine("Running tests against Scalar on path");

--- a/Scalar.FunctionalTests/ScalarTestConfig.cs
+++ b/Scalar.FunctionalTests/ScalarTestConfig.cs
@@ -14,6 +14,20 @@ namespace Scalar.FunctionalTests
 
         public static object[] GitRepoTestsValidateWorkTree { get; set; }
 
+        public static bool TestGitOnPath { get; set; }
+
+        public static string PathToGit
+        {
+            get
+            {
+		string gitBinaryFileName = "git" + Properties.Settings.Default.BinaryFileNameExtension;
+                return
+                    TestGitOnPath ?
+                    gitBinaryFileName :
+                    Path.Combine(Properties.Settings.Default.PathToGitRoot, gitBinaryFileName);
+            }
+        }
+
         public static bool TestScalarOnPath { get; set; }
 
         public static string PathToScalar

--- a/Scalar.FunctionalTests/ScalarTestConfig.cs
+++ b/Scalar.FunctionalTests/ScalarTestConfig.cs
@@ -20,7 +20,7 @@ namespace Scalar.FunctionalTests
         {
             get
             {
-		string gitBinaryFileName = "git" + Properties.Settings.Default.BinaryFileNameExtension;
+                string gitBinaryFileName = "git" + Properties.Settings.Default.BinaryFileNameExtension;
                 return
                     TestGitOnPath ?
                     gitBinaryFileName :

--- a/Scalar.FunctionalTests/Settings.cs
+++ b/Scalar.FunctionalTests/Settings.cs
@@ -24,7 +24,7 @@ namespace Scalar.FunctionalTests.Properties
             public static string CommitId { get; set; }
             public static string ControlGitRepoRoot { get; set; }
             public static string EnlistmentRoot { get; set; }
-            public static string PathToGit { get; set; }
+            public static string PathToGitRoot { get; set; }
             public static string PathToScalarService { get; set; }
             public static string BinaryFileNameExtension { get; set; }
 
@@ -40,7 +40,7 @@ namespace Scalar.FunctionalTests.Properties
                 {
                     EnlistmentRoot = @"C:\Repos\ScalarFunctionalTests\enlistment";
                     PathToScalar = @"Scalar.exe";
-                    PathToGit = @"C:\Program Files\Git\cmd\git.exe";
+                    PathToGitRoot = @"C:\Program Files\Git\cmd";
                     PathToBash = @"C:\Program Files\Git\bin\bash.exe";
 
                     ControlGitRepoRoot = @"C:\Repos\ScalarFunctionalTests\ControlRepo";
@@ -55,7 +55,7 @@ namespace Scalar.FunctionalTests.Properties
                     EnlistmentRoot = Path.Combine(root, "test");
                     ControlGitRepoRoot = Path.Combine(root, "control");
                     PathToScalar = "scalar";
-                    PathToGit = "/usr/local/bin/git";
+                    PathToGitRoot = "/usr/local/bin";
                     PathToBash = "/bin/bash";
                     BinaryFileNameExtension = string.Empty;
                 }

--- a/Scalar.FunctionalTests/Tools/GitProcess.cs
+++ b/Scalar.FunctionalTests/Tools/GitProcess.cs
@@ -35,7 +35,7 @@ namespace Scalar.FunctionalTests.Tools
 
         public static ProcessResult InvokeProcess(string executionWorkingDirectory, string command, Dictionary<string, string> environmentVariables = null, Stream inputStream = null)
         {
-            ProcessStartInfo processInfo = new ProcessStartInfo(Properties.Settings.Default.PathToGit);
+            ProcessStartInfo processInfo = new ProcessStartInfo(ScalarTestConfig.PathToGit);
             processInfo.WorkingDirectory = executionWorkingDirectory;
             processInfo.UseShellExecute = false;
             processInfo.RedirectStandardOutput = true;


### PR DESCRIPTION
We implement the equivalent of the existing `--test-scalar-on-path` functional test command-line option for Git also, namely by adding a new `--test-git-on-path` option.

This permits the manual execution of the functional test suite on systems where the default installation of Git may not be sufficient to support Scalar; i.e., it may be an older version or not the Microsoft Git [custom package](https://github.com/microsoft/git).

The existing CI jobs are not affected by this change as the default when the new command-line option is not provided is to continue to look for Git as `C:\Program Files\Git\cmd\git.exe` on Windows and `/usr/local/bin/git` on macOS, as the functional test program did before.