### PR TITLE
RunVerb: pass git features to ConfigStep

### DIFF
--- a/Scalar/CommandLine/RunVerb.cs
+++ b/Scalar/CommandLine/RunVerb.cs
@@ -117,7 +117,7 @@ namespace Scalar.CommandLine
                         switch (this.MaintenanceTask)
                         {
                             case ScalarConstants.VerbParameters.Maintenance.AllTasksName:
-                                steps.Add(new ConfigStep(context));
+                                steps.Add(new ConfigStep(context, gitFeatures: gitFeatures));
                                 this.InitializeServerConnection(tracer, enlistment, cacheServerUrl, out objectRequestor, out cacheServer);
                                 gitObjects = new GitObjects(tracer, enlistment, objectRequestor, fileSystem);
                                 steps.Add(new FetchStep(context, gitObjects, requireCacheLock: false, forceRun: !this.StartedByService));
@@ -159,7 +159,7 @@ namespace Scalar.CommandLine
 
                             case ScalarConstants.VerbParameters.Maintenance.ConfigTaskName:
                                 this.FailIfBatchSizeSet(tracer);
-                                steps.Add(new ConfigStep(context));
+                                steps.Add(new ConfigStep(context, gitFeatures: gitFeatures));
                                 break;
 
                             default:


### PR DESCRIPTION
The ConfigStep makes a decision about calling 'git maintenance start'
depending on the platform (Linux only for now) and the Git version.
However, the code for computing the feature flags is in ScalarVerb and
needs to be injected by passing it through the ConfigStep constructor.
This was missed in the earlier work that inserted this into other
maintenance steps.

This fixes a feature that should have been introduced in #398.