### PR TITLE
Build Debian packages and tarball for Linux builds

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -1,0 +1,43 @@
+name: Build Installers
+
+on:
+  push:
+    branches: [ main, release/* ]
+  pull_request:
+    branches: [ main, release/* ]
+
+jobs:
+  linux:
+    name: "Linux"
+
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.302
+
+    - name: Install dependencies
+      run: dotnet restore --force
+
+    - name: Build Linux packages
+      run: dotnet publish -c Release 'Scalar.Packaging.Linux/Scalar.Packaging.Linux.csproj'
+
+      # Because the actions/upload-artifact action does not allow you to specify
+      # relative file paths we must first use a shell script to copy the
+      # artifacts to a different directory.
+    - name: Collect packages
+      shell: bash
+      run: |
+        rm -rf to_upload
+        mkdir to_upload
+        cp ../out/Scalar.Packaging.Linux/deb/Release/*.deb    to_upload
+        cp ../out/Scalar.Packaging.Linux/tar/Release/*.tar.gz to_upload
+
+    - name: Upload packages
+      uses: actions/upload-artifact@v2
+      with:
+        name: Linux
+        path: to_upload/*

--- a/Scalar.Packaging.Linux/Scalar.Packaging.Linux.csproj
+++ b/Scalar.Packaging.Linux/Scalar.Packaging.Linux.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+  </PropertyGroup>
+
+  <ItemDefinitionGroup>
+    <ProjectReference ReferenceOutputAssembly="false" Private="false" />
+  </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Scalar\Scalar.csproj" />
+  </ItemGroup>
+
+  <!-- Only create the packages when running on Linux -->
+  <Target Name="BuildInstaller" AfterTargets="Publish" Condition="'$(OSPlatform)' == 'linux'" >
+    <!-- Ensure all projects have been published with the correct runtime identifier and configuration -->
+    <MSBuild Projects="@(ProjectReference)"
+             Targets="Publish"
+             Properties="
+             Configuration=$(Configuration);
+             RuntimeIdentifier=$(RuntimeIdentifier);"
+             BuildInParallel="true" />
+
+    <!-- Build the packages -->
+    <Exec Command="$(MSBuildProjectDirectory)/build.sh '$(ScalarVersion)' '$(Configuration)'"/>
+  </Target>
+
+  <Target Name="_Clean" AfterTargets="Clean">
+    <RemoveDir Directories="$(ProjectOutPath)" />
+  </Target>
+
+</Project>

--- a/Scalar.Packaging.Linux/build.sh
+++ b/Scalar.Packaging.Linux/build.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+die () {
+    echo "$*" >&2
+    exit 1
+}
+
+make_absolute () {
+    case "$1" in
+    /*)
+        echo "$1"
+        ;;
+    *)
+        echo "$PWD/$1"
+        ;;
+    esac
+}
+
+#####################################################################
+# Building
+#####################################################################
+echo "Building Scalar.Packaging.Linux..."
+
+# Parse script arguments
+VERSION=$1
+if [ -z "${VERSION}" ]; then
+  die "Error: Version not specified"
+fi
+
+CONFIGURATION=$2
+CONFIGURATION="${CONFIGURATION:=Debug}"
+
+# Directories
+THISDIR="$( cd "$(dirname "$0")" ; pwd -P )"
+ROOT="$( cd "$THISDIR"/../.. ; pwd -P )"
+SRC="$ROOT/src"
+OUT="$ROOT/out"
+SCALAR_SRC="$SRC/Scalar"
+PROJ_OUT="$OUT/Scalar.Packaging.Linux"
+
+# Build parameters
+FRAMEWORK=netcoreapp3.1
+RUNTIME=linux-x64
+
+ARCH="`dpkg-architecture -q DEB_HOST_ARCH`"
+if test -z "$ARCH"; then
+  die "Could not determine host architecture!"
+fi
+
+# Outputs
+PAYLOAD="$PROJ_OUT/payload/$CONFIGURATION"
+SYMBOLOUT="$PROJ_OUT/payload.sym/$CONFIGURATION"
+
+TAROUT="$PROJ_OUT/tar/$CONFIGURATION"
+TARBALL="$TAROUT/scalar-linux_$ARCH.$VERSION.tar.gz"
+SYMTARBALL="$TAROUT/symbols-linux_$ARCH.$VERSION.tar.gz"
+
+DEBOUT="$PROJ_OUT/deb/$CONFIGURATION"
+DEBROOT="$DEBOUT/root"
+DEBPKG="$DEBOUT/scalar-linux_$ARCH.$VERSION.deb"
+DEBROOTAZREPOS="$DEBOUT/root-azrepos"
+DEBPKGAZREPOS="$DEBOUT/scalar-azrepos-linux_$ARCH.$VERSION.deb"
+
+# Cleanup payload directory
+if [ -d "$PAYLOAD" ]; then
+    echo "Cleaning existing payload directory '$PAYLOAD'..."
+    rm -rf "$PAYLOAD"
+fi
+
+# Cleanup symbol directory
+if [ -d "$SYMBOLOUT" ]; then
+    echo "Cleaning existing symbols directory '$SYMBOLOUT'..."
+    rm -rf "$SYMBOLOUT"
+fi
+
+# Ensure directories exists
+mkdir -p "$PAYLOAD" "$SYMBOLOUT" "$DEBROOT" "$DEBROOTAZREPOS"
+
+# Publish core application executables
+echo "Publishing core application..."
+dotnet publish "$SCALAR_SRC" \
+    --configuration="$CONFIGURATION" \
+    --framework="$FRAMEWORK" \
+    --runtime="$RUNTIME" \
+    --self-contained=true \
+    "/p:PublishSingleFile=True" \
+    --output="$(make_absolute "$PAYLOAD")" || exit 1
+
+# Collect symbols
+echo "Collecting managed symbols..."
+mv "$PAYLOAD"/*.pdb "$SYMBOLOUT" || exit 1
+
+echo "Build complete."
+
+#####################################################################
+# PACKING
+#####################################################################
+echo "Packing Scalar.Packaging.Linux..."
+# Cleanup any old archive files
+if [ -e "$TAROUT" ]; then
+    echo "Deleting old archive '$TAROUT'..."
+    rm "$TAROUT"
+fi
+
+# Ensure the parent directory for the archive exists
+mkdir -p "$TAROUT" || exit 1
+
+# Set full read, write, execute permissions for owner and just read and execute permissions for group and other
+echo "Setting file permissions..."
+/bin/chmod -R 755 "$PAYLOAD" || exit 1
+
+# Build binaries tarball
+echo "Building binaries tarball..."
+pushd "$PAYLOAD"
+tar -czvf "$TARBALL" * || exit 1
+popd
+
+# Build symbols tarball
+echo "Building symbols tarball..."
+pushd "$SYMBOLOUT"
+tar -czvf "$SYMTARBALL" * || exit 1
+popd
+
+# Build .deb
+INSTALL_TO="$DEBROOT/usr/local/bin/"
+INSTALL_TOAZREPOS="$DEBROOTAZREPOS/usr/local/bin/"
+mkdir -p "$DEBROOT/DEBIAN" "$DEBROOTAZREPOS/DEBIAN" "$INSTALL_TO" "$INSTALL_TOAZREPOS" || exit 1
+
+# Make the debian control files
+cat >"$DEBROOT/DEBIAN/control" <<EOF
+Package: scalar
+Version: $VERSION
+Section: vcs
+Priority: optional
+Architecture: $ARCH
+Pre-Depends: git (>= 1:2.25.1)
+Recommends: gcmcore
+Maintainer: Git Client Team <git-client@github.com>
+Description: A set of tools and extensions for Git to allow very large
+ monorepos to run on Git without a virtualization layer.
+ For more information see https://aka.ms/scalar
+EOF
+
+cat >"$DEBROOTAZREPOS/DEBIAN/control" <<EOF
+Package: scalar-azrepos
+Version: $VERSION
+Section: vcs
+Priority: optional
+Architecture: $ARCH
+Pre-Depends: git-vfs (>= 2.28.0.vfs.1.0)
+Recommends: gcmcore
+Maintainer: Git Client Team <git-client@github.com>
+Description: A set of tools and extensions for Git to allow very large
+ monorepos to run on Git without a virtualization layer.
+ For more information see https://aka.ms/scalar
+EOF
+
+# Copy single binary to target installation location
+cp "$PAYLOAD/scalar" "$INSTALL_TO" || exit 1
+cp "$PAYLOAD/scalar" "$INSTALL_TOAZREPOS" || exit 1
+
+dpkg-deb --build "$DEBROOT" "$DEBPKG" || exit 1
+dpkg-deb --build "$DEBROOTAZREPOS" "$DEBPKGAZREPOS" || exit 1
+
+echo "Pack complete."

--- a/Scalar.Packaging.Linux/build.sh
+++ b/Scalar.Packaging.Linux/build.sh
@@ -32,7 +32,7 @@ CONFIGURATION="${CONFIGURATION:=Debug}"
 # Directories
 THISDIR="$( cd "$(dirname "$0")" ; pwd -P )"
 ROOT="$( cd "$THISDIR"/../.. ; pwd -P )"
-SRC="$ROOT/src"
+SRC="$( cd "$THISDIR"/.. ; pwd -P )"
 OUT="$ROOT/out"
 SCALAR_SRC="$SRC/Scalar"
 PROJ_OUT="$OUT/Scalar.Packaging.Linux"

--- a/Scalar.sln
+++ b/Scalar.sln
@@ -1,5 +1,4 @@
-
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30406.18
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -34,6 +33,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Scalar.Service.UI", "Scalar.Service.UI\Scalar.Service.UI.csproj", "{32D8335E-E9E8-4AD8-BAE5-162F53AA4D72}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Scalar.Notifications.Mac", "Scalar.Notifications.Mac\Scalar.Notifications.Mac.csproj", "{ED367118-BFB1-41CA-A010-E46C28796ED8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Scalar.Packaging.Linux", "Scalar.Packaging.Linux\Scalar.Packaging.Linux.csproj", "{AAD540B9-E65F-4C0B-916C-4CB50DA7A7DB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -89,6 +90,10 @@ Global
 		{ED367118-BFB1-41CA-A010-E46C28796ED8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ED367118-BFB1-41CA-A010-E46C28796ED8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ED367118-BFB1-41CA-A010-E46C28796ED8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AAD540B9-E65F-4C0B-916C-4CB50DA7A7DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AAD540B9-E65F-4C0B-916C-4CB50DA7A7DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AAD540B9-E65F-4C0B-916C-4CB50DA7A7DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AAD540B9-E65F-4C0B-916C-4CB50DA7A7DB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Build Debian packages for the Linux build of Scalar, as well as a tarball and symbol tarball. Upload these as artefacts as part of a GitHub workflow.

When building locally via `dotnet` CLI or `Scripts/Linux/BuildScalarForLinux.sh`, the Debian packages and tarballs can be found in `../out/Scalar.Packaging.Linux/(deb|tar)`.