### PR TITLE
Remove spinner from all progress (allow auth prompts to use the terminal)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -120,13 +120,14 @@ Clone parameters:
   Local Cache:  C:\.scalarCache
   Destination:  C:\_git\ForTests
   FullClone:     False
-Authenticating...Succeeded
-Querying remote for config...Succeeded
+Authenticating...
+Querying remote for config...
 Using cache server: None (https://dev.azure.com/gvfs/ci/_git/ForTests)
-Cloning...Succeeded
-Fetching commits and trees from origin (no cache server)...Succeeded
-Configuring Watchman...Succeeded.
-Validating repo...Succeeded
+Cloning...
+Fetching commits and trees from origin (no cache server)...
+Configuring Watchman...
+Validating repo...
+Complete!
 ```
 
 Then, navigate into the repository's `src` directory.

--- a/Scalar.Common/Git/GitProcess.cs
+++ b/Scalar.Common/Git/GitProcess.cs
@@ -305,7 +305,8 @@ namespace Scalar.Common.Git
                 Result gitCredentialOutput = this.InvokeGitAgainstDotGitFolder(
                     GenerateCredentialVerbCommand("fill"),
                     stdin => stdin.Write($"url={repoUrl}\n\n"),
-                    parseStdOutLine: null);
+                    parseStdOutLine: null,
+                    userInteractive: true);
 
                 if (gitCredentialOutput.ExitCodeIsFailure)
                 {
@@ -614,11 +615,11 @@ namespace Scalar.Common.Git
                 }
             }
 
-            processInfo.EnvironmentVariables["GIT_TERMINAL_PROMPT"] = "0";
             processInfo.EnvironmentVariables["GCM_VALIDATE"] = "0";
 
             if (!userInteractive)
             {
+                processInfo.EnvironmentVariables["GIT_TERMINAL_PROMPT"] = "0";
                 processInfo.EnvironmentVariables["GCM_INTERACTIVE"] = "Never";
             }
 
@@ -844,7 +845,8 @@ namespace Scalar.Common.Git
             string command,
             Action<StreamWriter> writeStdIn,
             Action<string> parseStdOutLine,
-            string gitObjectsDirectory = null)
+            string gitObjectsDirectory = null,
+            bool userInteractive = true)
         {
             // This git command should not need/use the working directory of the repo.
             // Run git.exe in Environment.SystemDirectory to ensure the git.exe process
@@ -857,7 +859,8 @@ namespace Scalar.Common.Git
                 writeStdIn: writeStdIn,
                 parseStdOutLine: parseStdOutLine,
                 timeoutMs: -1,
-                gitObjectsDirectory: gitObjectsDirectory);
+                gitObjectsDirectory: gitObjectsDirectory,
+                userInteractive: userInteractive);
         }
 
         public class Result

--- a/Scalar.Upgrader/UpgradeOrchestrator.cs
+++ b/Scalar.Upgrader/UpgradeOrchestrator.cs
@@ -143,8 +143,7 @@ namespace Scalar.Upgrader
             return ConsoleHelper.ShowStatusWhileRunning(
                 method,
                 message,
-                this.output,
-                this.output == Console.Out && !ScalarPlatform.Instance.IsConsoleOutputRedirectedToFile());
+                this.output);
         }
 
         private JsonTracer CreateTracer()

--- a/Scalar/CommandLine/CloneVerb.cs
+++ b/Scalar/CommandLine/CloneVerb.cs
@@ -309,6 +309,15 @@ namespace Scalar.CommandLine
                 cloneResult = this.TryRegisterRepo();
             }
 
+            if (cloneResult.Success)
+            {
+                this.Output.WriteLine("Complete!");
+            }
+            else
+            {
+                this.Output.WriteLine("Complete with errors.");
+            }
+
             return cloneResult;
         }
 

--- a/Scalar/CommandLine/ScalarVerb.cs
+++ b/Scalar/CommandLine/ScalarVerb.cs
@@ -157,9 +157,7 @@ namespace Scalar.CommandLine
             return ConsoleHelper.ShowStatusWhileRunning(
                 action,
                 message,
-                this.Output,
-                showSpinner: !this.Unattended && this.Output == Console.Out && !ScalarPlatform.Instance.IsConsoleOutputRedirectedToFile(),
-                initialDelayMs: 0);
+                this.Output);
         }
 
         protected GitAuthentication.Result TryAuthenticate(ITracer tracer, ScalarEnlistment enlistment, out string authErrorMessage)


### PR DESCRIPTION
Ensure authentication prompts shown by Git and any configured credential
helpers can write to the terminal/TTY and capture information.

We don't _really_ need the fancy spinner to show "Authenticating...";
this is only cosmetic.

Also explicitly pass-down the userInteractive=true argument down the
call stack to the construction of the Git process, and move the setting
of GIT_TERMINAL_PROMPT=0 into the if-not-user-interactive block.