### PR TITLE
Linux: functional test and XDG configuration support

### DIFF
--- a/Dependencies.props
+++ b/Dependencies.props
@@ -10,6 +10,7 @@
     <PackageReference Update="NuGet.Commands"                  Version="5.4.0"  />
     <PackageReference Update="GitForWindows.GVFS.Installer"    Version="$(GitPackageVersion)" />
     <PackageReference Update="GitForMac.GVFS.Installer"        Version="$(GitPackageVersion)" />
+    <PackageReference Update="GitForLinux.GVFS.Installer"      Version="$(GitPackageVersion)" />
 
     <!-- Build-only dependencies -->
     <PackageReference Update="MicroBuild.Core"                 Version="0.2.0" PrivateAssets="all" />

--- a/Scalar.Common/Platforms/Linux/LinuxPlatform.Shared.cs
+++ b/Scalar.Common/Platforms/Linux/LinuxPlatform.Shared.cs
@@ -9,9 +9,15 @@ namespace Scalar.Platform.Linux
     {
         public static string GetDataRootForScalarImplementation()
         {
-            // TODO(Linux): determine installation location and data path
-            string path = Environment.GetEnvironmentVariable("SCALAR_DATA_PATH");
-            return path ?? "/var/run/scalar";
+            string localDataRoot;
+            string localDataRootError;
+
+            if (!TryGetEnvironmentVariableBasePath(EnvironmentVariableBaseDataPaths, out localDataRoot, out localDataRootError))
+            {
+                throw new ArgumentException(localDataRootError);
+            }
+
+            return localDataRoot;
         }
 
         public static string GetDataRootForScalarComponentImplementation(string componentName)

--- a/Scalar.Common/Platforms/Linux/LinuxPlatform.cs
+++ b/Scalar.Common/Platforms/Linux/LinuxPlatform.cs
@@ -26,16 +26,28 @@ namespace Scalar.Platform.Linux
         // permission mode via a native wrapper for mkdir(2) instead of
         // relying on our caller's use of Directory.CreateDirectory().
         private static readonly EnvironmentVariableBasePath[] EnvironmentVariableBaseCachePaths = new[] {
-            new EnvironmentVariableBasePath("XDG_CACHE_HOME", "scalar"),
-            new EnvironmentVariableBasePath("HOME", Path.Combine(".cache", "scalar")),
+            new EnvironmentVariableBasePath(
+                ScalarConstants.LinuxPlatform.EnvironmentVariables.LocalUserCacheFolder,
+                ScalarConstants.LinuxPlatform.LocalScalarFolderName),
+            new EnvironmentVariableBasePath(
+                ScalarConstants.POSIXPlatform.EnvironmentVariables.LocalUserFolder,
+                ScalarConstants.LinuxPlatform.LocalScalarCachePath),
         };
         protected static readonly EnvironmentVariableBasePath[] EnvironmentVariableBaseConfigPaths = new[] {
-            new EnvironmentVariableBasePath("XDG_CONFIG_HOME", "scalar"),
-            new EnvironmentVariableBasePath("HOME", Path.Combine(".config", "scalar")),
+            new EnvironmentVariableBasePath(
+                ScalarConstants.LinuxPlatform.EnvironmentVariables.LocalUserConfigFolder,
+                ScalarConstants.LinuxPlatform.LocalScalarFolderName),
+            new EnvironmentVariableBasePath(
+                ScalarConstants.POSIXPlatform.EnvironmentVariables.LocalUserFolder,
+                ScalarConstants.LinuxPlatform.LocalScalarConfigPath),
         };
         protected static readonly EnvironmentVariableBasePath[] EnvironmentVariableBaseDataPaths = new[] {
-            new EnvironmentVariableBasePath("XDG_DATA_HOME", "scalar"),
-            new EnvironmentVariableBasePath("HOME", Path.Combine(".local", "share", "scalar")),
+            new EnvironmentVariableBasePath(
+                ScalarConstants.LinuxPlatform.EnvironmentVariables.LocalUserDataFolder,
+                ScalarConstants.LinuxPlatform.LocalScalarFolderName),
+            new EnvironmentVariableBasePath(
+                ScalarConstants.POSIXPlatform.EnvironmentVariables.LocalUserFolder,
+                ScalarConstants.LinuxPlatform.LocalScalarDataPath),
         };
 
         public LinuxPlatform() : base(

--- a/Scalar.Common/Platforms/Mac/MacPlatform.Shared.cs
+++ b/Scalar.Common/Platforms/Mac/MacPlatform.Shared.cs
@@ -9,11 +9,15 @@ namespace Scalar.Platform.Mac
     {
         public static string GetDataRootForScalarImplementation()
         {
-            return Path.Combine(
-                Environment.GetEnvironmentVariable("HOME"),
-                "Library",
-                "Application Support",
-                "Scalar");
+            string localDataRoot;
+            string localDataRootError;
+
+            if (!TryGetEnvironmentVariableBasePath(EnvironmentVariableBaseDataPaths, out localDataRoot, out localDataRootError))
+            {
+                throw new ArgumentException(localDataRootError);
+            }
+
+            return localDataRoot;
         }
 
         public static string GetDataRootForScalarComponentImplementation(string componentName)

--- a/Scalar.Common/Platforms/Mac/MacPlatform.cs
+++ b/Scalar.Common/Platforms/Mac/MacPlatform.cs
@@ -17,6 +17,12 @@ namespace Scalar.Platform.Mac
     public partial class MacPlatform : POSIXPlatform
     {
         private const string UpgradeProtectedDataDirectory = "/usr/local/scalar_upgrader";
+        private static readonly EnvironmentVariableBasePath[] EnvironmentVariableBaseCachePaths = new[] {
+            new EnvironmentVariableBasePath("HOME", ScalarConstants.DefaultScalarCacheFolderName),
+        };
+        protected static readonly EnvironmentVariableBasePath[] EnvironmentVariableBaseDataPaths = new[] {
+            new EnvironmentVariableBasePath("HOME", Path.Combine("Library", "Application Support", "Scalar")),
+        };
 
         public MacPlatform() : base(
              underConstruction: new UnderConstructionFlags(
@@ -124,6 +130,11 @@ namespace Scalar.Platform.Mac
             }
 
             return result;
+        }
+
+        public override bool TryGetDefaultLocalCacheRoot(string enlistmentRoot, out string localCacheRoot, out string localCacheRootError)
+        {
+            return TryGetEnvironmentVariableBasePath(EnvironmentVariableBaseCachePaths, out localCacheRoot, out localCacheRootError);
         }
 
         public override ProductUpgraderPlatformStrategy CreateProductUpgraderPlatformInteractions(

--- a/Scalar.Common/Platforms/Mac/MacPlatform.cs
+++ b/Scalar.Common/Platforms/Mac/MacPlatform.cs
@@ -18,10 +18,14 @@ namespace Scalar.Platform.Mac
     {
         private const string UpgradeProtectedDataDirectory = "/usr/local/scalar_upgrader";
         private static readonly EnvironmentVariableBasePath[] EnvironmentVariableBaseCachePaths = new[] {
-            new EnvironmentVariableBasePath("HOME", ScalarConstants.DefaultScalarCacheFolderName),
+            new EnvironmentVariableBasePath(
+                ScalarConstants.POSIXPlatform.EnvironmentVariables.LocalUserFolder,
+                ScalarConstants.DefaultScalarCacheFolderName),
         };
         protected static readonly EnvironmentVariableBasePath[] EnvironmentVariableBaseDataPaths = new[] {
-            new EnvironmentVariableBasePath("HOME", Path.Combine("Library", "Application Support", "Scalar")),
+            new EnvironmentVariableBasePath(
+                ScalarConstants.POSIXPlatform.EnvironmentVariables.LocalUserFolder,
+                ScalarConstants.MacPlatform.LocalScalarDataPath),
         };
 
         public MacPlatform() : base(

--- a/Scalar.Common/Platforms/POSIX/POSIXPlatform.cs
+++ b/Scalar.Common/Platforms/POSIX/POSIXPlatform.cs
@@ -264,9 +264,6 @@ namespace Scalar.Platform.POSIX
             }
 
             public override bool SupportsUpgradeWhileRunning => true;
-
-            // Documented here (in the addressing section): https://www.unix.com/man-page/linux/7/unix/
-            public override int MaxPipePathLength => 108;
         }
     }
 }

--- a/Scalar.Common/Scalar.Common.csproj
+++ b/Scalar.Common/Scalar.Common.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Windows.Compatibility" />
     <PackageReference Include="GitForWindows.GVFS.Installer" PrivateAssets="all" />
     <PackageReference Include="GitForMac.GVFS.Installer" PrivateAssets="all" />
+    <PackageReference Include="GitForLinux.GVFS.Installer" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Scalar.Common/ScalarConstants.cs
+++ b/Scalar.Common/ScalarConstants.cs
@@ -94,6 +94,35 @@ namespace Scalar.Common
             public const string UpgradeProcess = UpgradePrefix + "_process";
         }
 
+        public static class POSIXPlatform
+        {
+            public static class EnvironmentVariables
+            {
+                public const string LocalUserFolder = "HOME";
+            }
+        }
+
+        public static class LinuxPlatform
+        {
+            public static class EnvironmentVariables
+            {
+                public const string LocalUserCacheFolder = "XDG_CACHE_HOME";
+                public const string LocalUserConfigFolder = "XDG_CONFIG_HOME";
+                public const string LocalUserDataFolder = "XDG_DATA_HOME";
+            }
+
+            public const string LocalScalarFolderName = "scalar";
+
+            public static readonly string LocalScalarCachePath = Path.Combine(".cache", LocalScalarFolderName);
+            public static readonly string LocalScalarConfigPath = Path.Combine(".config", LocalScalarFolderName);
+            public static readonly string LocalScalarDataPath = Path.Combine(".local", "share", LocalScalarFolderName);
+        }
+
+        public static class MacPlatform
+        {
+            public static readonly string LocalScalarDataPath = Path.Combine("Library", "Application Support", "Scalar");
+        }
+
         public static class DotGit
         {
             public const string Root = ".git";

--- a/Scalar.FunctionalTests/Categories.cs
+++ b/Scalar.FunctionalTests/Categories.cs
@@ -5,7 +5,7 @@ namespace Scalar.FunctionalTests
         public const string GitCommands = "GitCommands";
 
         public const string WindowsOnly = "WindowsOnly";
-        public const string MacOnly = "MacOnly";
+        public const string POSIXOnly = "POSIXOnly";
 
         public const string GitRepository = "GitRepository";
 

--- a/Scalar.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
+++ b/Scalar.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
@@ -16,7 +16,7 @@ namespace Scalar.FunctionalTests.FileSystemRunners
                 new object[] { new BashRunner() },
             };
 
-        public static object[] AllMacRunners { get; } =
+        public static object[] AllPOSIXRunners { get; } =
             new[]
             {
                 new object[] { new SystemIORunner() },

--- a/Scalar.FunctionalTests/FileSystemRunners/SystemIORunner.cs
+++ b/Scalar.FunctionalTests/FileSystemRunners/SystemIORunner.cs
@@ -93,7 +93,7 @@ namespace Scalar.FunctionalTests.FileSystemRunners
             }
             else
             {
-                MacCreateHardLink(existingFilePath, newLinkFilePath).ShouldEqual(0, $"Failed to create hard link: {Marshal.GetLastWin32Error()}");
+                POSIXCreateHardLink(existingFilePath, newLinkFilePath).ShouldEqual(0, $"Failed to create hard link: {Marshal.GetLastWin32Error()}");
             }
         }
 
@@ -210,9 +210,13 @@ namespace Scalar.FunctionalTests.FileSystemRunners
             {
                 throw new NotSupportedException();
             }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                LinuxChmod(path, (uint)mode).ShouldEqual(0, $"Failed to chmod: {Marshal.GetLastWin32Error()}");
+            }
             else
             {
-                Chmod(path, mode).ShouldEqual(0, $"Failed to chmod: {Marshal.GetLastWin32Error()}");
+                MacChmod(path, mode).ShouldEqual(0, $"Failed to chmod: {Marshal.GetLastWin32Error()}");
             }
         }
 
