### PR TITLE
FunctionalTests: drop unused negative runner methods

### DIFF
--- a/Scalar.FunctionalTests/FileSystemRunners/BashRunner.cs
+++ b/Scalar.FunctionalTests/FileSystemRunners/BashRunner.cs
@@ -120,18 +120,6 @@ namespace Scalar.FunctionalTests.FileSystemRunners
             return this.RunProcess(string.Format("-c \"mv '{0}' '{1}'\"", sourceBashPath, targetBashPath));
         }
 
-        public override void MoveFileShouldFail(string sourcePath, string targetPath)
-        {
-            // BashRunner does nothing special when a failure is expected, so just confirm source file is still present
-            this.MoveFile(sourcePath, targetPath);
-            this.FileExists(sourcePath).ShouldBeTrue($"{sourcePath} does not exist when it should");
-        }
-
-        public override void MoveFile_FileShouldNotBeFound(string sourcePath, string targetPath)
-        {
-            this.MoveFile(sourcePath, targetPath).ShouldContainOneOf(fileNotFoundMessages);
-        }
-
         public override string ReplaceFile(string sourcePath, string targetPath)
         {
             string sourceBashPath = this.ConvertWinPathToBashPath(sourcePath);
@@ -194,12 +182,6 @@ namespace Scalar.FunctionalTests.FileSystemRunners
             this.RunProcess(string.Format("-c \"echo \\\"{0}\\\" > '{1}'\"", contents, bashPath));
         }
 
-        public override void WriteAllTextShouldFail<ExceptionType>(string path, string contents)
-        {
-            // BashRunner does nothing special when a failure is expected
-            this.WriteAllText(path, contents);
-        }
-
         public override bool DirectoryExists(string path)
         {
             return this.FileExistsOnDisk(path, FileType.Directory);
@@ -213,16 +195,6 @@ namespace Scalar.FunctionalTests.FileSystemRunners
         public override void RenameDirectory(string workingDirectory, string source, string target)
         {
             this.MoveDirectory(Path.Combine(workingDirectory, source), Path.Combine(workingDirectory, target));
-        }
-
-        public override void MoveDirectory_RequestShouldNotBeSupported(string sourcePath, string targetPath)
-        {
-            this.MoveFile(sourcePath, targetPath).ShouldContain(moveDirectoryNotSupportedMessage);
-        }
-
-        public override void MoveDirectory_TargetShouldBeInvalid(string sourcePath, string targetPath)
-        {
-            this.MoveFile(sourcePath, targetPath).ShouldContainOneOf(invalidMovePathMessages);
         }
 
         public override void CreateDirectory(string path)
@@ -246,45 +218,12 @@ namespace Scalar.FunctionalTests.FileSystemRunners
             return this.RunProcess(string.Format("-c \"ls '{0}'\"", bashPath));
         }
 
-        public override void ReplaceFile_FileShouldNotBeFound(string sourcePath, string targetPath)
-        {
-            this.ReplaceFile(sourcePath, targetPath).ShouldContainOneOf(fileNotFoundMessages);
-        }
-
-        public override void DeleteFile_FileShouldNotBeFound(string path)
-        {
-            this.DeleteFile(path).ShouldContainOneOf(fileNotFoundMessages);
-        }
-
-        public override void DeleteFile_AccessShouldBeDenied(string path)
-        {
-            // bash does not report any error messages when access is denied, so just confirm the file still exists
-            this.DeleteFile(path);
-            this.FileExists(path).ShouldBeTrue($"{path} does not exist when it should");
-        }
-
-        public override void ReadAllText_FileShouldNotBeFound(string path)
-        {
-            this.ReadAllText(path).ShouldContainOneOf(fileNotFoundMessages);
-        }
-
-        public override void DeleteDirectory_DirectoryShouldNotBeFound(string path)
-        {
-            // Delete directory silently succeeds when deleting a non-existent path
-            this.DeleteDirectory(path);
-        }
-
         public override void ChangeMode(string path, ushort mode)
         {
             string octalMode = Convert.ToString(mode, 8);
             string bashPath = this.ConvertWinPathToBashPath(path);
             string command = $"-c \"chmod {octalMode} '{bashPath}'\"";
             this.RunProcess(command);
-        }
-
-        public override void DeleteDirectory_ShouldBeBlockedByProcess(string path)
-        {
-            Assert.Fail("Unlike the other runners, bash.exe does not check folder handle before recusively deleting");
         }
 
         public override long FileSize(string path)

