### PR TITLE
simplify and align functional test CI and docs, and fix failing skipped test

### DIFF
--- a/.azure-pipelines/templates/osx/functional-test.yml
+++ b/.azure-pipelines/templates/osx/functional-test.yml
@@ -40,7 +40,7 @@ steps:
     - bash: watchman log-level debug
       displayName: Set watchman log level to debug
 
-  - bash: $(Build.BinariesDirectory)/ft/src/Scripts/Mac/RunFunctionalTests.sh $(configuration) --test-scalar-on-path --trace2-output=$(Build.ArtifactStagingDirectory)/logs/trace2-event.log
+  - bash: $(Build.BinariesDirectory)/ft/src/Scripts/Mac/RunFunctionalTests.sh $(configuration) --full-suite --test-scalar-on-path --trace2-output=$(Build.ArtifactStagingDirectory)/logs/trace2-event.log
     displayName: Run functional tests
 
   - ${{ if eq(parameters.useWatchman, 'true') }}:

--- a/.azure-pipelines/templates/win/functional-test.yml
+++ b/.azure-pipelines/templates/win/functional-test.yml
@@ -32,7 +32,7 @@ steps:
   - script: git config --global credential.interactive never
     displayName: Disable interactive auth
 
-  - script: $(Build.BinariesDirectory)\ft\src\Scripts\RunFunctionalTests.bat $(configuration) --test-scalar-on-path "--trace2-output=$(Build.ArtifactStagingDirectory)\logs\trace2-event.log"
+  - script: $(Build.BinariesDirectory)\ft\src\Scripts\RunFunctionalTests.bat $(configuration) --full-suite --test-scalar-on-path "--trace2-output=$(Build.ArtifactStagingDirectory)\logs\trace2-event.log"
     displayName: Run functional tests
 
   - ${{ if eq(parameters.useWatchman, 'true') }}:

--- a/AuthoringTests.md
+++ b/AuthoringTests.md
@@ -40,12 +40,7 @@ The functional tests are built on NUnit 3, which is available as a set of NuGet 
 
 #### Selecting Which Tests are Run
 
-By default, the functional tests run a subset of tests as a quick smoke test for developers.  There are mutually exclusive arguments that can be passed to the functional tests to change this behavior:
-
-- `--full-suite`: Run all configurations of all functional tests
-- `--windows-only`: Run only the tests marked as being Windows specific
-
-**NOTE** `Scripts\RunFunctionalTests.bat` already uses some of these arguments.  If you run the tests using `RunFunctionalTests.bat` consider locally modifying the script rather than passing these flags as arguments to the script.
+By default, the functional tests run on a single configuration.  Passing the `--full-suite` option runs all tests on all configurations.
 
 ### Mac
 

--- a/AuthoringTests.md
+++ b/AuthoringTests.md
@@ -5,19 +5,8 @@
 #### Runnable functional test projects
 
 - `Scalar.FunctionalTests`
-- `Scalar.FunctionalTests.Windows`
 
-`Scalar.FunctionalTests` is a .NET Core project and contains all cross-platform functional tests.  `Scalar.FunctionalTests.Windows`, contains functional tests that require Windows. Additionally, `Scalar.FunctionalTests.Windows` includes all the `Scalar.FunctionalTests` allowing it to run both cross-platform and Windows-specific functional tests.
-
-#### Other functional test projects
-
-*Scalar.NativeTests*
-
-`Scalar.NativeTests` contains tests written in C++ that use the Windows API directly.  These tests are called from the managed tests (see above) using PInvoke.
-
-*Scalar.FunctionalTests.LockHolder*
-
-The `LockHolder` is a small program that allows the functional tests to request and release the `ScalarLock`.  `LockHolder` is useful for simulating different timing/race conditions.
+`Scalar.FunctionalTests` is a .NET Core project and contains all cross-platform functional tests.
 
 ## Running the Functional Tests
 
@@ -34,7 +23,7 @@ The functional tests are built on NUnit 3, which is available as a set of NuGet 
 2. Run the Scalar installer that was built in step 2.  This will ensure that Scalar will be able to find the correct version of the pre/post-command hooks. The installer will be placed in `BuildOutput\Scalar.Installer.Windows\bin\x64\<Debug or Release>`
 3. Run the tests **with elevation**.  Elevation is required because the functional tests create and delete a test service.
 