@@ -225,10 +229,13 @@ namespace Scalar.FunctionalTests.FileSystemRunners
         private static extern bool MoveFileEx(string existingFileName, string newFileName, int flags);
 
         [DllImport("libc", EntryPoint = "link", SetLastError = true)]
-        private static extern int MacCreateHardLink(string oldPath, string newPath);
+        private static extern int POSIXCreateHardLink(string oldPath, string newPath);
 
         [DllImport("libc", EntryPoint = "chmod", SetLastError = true)]
-        private static extern int Chmod(string pathname, ushort mode);
+        private static extern int LinuxChmod(string pathname, uint mode);
+
+        [DllImport("libc", EntryPoint = "chmod", SetLastError = true)]
+        private static extern int MacChmod(string pathname, ushort mode);
 
         [DllImport("libc", EntryPoint = "rename", SetLastError = true)]
         private static extern int Rename(string oldPath, string newPath);

--- a/Scalar.FunctionalTests/Program.cs
+++ b/Scalar.FunctionalTests/Program.cs
@@ -62,9 +62,10 @@ namespace Scalar.FunctionalTests
                 {
                     ScalarTestConfig.FileSystemRunners = FileSystemRunners.FileSystemRunner.AllWindowsRunners;
                 }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
+                         RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
-                    ScalarTestConfig.FileSystemRunners = FileSystemRunners.FileSystemRunner.AllMacRunners;
+                    ScalarTestConfig.FileSystemRunners = FileSystemRunners.FileSystemRunner.AllPOSIXRunners;
                 }
             }
             else

