### PR TITLE
Actions: run functional tests on all platforms (without Watchman)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,8 +12,12 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, windows-2019, macos-10.15]
+
+    env:
+      BUILD_FRAGMENT: bin/Release/netcoreapp3.1
 
     steps:
     - uses: actions/checkout@v2
@@ -25,13 +29,72 @@ jobs:
       with:
         dotnet-version: 3.1.302
 
-    - name: Install Dependencies
+    - name: Install dependencies
       run: dotnet restore
       env:
         DOTNET_NOLOGO: 1
 
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build --configuration Release --no-restore -p:UseAppHost=true # Force generation of executable on macOS.
 
-    - name: Unit Test
+    - name: Unit test
       run: dotnet test --no-restore
+
+    - name: Setup platform (Linux)
+      if: runner.os == 'Linux'
+      run: echo "::set-env name=BUILD_PLATFORM::${{ runner.os }}"
+
+    - name: Setup platform (Mac)
+      if: runner.os == 'macOS'
+      run: echo '::set-env name=BUILD_PLATFORM::Mac'
+
+    - name: Setup platform (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        echo "::set-env name=BUILD_PLATFORM::${{ runner.os }}"
+        echo '::set-env name=BUILD_FILE_EXT::.exe'
+
+    - name: Setup Git installer
+      shell: bash
+      run: |
+        GIT_VERSION=$(grep '<GitPackageVersion>' Directory.Build.props | grep -Eo '[0-9.]+(-\w+)*')
+        cd ../out
+        dotnet new classlib -n Scalar.GitInstaller
+        cd Scalar.GitInstaller
+        cp ../../scalar/nuget.config .
+        dotnet add Scalar.GitInstaller.csproj package "GitFor${BUILD_PLATFORM}.GVFS.Installer" --package-directory . --version "$GIT_VERSION"
+
+    - name: Install Git (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        cd ../out/Scalar.GitInstaller
+        sudo apt-get install -y $(find . -type f -name '*.deb')
+
+    - name: Install Git (Mac)
+      if: runner.os == 'macOS'
+      run: |
+        cd ../out/Scalar.GitInstaller
+        sudo /usr/sbin/installer -pkg $(find . -type f -name '*.pkg') -target /
+
+    - name: Install Git (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        Set-Location -Path ..\out\Scalar.GitInstaller
+        Write-Host 'Uninstalling Git ...'
+        foreach ($file in Get-ChildItem 'C:\Program Files\Git' -Recurse -File -Include 'unins*.exe') {
+          & $file.Fullname /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+          Wait-Process -Name $file.Basename
+        }
+        Remove-Item 'C:\Program Files\Git' -Recurse -Force
+        Write-Host 'Installing GitForWindows ...'
+        $files = Get-ChildItem . -Recurse -File -Include 'Git-*.vfs.*.exe'
+        & $files[0].Fullname /DIR="C:\Program Files\Git" /NOICONS /COMPONENTS="ext,ext\shellhere,ext\guihere,assoc,assoc_sh" /GROUP="Git" /SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /ALLOWDOWNGRADE=1 /LOG=install.log
+        Wait-Process $files[0].Basename
+        Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\GitForWindows'
+
+    - name: Functional test
+      shell: bash
+      run: |
+        cd ../out
+        PATH="$PWD/Scalar/$BUILD_FRAGMENT:$PWD/Scalar.Service/$BUILD_FRAGMENT:$PATH"
+        Scalar.FunctionalTests/$BUILD_FRAGMENT/Scalar.FunctionalTests$BUILD_FILE_EXT --test-scalar-on-path --full-suite


### PR DESCRIPTION
To run the functional test suite in GitHub Actions, we write platform-specific steps to install the GVFS Git package, but then use a single common step to run the functional tests themselves.

The Actions YAML steps added in this PR resulted in a recent [successful run](https://github.com/chrisd8088/scalar/runs/1103660793) on all platforms.

This PR builds on #422, which adds functional test support on Linux, and can be rebased once that PR is accepted and merged into `main`.

---

The commands in the Git installer steps are drawn in part from those found in the existing `Scalar.Installer.{Mac,Windows}/InstallScalar.template.{sh,bat}` scripts.

On Windows, we specifically need to ensure that our version of Git is the one in `C:\Program Files\Git\cmd\git.exe`, so we start install process by uninstalling the GitForWindows version provided on the Actions instance.  For future debugging purposes we also include a final `Get-ItemProperty` PowerShell query to report whether we successfully updated the GitForWindows registry entry.

We also disable the fast-fail option on our matrix builds so all platforms will run to completion, allowing us to see any mix of platform-specific errors without short-circuting due to the first CI failure on any platform.

Note that we do not yet install Watchman or provide additional functional test runs using it; that work remains to be done.