-   **Option 1:** Run the `Scalar.FunctionalTests.Windows` project from inside Visual Studio launched as Administrator.
+   **Option 1:** Run the `Scalar.FunctionalTests` project from inside Visual Studio launched as Administrator.
    
    **Option 2:** Run `Scripts\RunFunctionalTests.bat` from CMD launched as Administrator.
 
@@ -73,34 +62,30 @@ Note that the test name must include the class and namespace and that `Debug` or
 
 Windows (Script):
 
-`Scripts\RunFunctionalTests.bat Debug --test=Scalar.FunctionalTests.Tests.EnlistmentPerFixture.GitFilesTests.CreateFileTest`
+`Scripts\RunFunctionalTests.bat Debug --test=Scalar.FunctionalTests.Tests.EnlistmentPerFixture.CloneTests.CloneToPathWithSpaces
 
 Windows (Visual Studio):
 
-1. Set `Scalar.FunctionalTests.Windows` as StartUp project
-2. Project Properties->Debug->Start options->Command line arguments (all on a single line): `--test=Scalar.FunctionalTests.Tests.EnlistmentPerFixture.GitFilesTests.CreateFileTest`
+1. Set `Scalar.FunctionalTests` as StartUp project
+2. Project Properties->Debug->Start options->Command line arguments (all on a single line): `--test=Scalar.FunctionalTests.Tests.EnlistmentPerFixture.CloneTests.CloneToPathWithSpaces
 
 Mac:
 
-`Scripts/Mac/RunFunctionalTests.sh Debug --test=Scalar.FunctionalTests.Tests.EnlistmentPerFixture.GitFilesTests.CreateFileTest`
+`Scripts/Mac/RunFunctionalTests.sh Debug --test=Scalar.FunctionalTests.Tests.EnlistmentPerFixture.CloneTests.CloneToPathWithSpaces`
 
 ## How to Write a Functional Test
 
 Each piece of functionality that we add to Scalar should have corresponding functional tests that clone a repo and use existing tools and filesystem APIs to interact with the virtual repo.
 
 Since these are functional tests that can potentially modify the state of files on disk, you need to be careful to make sure each test can run in a clean 
-environment.  There are three base classes that you can derive from when writing your tests.  It's also important to put your new class into the same namespace
+environment.  There are two base classes that you can derive from when writing your tests.  It's also important to put your new class into the same namespace
 as the base class, because NUnit treats namespaces like test suites, and we have logic that keys off that for deciding when to create enlistments.
 
-1. `TestsWithLongRunningEnlistment`
-
-    Before any test in this namespace is executed, we create a single enlistment.  We then run all tests in this namespace that derive from this base class.  Only put tests in here that are purely readonly and will leave the repo in a good state for future tests.
-
-2. `TestsWithEnlistmentPerFixture`
+1. `TestsWithEnlistmentPerFixture`
 
     For any test fixture (a fixture is the same as a class in NUnit) that derives from this class, we create an enlistment before running any of the tests in the fixture, and then we delete the enlistment after all tests are done (but before any other fixture runs).  If you need to write a sequence of tests that manipulate the same repo, this is the right base class.
 
-3. `TestsWithEnlistmentPerTestCase`
+2. `TestsWithEnlistmentPerTestCase`
 
    Derive from this class if you need a new enlistment created for each test case.  This is the most reliable, but also most expensive option.
 

--- a/AuthoringTests.md
+++ b/AuthoringTests.md
@@ -40,10 +40,9 @@ The functional tests are built on NUnit 3, which is available as a set of NuGet 
 
 #### Selecting Which Tests are Run
 
-By default, the functional tests run a subset of tests as a quick smoke test for developers.  There are three mutually exclusive arguments that can be passed to the functional tests to change this behavior:
+By default, the functional tests run a subset of tests as a quick smoke test for developers.  There are mutually exclusive arguments that can be passed to the functional tests to change this behavior:
 
 - `--full-suite`: Run all configurations of all functional tests
-- `--extra-only`: Run only those tests marked as "ExtraCoverage" (i.e. the tests that are not run by default)
 - `--windows-only`: Run only the tests marked as being Windows specific
 
 **NOTE** `Scripts\RunFunctionalTests.bat` already uses some of these arguments.  If you run the tests using `RunFunctionalTests.bat` consider locally modifying the script rather than passing these flags as arguments to the script.