--- a/Scalar.FunctionalTests/Program.cs
+++ b/Scalar.FunctionalTests/Program.cs
@@ -73,13 +73,14 @@ namespace Scalar.FunctionalTests
                 ScalarTestConfig.FileSystemRunners = FileSystemRunners.FileSystemRunner.DefaultRunners;
             }
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ||
+                RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 excludeCategories.Add(Categories.WindowsOnly);
             }
             else
             {
-                excludeCategories.Add(Categories.MacOnly);
+                excludeCategories.Add(Categories.POSIXOnly);
             }
 
             // For now, run all of the tests not flagged as needing to be updated to work

--- a/Scalar.FunctionalTests/ScalarTestConfig.cs
+++ b/Scalar.FunctionalTests/ScalarTestConfig.cs
@@ -1,3 +1,4 @@
+using Scalar.FunctionalTests.Tools;
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -16,7 +17,7 @@ namespace Scalar.FunctionalTests
             get
             {
                 string homeDirectory = null;
-                string cachePath = ".scalarCache";
+                string cachePath = TestConstants.DefaultScalarCacheFolderName;
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
@@ -24,20 +25,23 @@ namespace Scalar.FunctionalTests
                 }
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
-                    homeDirectory = Environment.GetEnvironmentVariable("HOME");
+                    homeDirectory = Environment.GetEnvironmentVariable(
+                        TestConstants.POSIXPlatform.EnvironmentVariables.LocalUserFolder);
                 }
                 else
                 {
                     // On Linux we use a local cache path per the XDG Base Directory Specification.
-                    homeDirectory = Environment.GetEnvironmentVariable("XDG_CACHE_HOME");
+                    homeDirectory = Environment.GetEnvironmentVariable(
+                        TestConstants.LinuxPlatform.EnvironmentVariables.LocalUserCacheFolder);
                     if (!string.IsNullOrEmpty(homeDirectory))
                     {
-                        cachePath = "scalar";
+                        cachePath = TestConstants.LinuxPlatform.LocalScalarFolderName;
                     }
                     else
                     {
-                        homeDirectory = Environment.GetEnvironmentVariable("HOME");
-                        cachePath = Path.Combine(".cache", "scalar");
+                        homeDirectory = Environment.GetEnvironmentVariable(
+                            TestConstants.POSIXPlatform.EnvironmentVariables.LocalUserFolder);
+                        cachePath = TestConstants.LinuxPlatform.LocalScalarCachePath;
                     }
 
                 }

