### PR TITLE
[WIP] DO NOT MERGE:  fsmonitor: Update to use my PR build of Git

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -167,3 +167,4 @@ jobs:
       with:
         name: ${{ env.TRACE2_BASENAME }}.zip
         path: ${{ env.TRACE2_BASENAME }}.zip
+        retention-days: 7

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -43,17 +43,22 @@ jobs:
 
     - name: Setup platform (Linux)
       if: runner.os == 'Linux'
-      run: echo "::set-env name=BUILD_PLATFORM::${{ runner.os }}"
+      run: |
+        echo "::set-env name=BUILD_PLATFORM::${{ runner.os }}"
+        echo "::set-env name=TRACE2_BASENAME::Trace2.${{ runner.run_id }}.${{ runner.run_number }}.${{ matrix.os }}.${{ matrix.watchman }}"
 
     - name: Setup platform (Mac)
       if: runner.os == 'macOS'
-      run: echo '::set-env name=BUILD_PLATFORM::Mac'
+      run: |
+        echo '::set-env name=BUILD_PLATFORM::Mac'
+        echo "::set-env name=TRACE2_BASENAME::Trace2.${{ runner.run_id }}.${{ runner.run_number }}.${{ matrix.os }}.${{ matrix.watchman }}"
 
     - name: Setup platform (Windows)
       if: runner.os == 'Windows'
       run: |
         echo "::set-env name=BUILD_PLATFORM::${{ runner.os }}"
         echo '::set-env name=BUILD_FILE_EXT::.exe'
+        echo "::set-env name=TRACE2_BASENAME::Trace2.${{ runner.run_id }}.${{ runner.run_number }}.${{ matrix.os }}.${{ matrix.watchman }}"
 
     - name: Setup Git installer
       shell: bash
@@ -127,9 +132,38 @@ jobs:
         & watchman --version
         echo "::add-path::C:\Program Files\Watchman"
 
-    - name: Functional test
+    - id: functional_test
+      name: Functional test
       shell: bash
       run: |
+        GIT_TRACE2_EVENT="$PWD/$TRACE2_BASENAME/Event"
+        GIT_TRACE2_PERF="$PWD/$TRACE2_BASENAME/Perf"
+        GIT_TRACE2_PERF_BRIEF=true
+        export GIT_TRACE2_EVENT
+        export GIT_TRACE2_PERF
+        export GIT_TRACE2_PERF_BRIEF
+        mkdir -p "$TRACE2_BASENAME"
+        mkdir -p "$TRACE2_BASENAME/Event"
+        mkdir -p "$TRACE2_BASENAME/Perf"
+        git version --build-options
         cd ../out
         PATH="$PWD/Scalar/$BUILD_FRAGMENT:$PWD/Scalar.Service/$BUILD_FRAGMENT:$PATH"
         Scalar.FunctionalTests/$BUILD_FRAGMENT/Scalar.FunctionalTests$BUILD_FILE_EXT --test-scalar-on-path --full-suite
+
+    - id: trace2_zip_unix
+      if: runner.os != 'Windows' && ( success() || failure() ) && ( steps.functional_test.conclusion == 'success' || steps.functional_test.conclusion == 'failure' )
+      name: Zip Trace2 Logs (Unix)
+      shell: bash
+      run: zip -q -r $TRACE2_BASENAME.zip $TRACE2_BASENAME/
+
+    - id: trace2_zip_windows
+      if: runner.os == 'Windows' && ( success() || failure() ) && ( steps.functional_test.conclusion == 'success' || steps.functional_test.conclusion == 'failure' )
+      name: Zip Trace2 Logs (Windows)
+      run: Compress-Archive -DestinationPath ${{ env.TRACE2_BASENAME }}.zip -Path ${{ env.TRACE2_BASENAME }}
+
+    - name: Archive Trace2 Logs
+      if: ( success() || failure() ) && ( steps.trace2_zip_unix.conclusion == 'success' || steps.trace2_zip_windows == 'success' )
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ env.TRACE2_BASENAME }}.zip
+        path: ${{ env.TRACE2_BASENAME }}.zip

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
        VFS for Git (which is less flexible). Only update that version if we rely upon a
        new command-line interface in Git or if there is a truly broken interaction.
     -->
-    <GitPackageVersion>2.20200728.1</GitPackageVersion>
+    <GitPackageVersion>2.20200930.2-pr</GitPackageVersion>
     <MinimumGitVersion>v2.25.0.vfs.1.1</MinimumGitVersion>
 
     <WatchmanPackageUrl>https://github.com/facebook/watchman/releases/download/v2020.08.03.00/watchman-v2020.08.03.00-windows.zip</WatchmanPackageUrl>

--- a/Scalar.Common/Git/GitProcess.cs
+++ b/Scalar.Common/Git/GitProcess.cs
@@ -597,6 +597,25 @@ namespace Scalar.Common.Git
             // List of environment variables: https://git-scm.com/book/gr/v2/Git-Internals-Environment-Variables
             foreach (string key in processInfo.EnvironmentVariables.Keys.Cast<string>().ToList())
             {
+                if (key.StartsWith("GIT_TRACE2", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Allow Trace2 values to pass thru as is.  Technically, a Trace2 target
+                    // (such as GIT_TRACE2_EVENT, GIT_TRACE2_PERF, or GIT_TRACE2) can be set
+                    // to stderr just like traditional tracing, but these targets can be enabled
+                    // via global or system config settings, so this filtering is not sufficient.
+                    //
+                    // Simply checking for an absolute pathname is not sufficient because Trace2
+                    // allows targets to be set to integer, booleans and Unix domain socket values.
+                    // Only values "1", "2", and "true" (for target keys) cause output to go to
+                    // stderr.
+                    //
+                    // Additionally, there are other non-target Trace2 values that are useful to
+                    // preserve, such as GIT_TRACE2_PERF_BRIEF and GIT_TRACE2_CONFIG_PARAMS.
+                    //
+                    // TODO For now, just let them thru as is.
+                    continue;
+                }
+
                 // If GIT_TRACE is set to a fully-rooted path, then Git sends the trace
                 // output to that path instead of stdout (GIT_TRACE=1) or stderr (GIT_TRACE=2).
                 if (key.StartsWith("GIT_TRACE", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
The `fsmonitor3` branch in `microsoft/scalar` is a WIP to rebase/cherry-pick commits that are still significant from my `fsmonitor` branch (that I stole from Stolee's `fsmonitor` branch).  That branch is a 3 or 4 months old and `main` has moved quite a bit since that branch was started.

So I'm going to insert my the `fsmonitor3` branch of Git and use it to reconstruct a new branch in Scalar to consume it.
