### PR TITLE
use platform-specific filepath matching and add or revise relevant tests

### DIFF
--- a/Scalar.Common/GitHubUpgrader.cs
+++ b/Scalar.Common/GitHubUpgrader.cs
@@ -29,7 +29,7 @@ namespace Scalar.Common
         private const string GitSigner = "Johannes Schindelin";
         private const string GitCertIssuer = "COMODO RSA Code Signing CA";
 
-        private static readonly HashSet<string> ScalarInstallerFileNamePrefixCandidates = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        private static readonly HashSet<string> ScalarInstallerFileNamePrefixCandidates = new HashSet<string>(ScalarPlatform.Instance.Constants.PathComparer)
         {
             "SetupScalar",
             "Scalar"
@@ -152,7 +152,7 @@ namespace Scalar.Common
 
             foreach (Asset asset in this.newestRelease.Assets)
             {
-                bool targetOSMatch = string.Equals(Path.GetExtension(asset.Name), ScalarPlatform.Instance.Constants.InstallerExtension, StringComparison.OrdinalIgnoreCase);
+                bool targetOSMatch = string.Equals(Path.GetExtension(asset.Name), ScalarPlatform.Instance.Constants.InstallerExtension, ScalarPlatform.Instance.Constants.PathComparison);
                 bool isGitAsset = this.IsGitAsset(asset);
                 bool isScalarAsset = isGitAsset ? false : this.IsScalarAsset(asset);
                 if (!targetOSMatch || (!isScalarAsset && !isGitAsset))
@@ -461,7 +461,7 @@ namespace Scalar.Common
         {
             foreach (Asset asset in this.newestRelease.Assets)
             {
-                if (string.Equals(Path.GetExtension(asset.Name), ScalarPlatform.Instance.Constants.InstallerExtension, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(Path.GetExtension(asset.Name), ScalarPlatform.Instance.Constants.InstallerExtension, ScalarPlatform.Instance.Constants.PathComparison))
                 {
                     path = asset.LocalPath;
                     if (assetId == GitAssetId && this.IsGitAsset(asset))
@@ -497,7 +497,7 @@ namespace Scalar.Common
         {
             foreach (string fileNamePrefix in expectedFileNamePrefixes)
             {
-                if (asset.Name.StartsWith(fileNamePrefix, StringComparison.OrdinalIgnoreCase))
+                if (asset.Name.StartsWith(fileNamePrefix, ScalarPlatform.Instance.Constants.PathComparison))
                 {
                     return true;
                 }

--- a/Scalar.Common/Maintenance/FetchStep.cs
+++ b/Scalar.Common/Maintenance/FetchStep.cs
@@ -200,7 +200,7 @@ namespace Scalar.Common.Maintenance
         private static long? GetTimestamp(string packName)
         {
             string filename = Path.GetFileName(packName);
-            if (!filename.StartsWith(ScalarConstants.PrefetchPackPrefix, StringComparison.OrdinalIgnoreCase))
+            if (!filename.StartsWith(ScalarConstants.PrefetchPackPrefix, ScalarPlatform.Instance.Constants.PathComparison))
             {
                 return null;
             }
@@ -362,8 +362,8 @@ namespace Scalar.Common.Maintenance
             DirectoryItemInfo info = this.Context
                                          .FileSystem
                                          .ItemsInDirectory(this.Context.Enlistment.GitPackRoot)
-                                         .Where(item => item.Name.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
-                                                        && string.Equals(Path.GetExtension(item.Name), ".pack", StringComparison.OrdinalIgnoreCase))
+                                         .Where(item => item.Name.StartsWith(prefix, ScalarPlatform.Instance.Constants.PathComparison)
+                                                        && string.Equals(Path.GetExtension(item.Name), ".pack", ScalarPlatform.Instance.Constants.PathComparison))
                                          .FirstOrDefault();
             if (info == null)
             {
@@ -382,7 +382,7 @@ namespace Scalar.Common.Maintenance
             foreach (string keepFile in this.Context
                                      .FileSystem
                                      .ItemsInDirectory(this.Context.Enlistment.GitPackRoot)
-                                     .Where(item => item.Name.EndsWith(".keep", StringComparison.OrdinalIgnoreCase))
+                                     .Where(item => item.Name.EndsWith(".keep", ScalarPlatform.Instance.Constants.PathComparison))
                                      .Select(item => item.FullName))
             {
                 if (!keepFile.Equals(newKeepFile))

--- a/Scalar.Common/Maintenance/FetchStep.cs
+++ b/Scalar.Common/Maintenance/FetchStep.cs
@@ -382,6 +382,7 @@ namespace Scalar.Common.Maintenance
             foreach (string keepFile in this.Context
                                      .FileSystem
                                      .ItemsInDirectory(this.Context.Enlistment.GitPackRoot)
+                                     .Where(item => item.Name.StartsWith(ScalarConstants.PrefetchPackPrefix, ScalarPlatform.Instance.Constants.PathComparison))
                                      .Where(item => item.Name.EndsWith(".keep", ScalarPlatform.Instance.Constants.PathComparison))
                                      .Select(item => item.FullName))
             {

--- a/Scalar.Common/Maintenance/GitMaintenanceStep.cs
+++ b/Scalar.Common/Maintenance/GitMaintenanceStep.cs
@@ -153,7 +153,7 @@ namespace Scalar.Common.Maintenance
             {
                 string extension = Path.GetExtension(info.Name);
 
-                if (string.Equals(extension, ".pack", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(extension, ".pack", ScalarPlatform.Instance.Constants.PathComparison))
                 {
                     count++;
                     size += info.Length;
@@ -164,7 +164,7 @@ namespace Scalar.Common.Maintenance
                         maxSize = info.Length;
                     }
                 }
-                else if (string.Equals(extension, ".keep", StringComparison.OrdinalIgnoreCase))
+                else if (string.Equals(extension, ".keep", ScalarPlatform.Instance.Constants.PathComparison))
                 {
                     hasKeep = true;
                 }

--- a/Scalar.Common/Maintenance/GitProcessChecker.cs
+++ b/Scalar.Common/Maintenance/GitProcessChecker.cs
@@ -11,7 +11,7 @@ namespace Scalar.Common.Maintenance
         {
             Process[] allProcesses = Process.GetProcesses();
             return allProcesses
-                .Where(x => x.ProcessName.Equals("git", StringComparison.OrdinalIgnoreCase))
+                .Where(x => x.ProcessName.Equals("git", ScalarPlatform.Instance.Constants.PathComparison))
                 .Select(x => x.Id);
         }
     }

--- a/Scalar.Common/Maintenance/PackfileMaintenanceStep.cs
+++ b/Scalar.Common/Maintenance/PackfileMaintenanceStep.cs
@@ -69,7 +69,7 @@ namespace Scalar.Common.Maintenance
 
             foreach (DirectoryItemInfo info in packDirContents)
             {
-                if (string.Equals(Path.GetExtension(info.Name), ".idx", StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(Path.GetExtension(info.Name), ".idx", ScalarPlatform.Instance.Constants.PathComparison))
                 {
                     string pairedPack = Path.ChangeExtension(info.FullName, ".pack");
 

--- a/Scalar.Common/Platforms/Linux/LinuxFileSystem.cs
+++ b/Scalar.Common/Platforms/Linux/LinuxFileSystem.cs
@@ -20,12 +20,6 @@ namespace Scalar.Platform.Linux
             return NativeStat.IsSock(statBuffer.Mode);
         }
 
-        public override bool IsFileSystemSupported(string path, out string error)
-        {
-            error = null;
-            return true;
-        }
-
         private NativeStat.StatBuffer StatFile(string fileName)
         {
             if (NativeStat.Stat(fileName, out NativeStat.StatBuffer statBuffer) != 0)

--- a/Scalar.Common/Platforms/Linux/LinuxPlatform.cs
+++ b/Scalar.Common/Platforms/Linux/LinuxPlatform.cs
@@ -195,6 +195,8 @@ namespace Scalar.Platform.Linux
 
             // Documented here (in the addressing section): https://www.unix.com/man-page/linux/7/unix/
             public override int MaxPipePathLength => 108;
+
+            public override bool CaseSensitiveFileSystem => true;
         }
 
         private static class NativeMethods

--- a/Scalar.Common/Platforms/Mac/MacFileSystem.cs
+++ b/Scalar.Common/Platforms/Mac/MacFileSystem.cs
@@ -20,32 +20,6 @@ namespace Scalar.Platform.Mac
             return NativeStat.IsSock(statBuffer.Mode);
         }
 
-        public override bool IsFileSystemSupported(string path, out string error)
-        {
-            error = null;
-            try
-            {
-                string lowerCaseFilePath = Path.Combine(path, $"casetest{Guid.NewGuid().ToString()}");
-                string upperCaseFilePath = lowerCaseFilePath.ToUpper();
-
-                File.Create(lowerCaseFilePath);
-                if (File.Exists(upperCaseFilePath))
-                {
-                    File.Delete(lowerCaseFilePath);
-                    return true;
-                }
-
-                File.Delete(lowerCaseFilePath);
-                error = "Scalar does not support case sensitive filesystems";
-                return false;
-            }
-            catch (Exception ex)
-            {
-                error = $"Exception when performing {nameof(MacFileSystem)}.{nameof(this.IsFileSystemSupported)}: {ex.ToString()}";
-                return false;
-            }
-        }
-
         private NativeStat.StatBuffer StatFile(string fileName)
         {
             if (NativeStat.Stat(fileName, out NativeStat.StatBuffer statBuffer) != 0)

--- a/Scalar.Common/Platforms/Mac/MacPlatform.cs
+++ b/Scalar.Common/Platforms/Mac/MacPlatform.cs
@@ -198,6 +198,8 @@ namespace Scalar.Platform.Mac
 
             // Documented here (in the addressing section): https://www.unix.com/man-page/mojave/4/unix/
             public override int MaxPipePathLength => 104;
+
+            public override bool CaseSensitiveFileSystem => false;
         }
 
         private static class NativeMethods

--- a/Scalar.Common/Platforms/POSIX/POSIXFileSystem.cs
+++ b/Scalar.Common/Platforms/POSIX/POSIXFileSystem.cs
@@ -61,10 +61,9 @@ namespace Scalar.Platform.POSIX
             throw new NotImplementedException();
         }
 
-        public virtual bool IsFileSystemSupported(string path, out string error)
+        public bool IsFileSystemSupported(string path, out string error)
         {
-            error = null;
-            return true;
+            return ScalarPlatform.Instance.IsFileSystemCaseSensitivitySupported(path, out error);
         }
 
         [DllImport("libc", EntryPoint = "rename", SetLastError = true)]

--- a/Scalar.Common/Platforms/POSIX/POSIXPlatform.cs
+++ b/Scalar.Common/Platforms/POSIX/POSIXPlatform.cs
@@ -224,7 +224,7 @@ namespace Scalar.Platform.POSIX
 
             public override HashSet<string> UpgradeBlockingProcesses
             {
-                get { return new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "git", "wish" }; }
+                get { return new HashSet<string>(ScalarPlatform.Instance.Constants.PathComparer) { "git", "wish" }; }
             }
 
             public override bool SupportsUpgradeWhileRunning => true;

--- a/Scalar.Common/Platforms/Windows/WindowsFileSystem.cs
+++ b/Scalar.Common/Platforms/Windows/WindowsFileSystem.cs
@@ -100,7 +100,7 @@ namespace Scalar.Platform.Windows
         public bool IsExecutable(string fileName)
         {
             string fileExtension = Path.GetExtension(fileName);
-            return string.Equals(fileExtension, ".exe", StringComparison.OrdinalIgnoreCase);
+            return string.Equals(fileExtension, ".exe", ScalarPlatform.Instance.Constants.PathComparison);
         }
 
         public bool IsSocket(string fileName)

--- a/Scalar.Common/Platforms/Windows/WindowsFileSystem.cs
+++ b/Scalar.Common/Platforms/Windows/WindowsFileSystem.cs
@@ -179,8 +179,7 @@ namespace Scalar.Platform.Windows
 
         public bool IsFileSystemSupported(string path, out string error)
         {
-            error = null;
-            return true;
+            return ScalarPlatform.Instance.IsFileSystemCaseSensitivitySupported(path, out error);
         }
     }
 }

--- a/Scalar.Common/Platforms/Windows/WindowsPlatform.cs
+++ b/Scalar.Common/Platforms/Windows/WindowsPlatform.cs
@@ -445,11 +445,13 @@ namespace Scalar.Platform.Windows
 
             public override HashSet<string> UpgradeBlockingProcesses
             {
-                get { return new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Scalar", "git", "ssh-agent", "wish", "bash" }; }
+                get { return new HashSet<string>(ScalarPlatform.Instance.Constants.PathComparer) { "Scalar", "git", "ssh-agent", "wish", "bash" }; }
             }
 
             // Tests show that 250 is the max supported pipe name length
             public override int MaxPipePathLength => 250;
+
+            public override bool CaseSensitiveFileSystem => false;
         }
     }
 }

--- a/Scalar.Common/ScalarPlatform.cs
+++ b/Scalar.Common/ScalarPlatform.cs
@@ -164,6 +164,28 @@ namespace Scalar.Common
             /// </summary>
             public abstract HashSet<string> UpgradeBlockingProcesses { get; }
 
+            public abstract bool CaseSensitiveFileSystem { get; }
+
+            public StringComparison PathComparison
+            {
+                get
+                {
+                    return this.CaseSensitiveFileSystem ?
+                        StringComparison.Ordinal :
+                        StringComparison.OrdinalIgnoreCase;
+                }
+            }
+
+            public StringComparer PathComparer
+            {
+                get
+                {
+                    return this.CaseSensitiveFileSystem ?
+                        StringComparer.Ordinal :
+                        StringComparer.OrdinalIgnoreCase;
+                }
+            }
+
             public string ScalarUpgraderExecutableName
             {
                 get { return "Scalar.Upgrader" + this.ExecutableExtension; }

--- a/Scalar.Common/ScalarPlatform.cs
+++ b/Scalar.Common/ScalarPlatform.cs
@@ -131,6 +131,28 @@ namespace Scalar.Common
             return true;
         }
 
+        public bool IsFileSystemCaseSensitivitySupported(string path, out string errorMessage)
+        {
+            Exception ex = null;
+            bool caseSensitive = IsDirectoryCaseSensitive(path, out ex);
+
+            if (ex != null)
+            {
+                errorMessage = $"Exception when performing {nameof(this.IsFileSystemCaseSensitivitySupported)}: {ex.ToString()}";
+                return false;
+            }
+
+            bool caseSensitiveFileSystem = this.Constants.CaseSensitiveFileSystem;
+            if (caseSensitive != caseSensitiveFileSystem)
+            {
+                errorMessage = $"Scalar does not support case {(caseSensitiveFileSystem ? "in" : "")}sensitive filesystems on {this.Name}";
+                return false;
+            }
+
+            errorMessage = null;
+            return true;
+        }
+
         public abstract class ScalarPlatformConstants
         {
             public static readonly char PathSeparator = Path.DirectorySeparatorChar;
@@ -210,6 +232,30 @@ namespace Scalar.Common
             public bool SupportsScalarConfig { get; }
             public bool SupportsNuGetEncryption { get; }
             public bool SupportsNuGetVerification { get; }
+        }
+
+        private bool IsDirectoryCaseSensitive(string path, out Exception exception)
+        {
+            try
+            {
+                string lowerCaseFilePath = Path.Combine(path, $"casetest{Guid.NewGuid().ToString()}");
+                string upperCaseFilePath = lowerCaseFilePath.ToUpper();
+                bool isCaseSensitive;
+
+                using (FileStream fs = File.Create(lowerCaseFilePath))
+                {
+                }
+                isCaseSensitive = !File.Exists(upperCaseFilePath);
+                File.Delete(lowerCaseFilePath);
+
+                exception = null;
+                return isCaseSensitive;
+            }
+            catch (Exception e)
+            {
+                exception = e;
+                return false;
+            }
         }
     }
 }

--- a/Scalar.FunctionalTests/FileSystemRunners/CmdRunner.cs
+++ b/Scalar.FunctionalTests/FileSystemRunners/CmdRunner.cs
@@ -1,4 +1,5 @@
 using Scalar.Tests.Should;
+using Scalar.FunctionalTests.Tools;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -143,7 +144,7 @@ namespace Scalar.FunctionalTests.FileSystemRunners
 
             foreach (string directory in directories)
             {
-                if (directory.Equals(targetName, StringComparison.OrdinalIgnoreCase))
+                if (directory.Equals(targetName, FileSystemHelpers.PathComparison))
                 {
                     return true;
                 }

--- a/Scalar.FunctionalTests/Should/FileSystemShouldExtensions.cs
+++ b/Scalar.FunctionalTests/Should/FileSystemShouldExtensions.cs
@@ -249,7 +249,7 @@ namespace Scalar.FunctionalTests.Should
                 return info;
             }
 
-            private static bool IsMatchedPath(FileSystemInfo info, string repoRoot, string[] prefixes)
+            private static bool IsMatchedPath(FileSystemInfo info, string repoRoot, string[] prefixes, bool ignoreCase)
             {
                 if (prefixes == null || prefixes.Length == 0)
                 {
@@ -258,6 +258,7 @@ namespace Scalar.FunctionalTests.Should
 
                 string localPath = info.FullName.Substring(repoRoot.Length + 1);
                 int parentLength = localPath.LastIndexOf(System.IO.Path.DirectorySeparatorChar);
+                StringComparison pathComparison = ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 
                 string parentPath = null;
 
@@ -270,7 +271,7 @@ namespace Scalar.FunctionalTests.Should
                     parentPath = localPath.Substring(0, parentLength + 1);
                 }
 
-                if (localPath.Equals(".git", StringComparison.OrdinalIgnoreCase))
+                if (localPath.Equals(".git", pathComparison))
                 {
                     // Include _just_ the .git folder.
                     // All sub-items are not included in the enumerator.
@@ -286,13 +287,13 @@ namespace Scalar.FunctionalTests.Should
 
                 foreach (string prefixDir in prefixes)
                 {
-                    if (localPath.Equals(prefixDir, StringComparison.OrdinalIgnoreCase) ||
-                        localPath.StartsWith(prefixDir + System.IO.Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+                    if (localPath.Equals(prefixDir, pathComparison) ||
+                        localPath.StartsWith(prefixDir + System.IO.Path.DirectorySeparatorChar, pathComparison))
                     {
                         return true;
                     }
 
-                    if (parentPath != null && prefixDir.StartsWith(parentPath, StringComparison.OrdinalIgnoreCase))
+                    if (parentPath != null && prefixDir.StartsWith(parentPath, pathComparison))
                     {
                         // For example: localPath = "Scalar\\file.txt", parentPath="Scalar\\" and prefix is "Scalar\\Scalar".
                         return true;
@@ -318,7 +319,7 @@ namespace Scalar.FunctionalTests.Should
                 IEnumerator<FileSystemInfo> expectedEnumerator = expectedEntries
                     .Where(x => !x.FullName.Contains(dotGitFolder))
                     .OrderBy(x => x.FullName)
-                    .Where(x => IsMatchedPath(x, expectedPath, withinPrefixes))
+                    .Where(x => IsMatchedPath(x, expectedPath, withinPrefixes, ignoreCase))
                     .GetEnumerator();
                 IEnumerator<FileSystemInfo> actualEnumerator = actualEntries
                     .Where(x => !x.FullName.Contains(dotGitFolder))

--- a/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
+++ b/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
@@ -81,7 +81,7 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
 
             string gitObjectsRoot = ScalarHelpers.GetObjectsRootFromGitConfig(Path.Combine(newEnlistmentRoot, "src"));
 
-            gitObjectsRoot.StartsWith(defaultLocalCacheRoot, StringComparison.Ordinal).ShouldBeTrue($"Git objects root did not default to using {defaultLocalCacheRoot}");
+            gitObjectsRoot.StartsWith(defaultLocalCacheRoot, FileSystemHelpers.PathComparison).ShouldBeTrue($"Git objects root did not default to using {defaultLocalCacheRoot}");
 
             RepositoryHelpers.DeleteTestDirectory(newEnlistmentRoot);
         }
@@ -102,7 +102,7 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
                 Directory.GetFiles(enlistment.EnlistmentRoot).ShouldBeEmpty("There should be no files in the enlistment root after cloning");
                 string[] directories = Directory.GetDirectories(enlistment.EnlistmentRoot);
                 directories.Length.ShouldEqual(1);
-                directories.ShouldContain(x => Path.GetFileName(x).Equals("src", StringComparison.Ordinal));
+                directories.ShouldContain(x => Path.GetFileName(x).Equals("src", FileSystemHelpers.PathComparison));
             }
             finally
             {

--- a/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
+++ b/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
@@ -17,23 +17,22 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
         [TestCase]
         public void CloneInsideExistingEnlistment()
         {
-            this.SubfolderCloneShouldFail();
+            ProcessResult result = this.RunCloneCommand(
+                this.Enlistment.EnlistmentRoot,
+                Path.Combine("src", "scalar", "test1"));
+            result.ExitCode.ShouldEqual(ScalarGenericError);
+            result.Output.ShouldContain("You can't clone inside an existing Scalar repo");
         }
 
         [TestCase]
         public void CloneWithLocalCachePathWithinSrc()
         {
             string newEnlistmentRoot = ScalarFunctionalTestEnlistment.GetUniqueEnlistmentRoot();
-
-            ProcessStartInfo processInfo = new ProcessStartInfo(ScalarTestConfig.PathToScalar);
-            processInfo.Arguments = $"clone {Properties.Settings.Default.RepoToClone} {newEnlistmentRoot} --local-cache-path {Path.Combine(newEnlistmentRoot, "src", ".scalarCache")}";
-            processInfo.WindowStyle = ProcessWindowStyle.Hidden;
-            processInfo.CreateNoWindow = true;
-            processInfo.WorkingDirectory = Path.GetDirectoryName(this.Enlistment.EnlistmentRoot);
-            processInfo.UseShellExecute = false;
-            processInfo.RedirectStandardOutput = true;
-
-            ProcessResult result = ProcessHelper.Run(processInfo);
+            string localCachePath = Path.Combine(newEnlistmentRoot, "src", ".scalarCache");
+            ProcessResult result = this.RunCloneCommand(
+                Path.GetDirectoryName(this.Enlistment.EnlistmentRoot),
+                newEnlistmentRoot,
+                $"--local-cache-path {localCachePath}");
             result.ExitCode.ShouldEqual(ScalarGenericError);
             result.Output.ShouldContain("'--local-cache-path' cannot be inside the src folder");
         }
@@ -67,16 +66,10 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
 
             string newEnlistmentRoot = ScalarFunctionalTestEnlistment.GetUniqueEnlistmentRoot();
 
-            ProcessStartInfo processInfo = new ProcessStartInfo(ScalarTestConfig.PathToScalar);
-
-            processInfo.Arguments = $"clone {Properties.Settings.Default.RepoToClone} {newEnlistmentRoot} --no-fetch-commits-and-trees";
-            processInfo.WindowStyle = ProcessWindowStyle.Hidden;
-            processInfo.CreateNoWindow = true;
-            processInfo.UseShellExecute = false;
-            processInfo.RedirectStandardOutput = true;
-            processInfo.WorkingDirectory = Properties.Settings.Default.EnlistmentRoot;
-
-            ProcessResult result = ProcessHelper.Run(processInfo);
+            ProcessResult result = this.RunCloneCommand(
+                Properties.Settings.Default.EnlistmentRoot,
+                newEnlistmentRoot,
+                "--no-fetch-commits-and-trees");
             result.ExitCode.ShouldEqual(0, result.Errors);
 
             string gitObjectsRoot = ScalarHelpers.GetObjectsRootFromGitConfig(Path.Combine(newEnlistmentRoot, "src"));
@@ -110,19 +103,17 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
             }
         }
 
-        private void SubfolderCloneShouldFail()
+        private ProcessResult RunCloneCommand(string workingDirectoryPath, string enlistmentRootPath, string extraArgs = null)
         {
             ProcessStartInfo processInfo = new ProcessStartInfo(ScalarTestConfig.PathToScalar);
-            processInfo.Arguments = "clone " + ScalarTestConfig.RepoToClone + " src\\scalar\\test1";
+            processInfo.Arguments = $"clone {ScalarTestConfig.RepoToClone} {enlistmentRootPath} {extraArgs}";
+            processInfo.WorkingDirectory = workingDirectoryPath;
             processInfo.WindowStyle = ProcessWindowStyle.Hidden;
             processInfo.CreateNoWindow = true;
-            processInfo.WorkingDirectory = this.Enlistment.EnlistmentRoot;
             processInfo.UseShellExecute = false;
             processInfo.RedirectStandardOutput = true;
 
-            ProcessResult result = ProcessHelper.Run(processInfo);
-            result.ExitCode.ShouldEqual(ScalarGenericError);
-            result.Output.ShouldContain("You can't clone inside an existing Scalar repo");
+            return ProcessHelper.Run(processInfo);
         }
     }
 }

--- a/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
+++ b/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
@@ -56,6 +56,24 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
                 $"--local-cache-path {localCachePath}");
             result.ExitCode.ShouldEqual(ScalarGenericError);
             result.Output.ShouldContain("'--local-cache-path' cannot be inside the src folder");
+
+            localCachePath = Path.Combine(newEnlistmentRoot, "SRC", ".scalarCache");
+
+            result = this.RunCloneCommand(
+                Path.GetDirectoryName(this.Enlistment.EnlistmentRoot),
+                newEnlistmentRoot,
+                $"--local-cache-path {localCachePath}");
+            if (FileSystemHelpers.CaseSensitiveFileSystem)
+            {
+                result.ExitCode.ShouldEqual(0, result.Errors);
+            }
+            else
+            {
+                result.ExitCode.ShouldEqual(ScalarGenericError);
+                result.Output.ShouldContain("'--local-cache-path' cannot be inside the src folder");
+            }
+
+            RepositoryHelpers.DeleteTestDirectory(newEnlistmentRoot);
         }
 
         [TestCase]

--- a/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
+++ b/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/CloneTests.cs
@@ -25,6 +25,27 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
         }
 
         [TestCase]
+        public void CloneInNonEmptyDirectory()
+        {
+            string newEnlistmentRoot = ScalarFunctionalTestEnlistment.GetUniqueEnlistmentRoot();
+            string newEnlistmentFilePath = Path.Combine(newEnlistmentRoot, "test2");
+
+            FileSystemRunner fileSystem = FileSystemRunner.DefaultRunner;
+            fileSystem.CreateDirectory(newEnlistmentRoot);
+            newEnlistmentRoot.ShouldBeADirectory(fileSystem);
+            fileSystem.CreateEmptyFile(newEnlistmentFilePath);
+            newEnlistmentFilePath.ShouldBeAFile(fileSystem);
+
+            ProcessResult result = this.RunCloneCommand(
+                Path.GetDirectoryName(this.Enlistment.EnlistmentRoot),
+                newEnlistmentRoot);
+            result.ExitCode.ShouldEqual(ScalarGenericError);
+            result.Output.ShouldContain("exists and is not empty");
+
+            RepositoryHelpers.DeleteTestDirectory(newEnlistmentRoot);
+        }
+
+        [TestCase]
         public void CloneWithLocalCachePathWithinSrc()
         {
             string newEnlistmentRoot = ScalarFunctionalTestEnlistment.GetUniqueEnlistmentRoot();

--- a/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/FetchStepTests.cs
+++ b/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/FetchStepTests.cs
@@ -36,7 +36,7 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
             this.fileSystem
                 .EnumerateDirectory(this.Enlistment.GetPackRoot(this.fileSystem))
                 .Split()
-                .Where(file => string.Equals(Path.GetExtension(file), ".keep", StringComparison.OrdinalIgnoreCase))
+                .Where(file => string.Equals(Path.GetExtension(file), ".keep", FileSystemHelpers.PathComparison))
                 .Count()
                 .ShouldEqual(1, "Incorrect number of .keep files in pack directory");
 

--- a/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/FetchStepWithoutSharedCacheTests.cs
+++ b/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/FetchStepWithoutSharedCacheTests.cs
@@ -230,23 +230,5 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
             mostRecentPackTimestamp.ShouldBeAtLeast(1, "Failed to find the most recent pack");
             return mostRecentPackTimestamp;
         }
-
-        private long GetOldestPackTimestamp(string[] prefetchPacks)
-        {
-            prefetchPacks.Length.ShouldBeAtLeast(1, "prefetchPacks should have at least one item");
-
-            long oldestPackTimestamp = long.MaxValue;
-            foreach (string prefetchPack in prefetchPacks)
-            {
-                long timestamp = this.GetTimestamp(prefetchPack);
-                if (timestamp < oldestPackTimestamp)
-                {
-                    oldestPackTimestamp = timestamp;
-                }
-            }
-
-            oldestPackTimestamp.ShouldBeAtMost(long.MaxValue - 1, "Failed to find the oldest pack");
-            return oldestPackTimestamp;
-        }
     }
 }

--- a/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/GitCorruptObjectTests.cs
+++ b/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/GitCorruptObjectTests.cs
@@ -145,6 +145,12 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
         {
             ProcessResult revParseResult = GitProcess.InvokeProcess(this.Enlistment.RepoRoot, $"rev-parse :{fileGitPath}");
             sha = revParseResult.Output.Trim();
+            if (FileSystemHelpers.CaseSensitiveFileSystem)
+            {
+                // Ensure SHA path is lowercase for case-sensitive filesystems
+                sha = sha.ToLower();
+            }
+
             sha.Length.ShouldEqual(40);
             string objectPath = Path.Combine(ScalarHelpers.GetObjectsRootFromGitConfig(this.Enlistment.RepoRoot), sha.Substring(0, 2), sha.Substring(2, 38));
             return objectPath;

--- a/Scalar.FunctionalTests/Tests/GitCommands/UpdateRefTests.cs
+++ b/Scalar.FunctionalTests/Tests/GitCommands/UpdateRefTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using Scalar.FunctionalTests.Properties;
+using Scalar.FunctionalTests.Tools;
 
 namespace Scalar.FunctionalTests.Tests.GitCommands
 {
@@ -29,11 +30,19 @@ namespace Scalar.FunctionalTests.Tests.GitCommands
 
         public override void TearDownForTest()
         {
-            // Need to ignore case changes in this test because the update-ref will have
-            // folder names that only changed the case and when checking the folder structure
-            // it will create partial folders with that case and will not get updated to the
-            // previous case when the reset --hard running in the tear down step
-            this.TestValidationAndCleanup(ignoreCase: true);
+            if (FileSystemHelpers.CaseSensitiveFileSystem)
+            {
+                this.TestValidationAndCleanup();
+            }
+            else
+            {
+                // On case-insensitive filesystems, we
+                // need to ignore case changes in this test because the update-ref will have
+                // folder names that only changed the case and when checking the folder structure
+                // it will create partial folders with that case and will not get updated to the
+                // previous case when the reset --hard running in the tear down step
+                this.TestValidationAndCleanup(ignoreCase: true);
+            }
         }
     }
 }

--- a/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/ScalarCloneFromGithub.cs
+++ b/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/ScalarCloneFromGithub.cs
@@ -45,7 +45,7 @@ namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
 
                 dirContents
                     .Split()
-                    .Where(file => string.Equals(Path.GetExtension(file), ".pack", StringComparison.OrdinalIgnoreCase))
+                    .Where(file => string.Equals(Path.GetExtension(file), ".pack", FileSystemHelpers.PathComparison))
                     .Count()
                     .ShouldEqual(count, $"'{dir}' after '{when}': '{dirContents}'");
             }