--- a/Scalar.FunctionalTests/ScalarTestConfig.cs
+++ b/Scalar.FunctionalTests/ScalarTestConfig.cs
@@ -1,4 +1,6 @@
+using System;
 using System.IO;
+using System.Runtime.InteropServices;
 
 namespace Scalar.FunctionalTests
 {
@@ -9,6 +11,40 @@ namespace Scalar.FunctionalTests
         public static bool NoSharedCache { get; set; }
 
         public static string LocalCacheRoot { get; set; }
+
+        public static string DefaultLocalCacheRoot {
+            get
+            {
+                string homeDirectory = null;
+                string cachePath = ".scalarCache";
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    homeDirectory = Path.GetPathRoot(Properties.Settings.Default.EnlistmentRoot);
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    homeDirectory = Environment.GetEnvironmentVariable("HOME");
+                }
+                else
+                {
+                    // On Linux we use a local cache path per the XDG Base Directory Specification.
+                    homeDirectory = Environment.GetEnvironmentVariable("XDG_CACHE_HOME");
+                    if (!string.IsNullOrEmpty(homeDirectory))
+                    {
+                        cachePath = "scalar";
+                    }
+                    else
+                    {
+                        homeDirectory = Environment.GetEnvironmentVariable("HOME");
+                        cachePath = Path.Combine(".cache", "scalar");
+                    }
+
+                }
+
+                return Path.Combine(homeDirectory, cachePath);
+            }
+        }
 
         public static object[] FileSystemRunners { get; set; }
 

