### PR TITLE
SignFiles: drop upgrader on macOS

### DIFF
--- a/Scalar.Signing/PostSignFiles.Mac.cmd
+++ b/Scalar.Signing/PostSignFiles.Mac.cmd
@@ -15,8 +15,6 @@ echo Copying signed files...
 xcopy "%SIGNDIR%\pe\scalar.dll"          "%LAYOUTDIR%\usr\local\scalar\" /k/h/y
 xcopy "%SIGNDIR%\pe\scalar.common.dll"   "%LAYOUTDIR%\usr\local\scalar\" /k/h/y
 xcopy "%SIGNDIR%\pe\scalar.service.dll"  "%LAYOUTDIR%\usr\local\scalar\" /k/h/y
-xcopy "%SIGNDIR%\pe\scalar.upgrader.dll" "%LAYOUTDIR%\usr\local\scalar\" /k/h/y
 xcopy "%SIGNDIR%\macho\scalar"           "%LAYOUTDIR%\usr\local\scalar\" /k/h/y
 xcopy "%SIGNDIR%\macho\scalar.service"   "%LAYOUTDIR%\usr\local\scalar\" /k/h/y
-xcopy "%SIGNDIR%\macho\scalar.upgrader"  "%LAYOUTDIR%\usr\local\scalar\" /k/h/y
 xcopy "%SIGNDIR%\macho\Scalar.app"      "%LAYOUTDIR%\Library\Application Support\Scalar\Scalar.app\" /s/h/e/k/f/c/y

--- a/Scalar.Signing/PreSignFiles.Mac.cmd
+++ b/Scalar.Signing/PreSignFiles.Mac.cmd
@@ -18,8 +18,6 @@ mkdir "%SIGNDIR%\macho"
 xcopy "%LAYOUTDIR%\usr\local\scalar\scalar.dll"                   "%SIGNDIR%\pe"    /k/h/y
 xcopy "%LAYOUTDIR%\usr\local\scalar\scalar.common.dll"            "%SIGNDIR%\pe"    /k/h/y
 xcopy "%LAYOUTDIR%\usr\local\scalar\scalar.service.dll"           "%SIGNDIR%\pe"    /k/h/y
-xcopy "%LAYOUTDIR%\usr\local\scalar\scalar.upgrader.dll"          "%SIGNDIR%\pe"    /k/h/y
 xcopy "%LAYOUTDIR%\usr\local\scalar\scalar"                       "%SIGNDIR%\macho" /k/h/y
 xcopy "%LAYOUTDIR%\usr\local\scalar\scalar.service"               "%SIGNDIR%\macho" /k/h/y
-xcopy "%LAYOUTDIR%\usr\local\scalar\scalar.upgrader"              "%SIGNDIR%\macho" /k/h/y
 xcopy "%LAYOUTDIR%\Library\Application Support\Scalar\Scalar.app" "%SIGNDIR%\macho\Scalar.app\" /s/h/e/k/f/c/y

--- a/Scalar.Signing/Scalar.SignFiles.Mac.csproj
+++ b/Scalar.Signing/Scalar.SignFiles.Mac.csproj
@@ -12,12 +12,10 @@
     <FilesToSign Include="
       $(OutDir)\pe\scalar.dll;
       $(OutDir)\pe\scalar.common.dll;
-      $(OutDir)\pe\scalar.service.dll;
-      $(OutDir)\pe\scalar.upgrader.dll;" />
+      $(OutDir)\pe\scalar.service.dll;" />
     <MacFilesToSign Include="
       $(OutDir)\macho\scalar;
       $(OutDir)\macho\scalar.service;
-      $(OutDir)\macho\scalar.upgrader;
       $(OutDir)\macho\Scalar.app;" />
   </ItemGroup>
 


### PR DESCRIPTION
This is a cherry-pick of a commit I pushed to `releases/20.10.178` to fix macOS signing problems in the `microsoft.scalar-release` build.

The `scalar.upgrader` project was removed from macOS in #412, but we didn't run the signing until release time.