--- a/Scalar.FunctionalTests/FileSystemRunners/CmdRunner.cs
+++ b/Scalar.FunctionalTests/FileSystemRunners/CmdRunner.cs
@@ -78,17 +78,6 @@ namespace Scalar.FunctionalTests.FileSystemRunners
             return this.RunProcess(string.Format("/C move \"{0}\" \"{1}\"", sourcePath, targetPath));
         }
 
-        public override void MoveFileShouldFail(string sourcePath, string targetPath)
-        {
-            // CmdRunner does nothing special when a failure is expected
-            this.MoveFile(sourcePath, targetPath);
-        }
-
-        public override void MoveFile_FileShouldNotBeFound(string sourcePath, string targetPath)
-        {
-            this.MoveFile(sourcePath, targetPath).ShouldContainOneOf(missingFileErrorMessages);
-        }
-
         public override string ReplaceFile(string sourcePath, string targetPath)
         {
             return this.RunProcess(string.Format("/C move /Y \"{0}\" \"{1}\"", sourcePath, targetPath));
@@ -126,12 +115,6 @@ namespace Scalar.FunctionalTests.FileSystemRunners
             // Use echo|set /p with "" to avoid adding any trailing whitespace or newline
             // to the contents
             this.RunProcess(string.Format("/C echo|set /p =\"{0}\" > {1}", contents, path));
-        }
-
-        public override void WriteAllTextShouldFail<ExceptionType>(string path, string contents)
-        {
-            // CmdRunner does nothing special when a failure is expected
-            this.WriteAllText(path, contents);
         }
 
         public override bool DirectoryExists(string path)
@@ -178,51 +161,9 @@ namespace Scalar.FunctionalTests.FileSystemRunners
             this.RunProcess(string.Format("/C ren \"{0}\" \"{1}\"", source, target), workingDirectory);
         }
 
-        public override void MoveDirectory_RequestShouldNotBeSupported(string sourcePath, string targetPath)
-        {
-            this.MoveFile(sourcePath, targetPath).ShouldContain(moveDirectoryFailureMessage);
-        }
-
-        public override void MoveDirectory_TargetShouldBeInvalid(string sourcePath, string targetPath)
-        {
-            this.MoveFile(sourcePath, targetPath).ShouldContain(moveDirectoryFailureMessage);
-        }
-
         public string RunCommand(string command)
         {
             return this.RunProcess(string.Format("/C {0}", command));
-        }
-
-        public override void ReplaceFile_FileShouldNotBeFound(string sourcePath, string targetPath)
-        {
-            this.ReplaceFile(sourcePath, targetPath).ShouldContainOneOf(missingFileErrorMessages);
-        }
-
-        public override void DeleteFile_FileShouldNotBeFound(string path)
-        {
-            this.DeleteFile(path).ShouldContainOneOf(missingFileErrorMessages);
-        }
-
-        public override void DeleteFile_AccessShouldBeDenied(string path)
-        {
-            // CMD does not report any error messages when access is denied, so just confirm the file still exists
-            this.DeleteFile(path);
-            this.FileExists(path).ShouldEqual(true);
-        }
-
-        public override void ReadAllText_FileShouldNotBeFound(string path)
-        {
-            this.ReadAllText(path).ShouldContainOneOf(missingFileErrorMessages);
-        }
-
-        public override void DeleteDirectory_DirectoryShouldNotBeFound(string path)
-        {
-            this.DeleteDirectory(path).ShouldContainOneOf(missingFileErrorMessages);
-        }
-
-        public override void DeleteDirectory_ShouldBeBlockedByProcess(string path)
-        {
-            this.DeleteDirectory(path).ShouldContain(fileUsedByAnotherProcessMessage);
         }
 
         public override void ChangeMode(string path, ushort mode)

--- a/Scalar.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
+++ b/Scalar.FunctionalTests/FileSystemRunners/FileSystemRunner.cs
@@ -46,22 +46,9 @@ namespace Scalar.FunctionalTests.FileSystemRunners
         public abstract bool FileExists(string path);
         public abstract string MoveFile(string sourcePath, string targetPath);
 