--- a/Scalar.FunctionalTests/Categories.cs
+++ b/Scalar.FunctionalTests/Categories.cs
@@ -2,7 +2,6 @@ namespace Scalar.FunctionalTests
 {
     public static class Categories
     {
-        public const string ExtraCoverage = "ExtraCoverage";
         public const string GitCommands = "GitCommands";
 
         public const string WindowsOnly = "WindowsOnly";

--- a/Scalar.FunctionalTests/Program.cs
+++ b/Scalar.FunctionalTests/Program.cs
@@ -69,16 +69,6 @@ namespace Scalar.FunctionalTests
             }
             else
             {
-                if (runner.HasCustomArg("--extra-only"))
-                {
-                    Console.WriteLine("Running only the tests marked as ExtraCoverage");
-                    includeCategories.Add(Categories.ExtraCoverage);
-                }
-                else
-                {
-                    excludeCategories.Add(Categories.ExtraCoverage);
-                }
-
                 ScalarTestConfig.FileSystemRunners = FileSystemRunners.FileSystemRunner.DefaultRunners;
             }
 
@@ -92,10 +82,6 @@ namespace Scalar.FunctionalTests
                 if (runner.HasCustomArg("--windows-only"))
                 {
                     includeCategories.Add(Categories.WindowsOnly);
-
-                    // RunTests unions all includeCategories.  Remove ExtraCoverage to
-                    // ensure that we only run tests flagged as WindowsOnly
-                    includeCategories.Remove(Categories.ExtraCoverage);
                 }
 
                 excludeCategories.Add(Categories.MacOnly);

--- a/Scalar.FunctionalTests/Program.cs
+++ b/Scalar.FunctionalTests/Program.cs
@@ -116,18 +116,6 @@ namespace Scalar.FunctionalTests
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 ScalarServiceProcess.InstallService();
-
-                string statusCacheVersionTokenPath = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles, Environment.SpecialFolderOption.Create),
-                    "Scalar",
-                    "ProgramData",
-                    "Scalar.Service",
-                    "EnableGitStatusCacheToken.dat");
-
-                if (!File.Exists(statusCacheVersionTokenPath))
-                {
-                    File.WriteAllText(statusCacheVersionTokenPath, string.Empty);
-                }
             }
         }
     }

--- a/Scalar.FunctionalTests/Program.cs
+++ b/Scalar.FunctionalTests/Program.cs
@@ -79,11 +79,6 @@ namespace Scalar.FunctionalTests
             }
             else
             {
-                if (runner.HasCustomArg("--windows-only"))
-                {
-                    includeCategories.Add(Categories.WindowsOnly);
-                }
-
                 excludeCategories.Add(Categories.MacOnly);
             }
 

