### PR TITLE
Update Git to include maintenance dependencies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
        VFS for Git (which is less flexible). Only update that version if we rely upon a
        new command-line interface in Git or if there is a truly broken interaction.
     -->
-    <GitPackageVersion>2.20200728.1</GitPackageVersion>
+    <GitPackageVersion>2.20200930.1-pr</GitPackageVersion>
     <MinimumGitVersion>v2.25.0.vfs.1.1</MinimumGitVersion>
 
     <WatchmanPackageUrl>https://github.com/facebook/watchman/releases/download/v2020.08.03.00/watchman-v2020.08.03.00-windows.zip</WatchmanPackageUrl>


### PR DESCRIPTION
This only updates Git to include the dependencies for `ds/maintenance-part-3`. See microsoft/git#292 for more details.