-        /// <summary>
-        /// Attempt to move the specified file to the specifed target path.  By calling this method the caller is
-        /// indicating that they expect the move to fail. However, the caller is responsible for verifying that
-        /// the move failed.
-        /// </summary>
-        /// <param name="sourcePath">Path to existing file</param>
-        /// <param name="targetPath">Path to target file (target of the move)</param>
-        public abstract void MoveFileShouldFail(string sourcePath, string targetPath);
-        public abstract void MoveFile_FileShouldNotBeFound(string sourcePath, string targetPath);
         public abstract string ReplaceFile(string sourcePath, string targetPath);
-        public abstract void ReplaceFile_FileShouldNotBeFound(string sourcePath, string targetPath);
         public abstract string DeleteFile(string path);
-        public abstract void DeleteFile_FileShouldNotBeFound(string path);
-        public abstract void DeleteFile_AccessShouldBeDenied(string path);
         public abstract string ReadAllText(string path);
-        public abstract void ReadAllText_FileShouldNotBeFound(string path);
 
         public abstract void CreateEmptyFile(string path);
         public abstract void CreateHardLink(string newLinkFilePath, string existingFilePath);
@@ -86,22 +73,10 @@ namespace Scalar.FunctionalTests.FileSystemRunners
         /// <param name="contents">File contents</param>
         public abstract void AppendAllText(string path, string contents);
 
-        /// <summary>
-        /// Attempt to write the specified contents to the specified file.  By calling this method the caller is
-        /// indicating that they expect the write to fail. However, the caller is responsible for verifying that
-        /// the write failed.
-        /// </summary>
-        /// <typeparam name="ExceptionType">Expected type of exception to be thrown</typeparam>
-        /// <param name="path">Path to file</param>
-        /// <param name="contents">File contents</param>
-        public abstract void WriteAllTextShouldFail<ExceptionType>(string path, string contents) where ExceptionType : Exception;
-
         // Directory methods
         public abstract bool DirectoryExists(string path);
         public abstract void MoveDirectory(string sourcePath, string targetPath);
         public abstract void RenameDirectory(string workingDirectory, string source, string target);
-        public abstract void MoveDirectory_RequestShouldNotBeSupported(string sourcePath, string targetPath);
-        public abstract void MoveDirectory_TargetShouldBeInvalid(string sourcePath, string targetPath);
         public abstract void CreateDirectory(string path);
         public abstract string EnumerateDirectory(string path);
         public abstract long FileSize(string path);
@@ -110,7 +85,5 @@ namespace Scalar.FunctionalTests.FileSystemRunners
         /// A recursive delete of a directory
         /// </summary>
         public abstract string DeleteDirectory(string path);
-        public abstract void DeleteDirectory_DirectoryShouldNotBeFound(string path);
-        public abstract void DeleteDirectory_ShouldBeBlockedByProcess(string path);
     }
 }

--- a/Scalar.FunctionalTests/FileSystemRunners/PowerShellRunner.cs
+++ b/Scalar.FunctionalTests/FileSystemRunners/PowerShellRunner.cs
@@ -63,17 +63,6 @@ namespace Scalar.FunctionalTests.FileSystemRunners
             return this.RunProcess(string.Format("-Command \"& {{ Move-Item {0} {1} -force}}\"", sourcePath, targetPath));
         }
 
-        public override void MoveFileShouldFail(string sourcePath, string targetPath)
-        {
-            // PowerShellRunner does nothing special when a failure is expected
-            this.MoveFile(sourcePath, targetPath);
-        }
-
-        public override void MoveFile_FileShouldNotBeFound(string sourcePath, string targetPath)
-        {
-            this.MoveFile(sourcePath, targetPath).ShouldContainOneOf(missingFileErrorMessages);
-        }
-
         public override string ReplaceFile(string sourcePath, string targetPath)
         {
             return this.RunProcess(string.Format("-Command \"& {{ Move-Item {0} {1} -force }}\"", sourcePath, targetPath));
@@ -116,12 +105,6 @@ namespace Scalar.FunctionalTests.FileSystemRunners
             this.RunProcess(string.Format("-Command \"&{{ Out-File -FilePath {0} -InputObject '{1}' -Encoding ascii -NoNewline}}\"", path, contents));
         }
 
