### PR TITLE
add Watchman-enabled functional tests to GitHub Actions CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,6 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, windows-2019, macos-10.15]
+        watchman: [false, true]
 
     env:
       BUILD_FRAGMENT: bin/Release/netcoreapp3.1
@@ -91,6 +92,40 @@ jobs:
         & $files[0].Fullname /DIR="C:\Program Files\Git" /NOICONS /COMPONENTS="ext,ext\shellhere,ext\guihere,assoc,assoc_sh" /GROUP="Git" /SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /ALLOWDOWNGRADE=1 /LOG=install.log
         Wait-Process $files[0].Basename
         Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\GitForWindows'
+
+    - name: Install Watchman (Linux)
+      if: runner.os == 'Linux' && matrix.watchman
+      run: |
+        cd ..
+        git clone https://github.com/facebook/watchman.git -b v4.9.0 --depth 1
+        cd watchman
+        ./autogen.sh
+        GCC_VERSION=$(gcc -dumpversion | cut -d. -f1)
+        if [ "$GCC_VERSION" -ge 7 ]; then CPPFLAGS="-Wno-error=format-truncation"; fi
+        if [ "$GCC_VERSION" -ge 8 ]; then CPPFLAGS="$CPPFLAGS -Wno-error=class-memaccess"; fi
+        export CPPFLAGS
+        ./configure --without-python
+        make
+        sudo make install
+
+    - name: Install Watchman (Mac)
+      if: runner.os == 'macOS' && matrix.watchman
+      run: brew install watchman
+
+    - name: Install Watchman (Windows)
+      if: runner.os == 'Windows' && matrix.watchman
+      run: |
+        Write-Host 'Downloading Watchman ...'
+        $Uri = (Select-Xml -Path Directory.Build.props -XPath /Project/PropertyGroup/WatchmanPackageUrl).Node.'#text'
+        Set-Location -Path ..
+        Invoke-WebRequest -Uri $Uri -OutFile watchman.zip
+        Expand-Archive watchman.zip
+        Write-Host 'Installing Watchman ...'
+        New-Item -Path 'C:\Program Files' -Name Watchman -ItemType Directory | Out-Null
+        Copy-Item -Path 'watchman\watchman-*-windows\bin\*' -Destination 'C:\Program Files\Watchman'
+        $ENV:PATH="$ENV:PATH;C:\Program Files\Watchman"
+        & watchman --version
+        echo "::add-path::C:\Program Files\Watchman"
 
     - name: Functional test
       shell: bash

--- a/Scalar.FunctionalTests/Tools/GitHelpers.cs
+++ b/Scalar.FunctionalTests/Tools/GitHelpers.cs
@@ -74,8 +74,8 @@ namespace Scalar.FunctionalTests.Tools
             ProcessResult expectedResult = GitProcess.InvokeProcess(controlRepoRoot, command, environmentVariables);
             ProcessResult actualResult = GitHelpers.InvokeGitAgainstScalarRepo(scalarRepoRoot, command, environmentVariables);
 