--- a/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/CacheServerTests.cs
+++ b/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/CacheServerTests.cs
@@ -5,7 +5,6 @@ using Scalar.Tests.Should;
 namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
 {
     [TestFixture]
-    [Category(Categories.ExtraCoverage)]
     public class CacheServerTests : TestsWithEnlistmentPerFixture
     {
         private const string CustomUrl = "https://myCache";

--- a/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/FetchStepWithoutSharedCacheTests.cs
+++ b/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/FetchStepWithoutSharedCacheTests.cs
@@ -8,7 +8,6 @@ using System.IO;
 namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
 {
     [TestFixture]
-    [Category(Categories.ExtraCoverage)]
     public class FetchStepWithoutSharedCacheTests : TestsWithEnlistmentPerFixture
     {
         private const string PrefetchPackPrefix = "prefetch";

--- a/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/FetchStepWithoutSharedCacheTests.cs
+++ b/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/FetchStepWithoutSharedCacheTests.cs
@@ -100,8 +100,9 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
             this.TempPackRoot.ShouldBeADirectory(this.fileSystem).WithNoItems();
         }
 
+        // WindowsOnly because the test depends on Windows-specific file sharing behavior
         [TestCase, Order(4)]
-        [Category(Categories.MacTODO.TestNeedsToLockFile)]
+        [Category(Categories.WindowsOnly)]
         public void FetchStepFailsWhenItCannotRemoveABadPrefetchPack()
         {
             this.Enlistment.Unregister();
@@ -118,9 +119,10 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
             // Open a handle to the bad pack that will prevent fetch-commits-and-trees from being able to delete it
             using (FileStream stream = new FileStream(badPackPath, FileMode.Open, FileAccess.Read, FileShare.None))
             {
-                string output = this.Enlistment.RunVerb("fetch", failOnError: false);
-                output.ShouldContain($"Unable to delete {badPackPath}");
+                this.Enlistment.RunVerb("fetch", failOnError: false);
             }
+
+            badPackPath.ShouldBeAFile(this.fileSystem).WithContents(badContents);
 
             // After handle is closed fetching commits and trees should succeed
             this.Enlistment.RunVerb("fetch");

--- a/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/ScalarUpgradeReminderTests.cs
+++ b/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/ScalarUpgradeReminderTests.cs
@@ -12,7 +12,6 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
 {
     [TestFixture]
     [NonParallelizable]
-    [Category(Categories.ExtraCoverage)]
     [Category(Categories.WindowsOnly)]
     [Category(Categories.NeedsUpdatesForNonVirtualizedMode)]
     public class UpgradeReminderTests : TestsWithEnlistmentPerFixture

--- a/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/ConfigVerbTests.cs
+++ b/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/ConfigVerbTests.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
 {
     [TestFixture]
-    [Category(Categories.ExtraCoverage)]
     [Category(Categories.NeedsUpdatesForNonVirtualizedMode)]
     public class ConfigVerbTests : TestsWithMultiEnlistment
     {

--- a/Scripts/Mac/RunFunctionalTests.sh
+++ b/Scripts/Mac/RunFunctionalTests.sh
@@ -18,4 +18,4 @@ shift
 chmod +x $TESTS_EXEC
 
 # Run the tests!
-$TESTS_EXEC --full-suite "$@"
+$TESTS_EXEC "$@"


### PR DESCRIPTION
This PR aims to simplify the options for the functional test program, align them between macOS and Windows (including in CI), update the relevant documentation, and fix a failing test so it runs and passes on all platforms.

It may be easiest to review commit-by-commit, but I've also tried to put all of the relevant background into this description as well.

----

The CI jobs run `Scripts\RunFunctionalTests.bat --test-scalar-on-path` on [Windows](https://github.com/microsoft/scalar/blob/562f127885580baee20769b981da0601787481d8/.azure-pipelines/templates/win/functional-test.yml#L35) and `Scripts/Mac/RunFunctionalTests.sh --test-scalar-on-path` on [macOS](https://github.com/microsoft/scalar/blob/562f127885580baee20769b981da0601787481d8/.azure-pipelines/templates/osx/functional-test.yml#L43).  However, these two scripts are different in that the Mac one [adds](https://github.com/microsoft/scalar/blob/562f127885580baee20769b981da0601787481d8/Scripts/Mac/RunFunctionalTests.sh#L21) the `--full-suite` option while the Windows one does [not](https://github.com/microsoft/scalar/blob/562f127885580baee20769b981da0601787481d8/Scripts/RunFunctionalTests.bat#L40).

One consequence of this is that about 7 additional tests run on macOS than Windows, in the Azure Pipelines CI jobs; for example in this recent [build](https://dev.azure.com/mseng/Scalar/_build/results?buildId=12872947):
```
Test Count: 189, Passed: 185, Failed: 0, Warnings: 0, Inconclusive: 0, Skipped: 4

Test Count: 196, Passed: 192, Failed: 0, Warnings: 0, Inconclusive: 0, Skipped: 4
```

Specifically these tests are from the [`CacheServerTests`](https://github.com/microsoft/scalar/blob/562f127885580baee20769b981da0601787481d8/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/CacheServerTests.cs#L8) and [`FetchStepWithoutSharedCacheTests`](https://github.com/microsoft/scalar/blob/562f127885580baee20769b981da0601787481d8/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/FetchStepWithoutSharedCacheTests.cs#L11) classes.

One of the latter `FetchStepWithoutSharedCacheTests` currently fails on Windows (the only platform on which it executed, due to its categorization as `MacTODO.TestNeedsToLockFile`); see for example this Azure Pipeline [run](https://dev.azure.com/mseng/Scalar/_build/results?buildId=12954958&view=logs&jobId=bc04dc6a-0ef6-5ae3-a0cb-93e4ecebc639&j=bc04dc6a-0ef6-5ae3-a0cb-93e4ecebc639&t=664a6552-7b48-5d89-33e0-43cbec01c58d) in which the `ExtraCoverage` tests were included on Windows.  The failure may have been introduced with the refactoring of the `RunVerb` logic in PR #295, and not noticed because the CI framework happens to skip this Windows-exclusive job on Windows.

----

First, we remove the `ExtraCoverage` category and `--extra-only` functional test program option, as well as the `--windows-only` option.

The `ExtraCoverage` category only includes a small number of tests now, and many of those are marked `NeedsUpdatesForNonVirtualizedMode` so they don't execute at all.  Originally introduced in microsoft/VFSForGit#1046 as an [enhancement](https://github.com/microsoft/VFSForGit/pull/1046#issuecomment-484560656) over the `FullSuiteOnly` category from the Azure Repos PR 302803, with the intent of speeding developer test runs.  Given the small remaining set of working tests in the category, it seems simplest to just remove it.

For similar reasons, we remove the `--windows-only` option (while keeping the `WindowsOnly` category).  We could add matching `--mac-only` and `--linux-only` options, but given the small number of relevant tests, this seems too complex for now.

The `--full-suite` option currently has no effect, because the only tests parameterized over the set of [`FileSystemRunners`](https://github.com/microsoft/scalar/blob/562f127885580baee20769b981da0601787481d8/Scalar.FunctionalTests/FileSystemRunners/FileSystemRunner.cs#L34) in [`ScalarTestConfig`](https://github.com/microsoft/scalar/blob/562f127885580baee20769b981da0601787481d8/Scalar.FunctionalTests/ScalarTestConfig.cs#L13) are the [`GitMoveRenameTests`](https://github.com/microsoft/scalar/blob/562f127885580baee20769b981da0601787481d8/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/GitMoveRenameTests.cs#L11), and since these are marked `NeedsUpdatesForNonVirtualizedMode` they don't run at all.  With the `ExtraCoverage` category removed, this means the difference between the Windows `RunFunctionalTests.bat` script and the Mac `RunFunctionalTests.sh` one (where the latter uses `--full-suite` but not the former) no longer has an effect, and the `FetchStepFailsWhenItCannotRemoveABadPrefetchPack()` test will now run, and fail, on Windows CI jobs.

We could remove `--full-suite` but instead choose to simply align the Mac `RunFunctionalTests.sh` script with the Windows equivalent (i.e., not passing that option by default), and then adding the option to both platform's scripts in our Azure Pipelines configurations.  This way, if the option does begin to have an effect again in the future, it will run on all CI jobs but won't slow down manual tests.

We update the `AuthoringTests.md` documentation to reflect these changes as well as others which have been introduced since this project diverged from VFSForGit, particularly the removal of a number of specialized test programs,
classes, and options.

Another cleanup we make is to remove the creation of the `EnableGitStatusCacheToken.dat` file on Windows by the functional test program, since the relevant implementation was removed in PR #29.

Lastly, we address the skipped-and-failing `FetchStepFailsWhenItCannotRemoveABadPrefetchPack()` functional
test, which was looking for the string `"Unable to delete"` in the output from a Scalar `run fetch` command.  That string is no longer output by `ReportErrorAndExit()` as a result of PR #295, which introduced a common progress meter to the `run` command.  To resolve the test failure we simply check for the continued presence of the locked bad pack file after the first fetch attempt instead of parsing for a specific text string.

The test is also Windows-specific because it depends on an open file handle with a `FileShare.None` attribute blocking attempts by other processes to delete the file, and this only works in C# on the Windows platform.  On Unix platforms, the C# core libraries implement file sharing in an [advisory](https://github.com/dotnet/runtime/blob/341b8b22280e297daa7d96b4b8a9fa1d40d28aa9/src/libraries/System.Private.CoreLib/src/System/IO/FileStream.Unix.cs#L73-L88) manner only, meaning other programs may simply delete the file.

We therefore mark this test as `WindowsOnly`, since it effectively does not apply to other platforms.  Note that the previous category assigned to the test, `MacTODO.TestNeedsToLockFile`, dates from VFSForGit and has been migrated to just this one test as a result of changes in PR #170.  However, the meaning of that category varies, so we clarify the situation by just marking this `WindowsOnly`.