--- a/Scalar.FunctionalTests/Tools/FileSystemHelpers.cs
+++ b/Scalar.FunctionalTests/Tools/FileSystemHelpers.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Scalar.FunctionalTests.Tools
+{
+    public static class FileSystemHelpers
+    {
+        public static StringComparison PathComparison
+        {
+            get
+            {
+                return CaseSensitiveFileSystem ?
+                    StringComparison.Ordinal :
+                    StringComparison.OrdinalIgnoreCase;
+            }
+        }
+
+        public static StringComparer PathComparer
+        {
+            get
+            {
+                return CaseSensitiveFileSystem ?
+                    StringComparer.Ordinal :
+                    StringComparer.OrdinalIgnoreCase;
+            }
+        }
+
+        public static bool CaseSensitiveFileSystem
+        {
+            get
+            {
+                return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            }
+        }
+    }
+}

--- a/Scalar.UnitTests/Common/FileBasedDictionaryTests.cs
+++ b/Scalar.UnitTests/Common/FileBasedDictionaryTests.cs
@@ -329,7 +329,7 @@ namespace Scalar.UnitTests.Common
                 if (this.maxFileExistsFailures > 0)
                 {
                     if (this.fileExistsFailureCount < this.maxFileExistsFailures &&
-                        string.Equals(path, this.fileExistsFailurePath, System.StringComparison.OrdinalIgnoreCase))
+                        string.Equals(path, this.fileExistsFailurePath, ScalarPlatform.Instance.Constants.PathComparison))
                     {
                         if (this.ExpectedFiles.ContainsKey(path))
                         {
@@ -342,7 +342,7 @@ namespace Scalar.UnitTests.Common
                 else if (this.failuresAcrossOpenExistsAndOverwritePath != null)
                 {
                     if (this.failuresAcrossOpenExistsAndOverwriteCount == 1 &&
-                        string.Equals(path, this.failuresAcrossOpenExistsAndOverwritePath, System.StringComparison.OrdinalIgnoreCase))
+                        string.Equals(path, this.failuresAcrossOpenExistsAndOverwritePath, ScalarPlatform.Instance.Constants.PathComparison))
                     {
                         if (this.ExpectedFiles.ContainsKey(path))
                         {
@@ -391,7 +391,7 @@ namespace Scalar.UnitTests.Common
                 if (this.maxOpenFileStreamFailures > 0)
                 {
                     if (this.openFileStreamFailureCount < this.maxOpenFileStreamFailures &&
-                        string.Equals(path, this.openFileStreamFailurePath, System.StringComparison.OrdinalIgnoreCase))
+                        string.Equals(path, this.openFileStreamFailurePath, ScalarPlatform.Instance.Constants.PathComparison))
                     {
                         ++this.openFileStreamFailureCount;
 
@@ -408,7 +408,7 @@ namespace Scalar.UnitTests.Common
                 else if (this.failuresAcrossOpenExistsAndOverwritePath != null)
                 {
                     if (this.failuresAcrossOpenExistsAndOverwriteCount == 0 &&
-                        string.Equals(path, this.failuresAcrossOpenExistsAndOverwritePath, System.StringComparison.OrdinalIgnoreCase))
+                        string.Equals(path, this.failuresAcrossOpenExistsAndOverwritePath, ScalarPlatform.Instance.Constants.PathComparison))
                     {
                         ++this.failuresAcrossOpenExistsAndOverwriteCount;
                         throw new IOException();

--- a/Scalar.UnitTests/Common/PhysicalFileSystemDeleteTests.cs
+++ b/Scalar.UnitTests/Common/PhysicalFileSystemDeleteTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using Scalar.Common;
 using Scalar.Common.FileSystem;
 using Scalar.Common.Tracing;
 using Scalar.Tests.Should;
@@ -241,7 +242,7 @@ namespace Scalar.UnitTests.Common
                 bool allFilesExist = false,
                 bool noOpDelete = false)
             {
-                this.ExistingFiles = new Dictionary<string, FileAttributes>(StringComparer.OrdinalIgnoreCase);
+                this.ExistingFiles = new Dictionary<string, FileAttributes>(ScalarPlatform.Instance.Constants.PathComparer);
                 foreach (KeyValuePair<string, FileAttributes> kvp in existingFiles)
                 {
                     this.ExistingFiles[kvp.Key] = kvp.Value;

--- a/Scalar.UnitTests/Mock/Common/MockPlatform.cs
+++ b/Scalar.UnitTests/Mock/Common/MockPlatform.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Pipes;
+using System.Runtime.InteropServices;
 
 namespace Scalar.UnitTests.Mock.Common
 {
@@ -212,12 +213,14 @@ namespace Scalar.UnitTests.Mock.Common
 
             public override HashSet<string> UpgradeBlockingProcesses
             {
-                get { return new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "Scalar", "git", "wish", "bash" }; }
+                get { return new HashSet<string>(this.PathComparer) { "Scalar", "git", "wish", "bash" }; }
             }
 
             public override bool SupportsUpgradeWhileRunning => false;
 
             public override int MaxPipePathLength => 250;
+
+            public override bool CaseSensitiveFileSystem => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
         }
     }
 }

--- a/Scalar.UnitTests/Mock/FileSystem/MockFileSystem.cs
+++ b/Scalar.UnitTests/Mock/FileSystem/MockFileSystem.cs
@@ -244,7 +244,7 @@ namespace Scalar.UnitTests.Mock.FileSystem
                 // if it's called for one of those paths remap the paths to be inside the mock: root
                 string mockDirectoryPath = directoryPath;
                 string scalarProgramData = @"C:\ProgramData\Scalar";
-                if (directoryPath.StartsWith(scalarProgramData, StringComparison.OrdinalIgnoreCase))
+                if (directoryPath.StartsWith(scalarProgramData, ScalarPlatform.Instance.Constants.PathComparison))
                 {
                     mockDirectoryPath = mockDirectoryPath.Substring(scalarProgramData.Length);
                     mockDirectoryPath = "mock:" + mockDirectoryPath;
@@ -335,7 +335,7 @@ namespace Scalar.UnitTests.Mock.FileSystem
                     {
                         yield return file.FullName;
                     }
-                    else if (file.Name.EndsWith(searchSuffix, StringComparison.OrdinalIgnoreCase))
+                    else if (file.Name.EndsWith(searchSuffix, ScalarPlatform.Instance.Constants.PathComparison))
                     {
                         yield return file.FullName;
                     }

--- a/Scalar/CommandLine/CloneVerb.cs
+++ b/Scalar/CommandLine/CloneVerb.cs
@@ -115,7 +115,7 @@ namespace Scalar.CommandLine
 
                 if (normalizedLocalCacheRootPath.StartsWith(
                     Path.Combine(normalizedEnlistmentRootPath, ScalarConstants.WorkingDirectoryRootName),
-                    StringComparison.OrdinalIgnoreCase))
+                    ScalarPlatform.Instance.Constants.PathComparison))
                 {
                     this.ReportErrorAndExit("'--local-cache-path' cannot be inside the src folder");
                 }
@@ -421,7 +421,7 @@ namespace Scalar.CommandLine
             // LogFileEventListener will create a file in EnlistmentRootPath
             if (Directory.Exists(normalizedEnlistementRootPath) && Directory.EnumerateFileSystemEntries(normalizedEnlistementRootPath).Any())
             {
-                if (fullEnlistmentRootPathParameter.Equals(normalizedEnlistementRootPath, StringComparison.OrdinalIgnoreCase))
+                if (fullEnlistmentRootPathParameter.Equals(normalizedEnlistementRootPath, ScalarPlatform.Instance.Constants.PathComparison))
                 {
                     return new Result($"Clone directory '{fullEnlistmentRootPathParameter}' exists and is not empty");
                 }

--- a/Scalar/CommandLine/DiagnoseVerb.cs
+++ b/Scalar/CommandLine/DiagnoseVerb.cs
@@ -476,7 +476,7 @@ namespace Scalar.CommandLine
                 DriveInfo enlistmentDrive = new DriveInfo(enlistmentNormalizedPathRoot);
                 string enlistmentDriveDiskSpace = this.FormatByteCount(enlistmentDrive.AvailableFreeSpace);
 
-                if (string.Equals(enlistmentNormalizedPathRoot, localCacheNormalizedPathRoot, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(enlistmentNormalizedPathRoot, localCacheNormalizedPathRoot, ScalarPlatform.Instance.Constants.PathComparison))
                 {
                     this.WriteMessage("Available space on " + enlistmentDrive.Name + " drive(enlistment and local cache): " + enlistmentDriveDiskSpace);
                 }

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -85,3 +85,21 @@ Finally, as Git gains the features that we need in Scalar, Scalar will need to
 support backwards compatibility with repositories cloned with older versions of
 Scalar. Using the C# layer, we can update the Git version and upgrade old
 repositories to whatever new features are added to Git.
+
+### Why doesn't Scalar support case-sensitive directories (or case-insensitive ones on Linux)?
+
+Although Scalar is agnostic about the contents of your repository and
+largely leaves file handling within your working tree to Git, it does check
+some file paths and manage some cache files, and to do so Scalar assumes
+your filesystem has the filename case-matching semantics typical for your
+operating system.  On Windows and macOS this means being case-insensitive
+when matching filenames, and on Linux it means matching case-sensitively.
+
+Because all three operating systems support exceptions to their case-matching
+conventions (e.g., [case-sensitive NTFS directories][ntfs-case] or
+[case-insensitive ext4 directories][ext4-case]), a possible future
+enhancement for Scalar would be to support these alternatives using
+a per-repository custom Git configuration value.
+
+[ext4-case]: https://github.com/torvalds/linux/blob/171d4ff79f965c1f164705ef0aaea102a6ad238b/Documentation/admin-guide/ext4.rst#case-insensitive-file-name-lookups
+[ntfs-case]: https://devblogs.microsoft.com/commandline/per-directory-case-sensitivity-and-wsl/#per-directory-case-sensitivity


### PR DESCRIPTION
Use filesystem-specific case matching when comparing file paths throughout Scalar and the functional test suite.

The primary change in this PR is to introduce a pair of wrappers which we use in place of `StringComparison.OrdinalIgnoreCase` and `StringComparer.OrdinalIgnoreCase` throughout the codebase whenever we need to compare or match file names or paths.

These new comparison utilities are named `ScalarPlatform.Instance.Constants.Path{Comparison,Comparer}` in the main Scalar project, and have equivalents named `FileSystemHelpers.Path{Comparison,Comparer}` in the functional test program's project.

From microsoft/VFSForGit#1232, microsoft/VFSForGit#1412, and microsoft/VFSForGit#1503, with additional new work and tests.

Given its scope this PR is probably best reviewed commit-by-commit; they should be logically separate and relatively manageable in size.

---

Note that this PR is not a perfect solution, just a first approximation, because all three platforms support filesystems and/or directories with the opposite sensitivity to their typical mode:
- [case-insensitive directories](https://www.collabora.com/news-and-blog/blog/2020/08/27/using-the-linux-kernel-case-insensitive-feature-in-ext4/) in `casefold` ext4 mounts on Linux
- [case-sensitive mounts](https://support.apple.com/lt-lt/guide/disk-utility/dsku19ed921c/mac) of HFS+ and APFS on Mac
- [case-sensitive directories](https://devblogs.microsoft.com/commandline/per-directory-case-sensitivity-and-wsl/#per-directory-case-sensitivity) in NTFS on Windows

Therefore in commit f712d43cc29ddb1665022c73344525466ec6ef7b we rework the existing Mac-specific case-sensitivity [check](https://github.com/microsoft/scalar/blob/944baa2927d843f67ccd19473d0ae8530d5ea941/Scalar.Common/Platforms/Mac/MacFileSystem.cs#L23-L47) for all platforms and refactor it into a common method in `ScalarPlatform`.

This check only runs during the `scalar clone` step, and then only when the `CreateScalarDirectories()` method is called, which requires, among other things, that the local Git installation support the GVFS protocol.  (This seems reasonable given that the key places where filepath matching is performed in the main Scalar codebase appear to be in maintenance routines handling the prefetch packfiles returned by the GVFS protocol and helper.)

---

We also add and expand a few of the tests in the `EnlistmentPerFixture.CloneTests` and `EnlistmentPerFixture.FetchStepWithoutSharedCacheTests` functional test suites, as these correspond most closely with the key remaining platform-variable file path checks in the main `Scalar/CommandLine` and `Scalar.Common` code (now that much of the filepath-matching logic associated with VFSForGit has been removed).

Specifically, the `scalar clone` command executes a [check](https://github.com/microsoft/scalar/blob/944baa2927d843f67ccd19473d0ae8530d5ea941/Scalar/CommandLine/CloneVerb.cs#L118) to determine whether the user is accidentally passing a path with `--local-cache-path` that is within the Scalar enlistment (i.e., the Scalar working directory), and that check is may be case-sensitive or case-insensitive depending on the platform.

And the `scalar run fetch` maintenance command, when the GVFS protocol is in use, executes several cleanup steps such as the `UpdateKeepPacks()` method, which now looks for [`prefetch-*.pack`](https://github.com/microsoft/scalar/blob/944baa2927d843f67ccd19473d0ae8530d5ea941/Scalar.Common/Maintenance/FetchStep.cs#L365-L366) and [`*.keep`](https://github.com/microsoft/scalar/blob/944baa2927d843f67ccd19473d0ae8530d5ea941/Scalar.Common/Maintenance/FetchStep.cs#L385) files using our new `ScalarPlatform.Instance.Constants.PathComparison` path-matching wrapper instead of `StringComparison.OrdinalIgnoreCase`.

So we extend the functional tests to cover these actions and in particular test that on Linux we see case-sensitive behaviour, while macOS and Windows behave case-insensitively when matching filename patterns and paths.

In addition to the above, we take the opportunity to tidy up both of the relevant functional test classes, removing some now-unused methods, refactoring a number of the `CloneTests` to use a new common `RunCloneCommand()` method which also standardizes the test repository URL so that the `--repo-to-clone` functional test command-line option is fully respected, fixing a hard-coded path which contained Windows-style backslashes as path separators, and adding a `CloneInNonEmptyDirectory()` test.  (The latter unfortunately cannot test the filepath [check](https://github.com/microsoft/scalar/blob/944baa2927d843f67ccd19473d0ae8530d5ea941/Scalar/CommandLine/CloneVerb.cs#L424) in `TryCreateEnlistment()`, though, because that check is used only to determine whether the user-provided path differs from the normalized path [which for our purposes is a Windows-specific concept] when printing the error message, and is not used in the actual check for an empty directory.)

And lastly we make a change to the `UpdateKeepPacks()` method mentioned above as part the maintenance executed by a `scalar run fetch` command; we adjust the [retrieval](https://github.com/microsoft/scalar/blob/944baa2927d843f67ccd19473d0ae8530d5ea941/Scalar.Common/Maintenance/FetchStep.cs#L382-L386) of the list of "keep" sentinel files so that it filters out any which do not start with the `ScalarConstants.PrefetchPackPrefix` string, i.e., the prefix `prefetch-`.  This aligns the behaviour when handling "keep" files to match that of the packfiles themselves [earlier](https://github.com/microsoft/scalar/blob/944baa2927d843f67ccd19473d0ae8530d5ea941/Scalar.Common/Maintenance/FetchStep.cs#L365-L366) in the same method, and it then also allows our new tests to parallel each other for both types of files.  It also looks to be in keeping with the case-sensitive filename prefix matching performed in the [`cb_keep_files()`](https://github.com/microsoft/git/blob/e75d1f7783c38333d2c7eb881f9eaa797f8500b7/gvfs-helper.c#L2246) and [`cb_find_last()`](https://github.com/microsoft/git/blob/e75d1f7783c38333d2c7eb881f9eaa797f8500b7/gvfs-helper.c#L3247) functions in `gvfs-helper.c` in https://github.com/microsoft/git, which I believe is what primarily writes new `prefetch-*.{pack,keep,idx}` files into the Scalar cache directory in the first place.