--- a/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
+++ b/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
@@ -57,7 +57,7 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase]
-        [Category(Categories.MacOnly)]
+        [Category(Categories.POSIXOnly)]
         public void CloneWithDefaultLocalCacheLocation()
         {
             FileSystemRunner fileSystem = FileSystemRunner.DefaultRunner;

--- a/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
+++ b/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
@@ -61,8 +61,9 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
         public void CloneWithDefaultLocalCacheLocation()
         {
             FileSystemRunner fileSystem = FileSystemRunner.DefaultRunner;
-            string homeDirectory = Environment.GetEnvironmentVariable("HOME");
-            homeDirectory.ShouldBeADirectory(fileSystem);
+            string defaultLocalCacheRoot = ScalarTestConfig.DefaultLocalCacheRoot;
+            fileSystem.CreateDirectory(defaultLocalCacheRoot);
+            defaultLocalCacheRoot.ShouldBeADirectory(fileSystem);
 
             string newEnlistmentRoot = ScalarFunctionalTestEnlistment.GetUniqueEnlistmentRoot();
 
@@ -80,8 +81,7 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
 
             string gitObjectsRoot = ScalarHelpers.GetObjectsRootFromGitConfig(Path.Combine(newEnlistmentRoot, "src"));
 
-            string defaultScalarCacheRoot = Path.Combine(homeDirectory, ".scalarCache");
-            gitObjectsRoot.StartsWith(defaultScalarCacheRoot, StringComparison.Ordinal).ShouldBeTrue($"Git objects root did not default to using {homeDirectory}");
+            gitObjectsRoot.StartsWith(defaultLocalCacheRoot, StringComparison.Ordinal).ShouldBeTrue($"Git objects root did not default to using {defaultLocalCacheRoot}");
 
             RepositoryHelpers.DeleteTestDirectory(newEnlistmentRoot);
         }

--- a/Scalar.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
+++ b/Scalar.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
@@ -548,17 +548,17 @@ namespace Scalar.FunctionalTests.Tests.GitCommands
             this.CommitChangesSwitchBranchSwitchBack(fileSystemAction: this.RenameFile);
         }
 