-        public override void WriteAllTextShouldFail<ExceptionType>(string path, string contents)
-        {
-            // PowerShellRunner does nothing special when a failure is expected
-            this.WriteAllText(path, contents);
-        }
-
         public override bool DirectoryExists(string path)
         {
             string command = string.Format("-Command \"&{{ Test-Path {0} -PathType Container }}\"", path);
@@ -145,16 +128,6 @@ namespace Scalar.FunctionalTests.FileSystemRunners
             this.RunProcess(string.Format("-Command \"& {{ Rename-Item -Path {0} -NewName {1} -force }}\"", Path.Combine(workingDirectory, source), target));
         }
 
-        public override void MoveDirectory_RequestShouldNotBeSupported(string sourcePath, string targetPath)
-        {
-            this.MoveFile(sourcePath, targetPath).ShouldContain(moveDirectoryNotSupportedMessage);
-        }
-
-        public override void MoveDirectory_TargetShouldBeInvalid(string sourcePath, string targetPath)
-        {
-            this.MoveFile(sourcePath, targetPath).ShouldContain(invalidPathErrorMessages);
-        }
-
         public override void CreateDirectory(string path)
         {
             this.RunProcess(string.Format("-Command \"&{{ New-Item {0} -type directory}}\"", path));
@@ -168,37 +141,6 @@ namespace Scalar.FunctionalTests.FileSystemRunners
         public override string EnumerateDirectory(string path)
         {
             return this.RunProcess(string.Format("-Command \"&{{ Get-ChildItem {0} }}\"", path));
-        }
-
-        public override void ReplaceFile_FileShouldNotBeFound(string sourcePath, string targetPath)
-        {
-            this.ReplaceFile(sourcePath, targetPath).ShouldContainOneOf(missingFileErrorMessages);
-        }
-
-        public override void DeleteFile_FileShouldNotBeFound(string path)
-        {
-            this.DeleteFile(path).ShouldContainOneOf(missingFileErrorMessages);
-        }
-
-        public override void DeleteFile_AccessShouldBeDenied(string path)
-        {
-            this.DeleteFile(path).ShouldContain(permissionDeniedMessage);
-            this.FileExists(path).ShouldBeTrue($"{path} does not exist when it should");
-        }
-
-        public override void ReadAllText_FileShouldNotBeFound(string path)
-        {
-            this.ReadAllText(path).ShouldContainOneOf(missingFileErrorMessages);
-        }
-
-        public override void DeleteDirectory_DirectoryShouldNotBeFound(string path)
-        {
-            this.DeleteDirectory(path).ShouldContainOneOf(missingFileErrorMessages);
-        }
-
-        public override void DeleteDirectory_ShouldBeBlockedByProcess(string path)
-        {
-            this.DeleteDirectory(path).ShouldContain(fileUsedByAnotherProcessMessage);
         }
 
         public override long FileSize(string path)

--- a/Scalar.FunctionalTests/FileSystemRunners/SystemIORunner.cs
+++ b/Scalar.FunctionalTests/FileSystemRunners/SystemIORunner.cs
@@ -42,48 +42,16 @@ namespace Scalar.FunctionalTests.FileSystemRunners
             return file;
         }
 
-        public override void MoveFileShouldFail(string sourcePath, string targetPath)
-        {
-            if (Debugger.IsAttached)
-            {
-                throw new InvalidOperationException("MoveFileShouldFail should not be run with the debugger attached");
-            }
-
-            this.ShouldFail<IOException>(() => { this.MoveFile(sourcePath, targetPath); });
-        }
-
-        public override void MoveFile_FileShouldNotBeFound(string sourcePath, string targetPath)
-        {
-            this.ShouldFail<IOException>(() => { this.MoveFile(sourcePath, targetPath); });
-        }
-
         public override string ReplaceFile(string sourcePath, string targetPath)
         {
             File.Replace(sourcePath, targetPath, null);
             return string.Empty;
         }
 
