### PR TITLE
Clean up functional test MacTODO categories and Windows-only option

### DIFF
--- a/Scalar.FunctionalTests/Categories.cs
+++ b/Scalar.FunctionalTests/Categories.cs
@@ -17,9 +17,6 @@ namespace Scalar.FunctionalTests
             // Tests that require Config to be built
             public const string NeedsScalarConfig = "NeedsConfig";
 
-            // Tests that require Scalar Service
-            public const string NeedsServiceVerb = "NeedsServiceVerb";
-
             // Tests requires code updates so that we lock the file instead of looking for a .lock file
             public const string TestNeedsToLockFile = "TestNeedsToLockFile";
         }

--- a/Scalar.FunctionalTests/Categories.cs
+++ b/Scalar.FunctionalTests/Categories.cs
@@ -14,9 +14,6 @@ namespace Scalar.FunctionalTests
 
         public static class MacTODO
         {
-            // Tests that require Config to be built
-            public const string NeedsScalarConfig = "NeedsConfig";
-
             // Tests requires code updates so that we lock the file instead of looking for a .lock file
             public const string TestNeedsToLockFile = "TestNeedsToLockFile";
         }

--- a/Scalar.FunctionalTests/Program.cs
+++ b/Scalar.FunctionalTests/Program.cs
@@ -101,11 +101,6 @@ namespace Scalar.FunctionalTests
             // with the non-virtualized solution
             excludeCategories.Add(Categories.NeedsUpdatesForNonVirtualizedMode);
 
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                excludeCategories.Add(Categories.MacOnly);
-            }
-
             ScalarTestConfig.RepoToClone =
                 runner.GetCustomArgWithParam("--repo-to-clone")
                 ?? Properties.Settings.Default.RepoToClone;

--- a/Scalar.FunctionalTests/Program.cs
+++ b/Scalar.FunctionalTests/Program.cs
@@ -87,7 +87,6 @@ namespace Scalar.FunctionalTests
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
-                excludeCategories.Add(Categories.MacTODO.NeedsScalarConfig);
                 excludeCategories.Add(Categories.MacTODO.TestNeedsToLockFile);
                 excludeCategories.Add(Categories.WindowsOnly);
             }

--- a/Scalar.FunctionalTests/Program.cs
+++ b/Scalar.FunctionalTests/Program.cs
@@ -88,7 +88,6 @@ namespace Scalar.FunctionalTests
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 excludeCategories.Add(Categories.MacTODO.NeedsScalarConfig);
-                excludeCategories.Add(Categories.MacTODO.NeedsServiceVerb);
                 excludeCategories.Add(Categories.MacTODO.TestNeedsToLockFile);
                 excludeCategories.Add(Categories.WindowsOnly);
             }

--- a/Scalar.FunctionalTests/Program.cs
+++ b/Scalar.FunctionalTests/Program.cs
@@ -117,7 +117,7 @@ namespace Scalar.FunctionalTests
             {
                 // Shutdown the watchman server now that the tests are complete.
                 // Allows deleting the unwatched directories.
-                ProcessHelper.Run("watchman", "shudown-server");
+                ProcessHelper.Run("watchman", "shutdown-server");
             }
             catch (Exception)
             {

--- a/Scalar.FunctionalTests/Program.cs
+++ b/Scalar.FunctionalTests/Program.cs
@@ -76,15 +76,6 @@ namespace Scalar.FunctionalTests
                 ScalarTestConfig.FileSystemRunners = FileSystemRunners.FileSystemRunner.DefaultRunners;
             }
 
-            if (runner.HasCustomArg("--windows-only"))
-            {
-                includeCategories.Add(Categories.WindowsOnly);
-
-                // RunTests unions all includeCategories.  Remove ExtraCoverage to
-                // ensure that we only run tests flagged as WindowsOnly
-                includeCategories.Remove(Categories.ExtraCoverage);
-            }
-
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 excludeCategories.Add(Categories.MacTODO.TestNeedsToLockFile);
@@ -92,6 +83,15 @@ namespace Scalar.FunctionalTests
             }
             else
             {
+                if (runner.HasCustomArg("--windows-only"))
+                {
+                    includeCategories.Add(Categories.WindowsOnly);
+
+                    // RunTests unions all includeCategories.  Remove ExtraCoverage to
+                    // ensure that we only run tests flagged as WindowsOnly
+                    includeCategories.Remove(Categories.ExtraCoverage);
+                }
+
                 excludeCategories.Add(Categories.MacOnly);
             }
 

--- a/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/ConfigVerbTests.cs
+++ b/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/ConfigVerbTests.cs
@@ -8,7 +8,6 @@ namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
 {
     [TestFixture]
     [Category(Categories.ExtraCoverage)]
-    [Category(Categories.MacTODO.NeedsScalarConfig)]
     [Category(Categories.NeedsUpdatesForNonVirtualizedMode)]
     public class ConfigVerbTests : TestsWithMultiEnlistment
     {

--- a/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
+++ b/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/SharedCacheTests.cs
@@ -91,7 +91,6 @@ namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
         }
 
         [TestCase]
-        [Category(Categories.MacTODO.NeedsServiceVerb)]
         public void SecondCloneSucceedsWithMissingTrees()
         {
             string newCachePath = Path.Combine(this.localCacheParentPath, ".customScalarCache2");


### PR DESCRIPTION
Prior to starting work to support runs of the functional test suite on Linux, we can simplify some of the tests marked `MacTODO` as no longer needing that designation and also simplify some of the Windows-related configuration and options.

On the Windows side of thing, we can remove the second invocation of `excludeCategories.Add(Categories.MacOnly)` because it is always performed on Windows in the `if/else` block just above it.

We also only parse the `--windows-only` functional test command-line option when running on Windows, as it has no effect on macOS since the `WindowsOnly` tests are always excluded there.

On the macOS side of things, there is one test still marked `MacTODO.NeedsServiceVerb` which appears to have been missed in PR #216, where that category was removed from many other tests.  This `SecondCloneSucceedsWithMissingTrees` test succeeds on macOS as written, so it seems OK to remove the `MacTODO` flag on it.

The other macOS change we make is to remove the `MacTODO.NeedsScalarConfig` category, which currently applies to all the tests in `MultiEnlistmentTests/ConfigVerbTests.cs`.  These tests are also marked with `NeedsUpdatesForNonVirtualizedMode` and therefore will continue to _not_ run even after this change.  (However, limited testing by disabling the `config` verb's "elevated privileges" [checks](https://github.com/microsoft/scalar/blob/ef5c1bc753d0e129a2ca27c0e4daee78a27d1d30/Scalar/CommandLine/ConfigVerb.cs#L95) and removing `NeedsUpdatesForNonVirtualizedMode` from the `ConfigVerbTests` indicates that, in fact, these tests would all succeed on macOS/Linux with some further adjustments.  But for now we just remove the "extra" `MacTODO` exclusion on these tests.)

These two changes allow us to remove two of the three `MacTODO` categories entirely.

We also do minor housekeeping by fixing one typo in the Watchman `shutdown-server` command.