-        // MacOnly because renames of partial folders are blocked on Windows
+        // Mac and Linux only because renames of partial folders are blocked on Windows
         [TestCase]
-        [Category(Categories.MacOnly)]
+        [Category(Categories.POSIXOnly)]
         public void MoveFolderCommitChangesSwitchBranchSwitchBackTest()
         {
             this.CommitChangesSwitchBranchSwitchBack(fileSystemAction: this.MoveFolder);
         }
 
-        // MacOnly because Windows does not support file mode
+        // Mac and Linux only because Windows does not support file mode
         [TestCase]
-        [Category(Categories.MacOnly)]
+        [Category(Categories.POSIXOnly)]
         public void UpdateFileModeOnly()
         {
             const string TestFileName = "test-file-mode";

--- a/Scalar.FunctionalTests/Tools/TestConstants.cs
+++ b/Scalar.FunctionalTests/Tools/TestConstants.cs
@@ -7,6 +7,28 @@ namespace Scalar.FunctionalTests.Tools
         public const char GitPathSeparator = '/';
         public const string InternalUseOnlyFlag = "--internal_use_only";
 
+        public const string DefaultScalarCacheFolderName = ".scalarCache";
+
+        public static class POSIXPlatform
+        {
+            public static class EnvironmentVariables
+            {
+                public const string LocalUserFolder = "HOME";
+            }
+        }
+
+        public static class LinuxPlatform
+        {
+            public static class EnvironmentVariables
+            {
+                public const string LocalUserCacheFolder = "XDG_CACHE_HOME";
+            }
+
+            public const string LocalScalarFolderName = "scalar";
+
+            public static readonly string LocalScalarCachePath = Path.Combine(".cache", LocalScalarFolderName);
+        }
+
         public static class DotGit
         {
             public const string Root = ".git";

--- a/Scripts/Linux/CleanupFunctionalTests.sh
+++ b/Scripts/Linux/CleanupFunctionalTests.sh
@@ -1,0 +1,9 @@
+. "$(dirname ${BASH_SOURCE[0]})/InitializeEnvironment.sh"
+
+pkill -9 -l Scalar.FunctionalTests
+pkill -9 -l git
+pkill -9 -l scalar
+
+if [ -d /Scalar.FT ]; then
+    sudo rm -r /Scalar.FT
+fi

--- a/Scripts/Linux/RunFunctionalTests.sh
+++ b/Scripts/Linux/RunFunctionalTests.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+. "$(dirname ${BASH_SOURCE[0]})/InitializeEnvironment.sh"
+
+CONFIGURATION=$1
+if [ -z $CONFIGURATION ]; then
+  CONFIGURATION=Debug
+fi
+
+TESTS_EXEC=$SCALAR_OUTPUTDIR/Scalar.FunctionalTests/bin/$CONFIGURATION/netcoreapp3.1/linux-x64/publish/Scalar.FunctionalTests
+
+mkdir ~/Scalar.FT
+
+# Consume the first argument
+shift
+
+# Ensure the binary is executable
+chmod +x $TESTS_EXEC
+
+# Run the tests!
+$TESTS_EXEC "$@"

--- a/Scripts/Linux/RunFunctionalTests.sh
+++ b/Scripts/Linux/RunFunctionalTests.sh
@@ -7,7 +7,20 @@ if [ -z $CONFIGURATION ]; then
   CONFIGURATION=Debug
 fi
 
-TESTS_EXEC=$SCALAR_OUTPUTDIR/Scalar.FunctionalTests/bin/$CONFIGURATION/netcoreapp3.1/linux-x64/publish/Scalar.FunctionalTests
+PUBLISH_FRAGMENT="bin/$CONFIGURATION/netcoreapp3.1/linux-x64/publish"
+FUNCTIONAL_TESTS_DIR="$SCALAR_OUTPUTDIR/Scalar.FunctionalTests/$PUBLISH_FRAGMENT"
+
+if [ "$2" = "--test-scalar-on-path" ]; then
+  echo "PATH:"
+  echo "$PATH"
+  echo "Scalar location:"
+  where scalar
+else
+  # Copy most recently build Scalar binaries
+  rsync -r "$SCALAR_OUTPUTDIR/Scalar/$PUBLISH_FRAGMENT/" "$FUNCTIONAL_TESTS_DIR"
+fi
+
+TESTS_EXEC="$FUNCTIONAL_TESTS_DIR/Scalar.FunctionalTests"
 
 mkdir ~/Scalar.FT
 


### PR DESCRIPTION
This PR adds functional test scripts for Linux, adjusts a number of Mac-specific syscall wrappers and `FileSystemRunners` to be either POSIX-generic or have Linux-specific equivalents, makes some minor updates to align Linux packaging details with other platforms, and refactors the setup of the cache, config, and data directories on POSIX platforms to support (in the Linux case only) the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).

It should be possible to review either commit-by-commit or as a single set of changes; the former might be slightly easier, though.

---

The (partial) support for the XDG specification comprises the majority of the changes in this PR, and is motivated by the fact that the functional tests depend on the value returned by `GetDataRootForScalarImplementation()` in `LinuxPlatform.Shared.cs`, and we [currently](https://github.com/microsoft/scalar/blob/5c5cf305ca13fa0797205b3a0b82aaeecd72fe37/Scalar.Common/Platforms/Linux/LinuxPlatform.Shared.cs#L10-L15) return the value of either a custom environment variable or a default of `/var/run/scalar`, which may not be accessible to a non-root user and thus cause the tests to fail.  While we could return a simple `$HOME/.scalar` response, following the XDG specification allows us to make parallel changes so that on Linux we utilize the relevant locations for all three types of files, which by default will be:
- cache files in `~/.cache/scalar`
- config files in `~/.config/scalar`
- data files in `~/.local/share/scalar`

Although our implementation is not 100% complete (yet), it does permit runs of the functional test suite on Linux, and moreover allows for runs which avoid polluting these locations by defining the relevant `$XDG_{CACHE,CONFIG,DATA}_HOME` environment variables.

What remains to be done, if desired, is described in a [comment](https://github.com/chrisd8088/scalar/blob/a4cee25d6d9a3cee92ead14e52e0db04d3491967/Scalar.Common/Platforms/Linux/LinuxPlatform.cs#L22-L27) in `LinuxPlatform.cs` as well as the description for commit 9e859dfd28e5e0478fa1a7de9dbfe865129062b9:
```
Note that on Linux we do not yet create missing directories with
a 0700 mode, as specified by the XDG standard, and we also do not
check system-wide locations from either the $XDG_{CONFIG,DATA}_DIRS
environment variables or the defaults for them.  The latter
might require more extensive refactoring to distinguish cases
in which user-specific data or configurations are to be written,
as these should possibly not be written to system-wide files.
```

We also slightly refactor the `CloneTests.CloneWithDefaultLocalCacheLocation()` functional test, which runs on POSIX platforms only, so as to ensure it passes on Linux regardless of whether the `$XDG_CACHE_HOME` environment variable is set or not.  This change depends on the introduction of a `ScalarTestConfig.DefaultLocalCacheRoot ` accessor which returns the appropriate cache path on each platform.