-        public override void ReplaceFile_FileShouldNotBeFound(string sourcePath, string targetPath)
-        {
-            this.ShouldFail<IOException>(() => { this.ReplaceFile(sourcePath, targetPath); });
-        }
-
         public override string DeleteFile(string path)
         {
             File.Delete(path);
             return string.Empty;
-        }
-
-        public override void DeleteFile_FileShouldNotBeFound(string path)
-        {
-            // Delete file silently succeeds when file is non-existent
-            this.DeleteFile(path);
-        }
-
-        public override void DeleteFile_AccessShouldBeDenied(string path)
-        {
-            this.ShouldFail<Exception>(() => { this.DeleteFile(path); });
-            this.FileExists(path).ShouldBeTrue($"{path} does not exist when it should");
         }
 
         public override string ReadAllText(string path)
@@ -120,16 +88,6 @@ namespace Scalar.FunctionalTests.FileSystemRunners
             File.AppendAllText(path, contents);
         }
 
-        public override void WriteAllTextShouldFail<ExceptionType>(string path, string contents)
-        {
-            if (Debugger.IsAttached)
-            {
-                throw new InvalidOperationException("WriteAllTextShouldFail should not be run with the debugger attached");
-            }
-
-            this.ShouldFail<ExceptionType>(() => { this.WriteAllText(path, contents); });
-        }
-
         public override bool DirectoryExists(string path)
         {
             return Directory.Exists(path);
@@ -150,26 +108,6 @@ namespace Scalar.FunctionalTests.FileSystemRunners
             {
                 Rename(Path.Combine(workingDirectory, source), Path.Combine(workingDirectory, target));
             }
-        }
-
-        public override void MoveDirectory_RequestShouldNotBeSupported(string sourcePath, string targetPath)
-        {
-            if (Debugger.IsAttached)
-            {
-                throw new InvalidOperationException("MoveDirectory_RequestShouldNotBeSupported should not be run with the debugger attached");
-            }
-
-            Assert.Catch<IOException>(() => this.MoveDirectory(sourcePath, targetPath));
-        }
-
-        public override void MoveDirectory_TargetShouldBeInvalid(string sourcePath, string targetPath)
-        {
-            if (Debugger.IsAttached)
-            {
-                throw new InvalidOperationException("MoveDirectory_TargetShouldBeInvalid should not be run with the debugger attached");
-            }
-
-            Assert.Catch<IOException>(() => this.MoveDirectory(sourcePath, targetPath));
         }
 
         public override void CreateDirectory(string path)
@@ -200,21 +138,6 @@ namespace Scalar.FunctionalTests.FileSystemRunners
         public override string EnumerateDirectory(string path)
         {
             return string.Join(Environment.NewLine, Directory.GetFileSystemEntries(path));
-        }
-
-        public override void DeleteDirectory_DirectoryShouldNotBeFound(string path)
-        {
-            this.ShouldFail<IOException>(() => { this.DeleteDirectory(path); });
-        }
-
-        public override void DeleteDirectory_ShouldBeBlockedByProcess(string path)
-        {
-            Assert.Fail("DeleteDirectory_ShouldBeBlockedByProcess not supported by SystemIORunner");
-        }
-
-        public override void ReadAllText_FileShouldNotBeFound(string path)
-        {
-            this.ShouldFail<IOException>(() => { this.ReadAllText(path); });
         }
 
         public override void ChangeMode(string path, ushort mode)
@@ -283,11 +206,6 @@ namespace Scalar.FunctionalTests.FileSystemRunners
             }
 
             throw new Exception(message.ToString());
-        }
-
-        private void ShouldFail<ExceptionType>(Action action) where ExceptionType : Exception
-        {
-            Assert.Catch<ExceptionType>(() => action());
         }
     }
 }


### PR DESCRIPTION
We can prune the various negative "should fail" and "should not" methods from the `FileSystemRunner` classes as these are no longer utilized by any tests.

These methods were previously used by the `BasicFileSystemTests` and `MoveRenameFolderTests`, which were removed in commit d748084d852759e3e6c7c1e657452e2e75adf666.

Three additional methods could also be removed from these runner classes, namely `FileSize()`, `ReplaceFile()`, and `RenameDirectory()`.  I left them in because it seemed like they might be more obviously useful in the future than the "negative" methods.

OTOH these three additional unused methods could also be pruned now and then resurrected from Git history if they are ever needed again.  If the latter is preferred, I can add commit d32582c17c85a130293c3b394cddd3fddbb59cc0 to this PR to also drop them; just let me know either way.