-            LinesShouldMatch(command + " Errors Lines", actualResult.Errors, expectedResult.Errors);
-            LinesShouldMatch(command + " Output Lines", actualResult.Output, expectedResult.Output);
+            LinesShouldMatch(command + " Errors Lines", expectedResult.Errors, actualResult.Errors);
+            LinesShouldMatch(command + " Output Lines", expectedResult.Output, actualResult.Output);
 
             if (command != "status")
             {

--- a/Scalar/CommandLine/CloneVerb.cs
+++ b/Scalar/CommandLine/CloneVerb.cs
@@ -672,7 +672,7 @@ namespace Scalar.CommandLine
             GitProcess.Result initResult = GitProcess.Init(this.enlistment);
             if (initResult.ExitCodeIsFailure)
             {
-                string error = string.Format("Could not init repo at to {0}: {1}", repoPath, initResult.Errors);
+                string error = string.Format("Could not init repo at {0}: {1}", repoPath, initResult.Errors);
                 this.tracer.RelatedError(error);
                 return new Result(error);
             }
@@ -694,7 +694,7 @@ namespace Scalar.CommandLine
                 GitProcess.Result sparseCheckoutResult = GitProcess.SparseCheckoutInit(this.enlistment);
                 if (sparseCheckoutResult.ExitCodeIsFailure)
                 {
-                    string error = string.Format("Could not init sparse-checkout at to {0}: {1}", repoPath, sparseCheckoutResult.Errors);
+                    string error = string.Format("Could not init sparse-checkout at {0}: {1}", repoPath, sparseCheckoutResult.Errors);
                     this.tracer.RelatedError(error);
                     return new Result(error);
                 }

--- a/Scripts/Mac/RunFunctionalTests.sh
+++ b/Scripts/Mac/RunFunctionalTests.sh
@@ -7,7 +7,20 @@ if [ -z $CONFIGURATION ]; then
   CONFIGURATION=Debug
 fi
 
-TESTS_EXEC=$SCALAR_OUTPUTDIR/Scalar.FunctionalTests/bin/$CONFIGURATION/netcoreapp3.1/osx-x64/publish/Scalar.FunctionalTests
+PUBLISH_FRAGMENT="bin/$CONFIGURATION/netcoreapp3.1/osx-x64/publish"
+FUNCTIONAL_TESTS_DIR="$SCALAR_OUTPUTDIR/Scalar.FunctionalTests/$PUBLISH_FRAGMENT"
+
+if [ "$2" = "--test-scalar-on-path" ]; then
+  echo "PATH:"
+  echo "$PATH"
+  echo "Scalar location:"
+  where scalar
+else
+  # Copy most recently build Scalar binaries
+  rsync -r "$SCALAR_OUTPUTDIR/Scalar/$PUBLISH_FRAGMENT/" "$FUNCTIONAL_TESTS_DIR"
+fi
+
+TESTS_EXEC="$FUNCTIONAL_TESTS_DIR/Scalar.FunctionalTests"
 
 mkdir ~/Scalar.FT
 


### PR DESCRIPTION
We add Watchman-enabled runs of the functional test suite on all GitHub Actions runners for all three platforms.

The code changes in this PR are primarily the result of needing to work around some inconsistent behaviour from Watchman when running on macOS Catalina, which is used by the Actions macOS runners.  As described in facebook/watchman#858, creating a hard link to an existing inode from inside the watched Git working tree may not be reported to Git as a new file if the inode's other, existing "source" path (as passed to `link(2)`) resides outside the watched directory.

This problem is tickled by our functional test suite because the [`MoveFileFromOutsideRepoToInsideRepoAndAdd()`](https://github.com/microsoft/scalar/blob/7a86016e9bb7a6c7560a87aba2c7c0739f896571/Scalar.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs#L418-L449) test [relies](https://github.com/microsoft/scalar/blob/7a86016e9bb7a6c7560a87aba2c7c0739f896571/Scalar.FunctionalTests/FileSystemRunners/SystemIORunner.cs#L21) on the `System.IO.File.Move()` method, which on Unix/POSIX systems like macOS, actually [performs](https://github.com/dotnet/runtime/blob/94515f7bd34aabaab5ba6a1316f4a881cbf2370c/src/libraries/System.IO.FileSystem/src/System/IO/FileSystem.Unix.cs#L142-L144) a `link(2)` call rather than `rename(2)`.

While the underlying problem is outside of Scalar's control, we can work around it by using `rename(2)` directly to move files in the `SystemIORunner` test helper class.

This particular intermittent but persistent test failure also exposed another, minor issue in the `ValidateGitCommand()` utility method, which passed its actual and expected string values to the `LinesShouldMatch()` method in the reverse order from what was intended, so we swap them here.

Debugging these issues also turned up some minor typos in the error messages output from the `run clone` command when a repository can not be initialized, so those are fixed here also.

Finally, to enable the functional test suite to run in CI on macOS, we add to the Mac version of the `RunFunctionalTests.sh` script so that like the Linux and Windows versions it copies the Scalar binary into the functional test binary's build location so it can be located by the functional test program.