### PR TITLE
Port Debian package signing

### DIFF
--- a/.github/run_esrp_signing.py
+++ b/.github/run_esrp_signing.py
@@ -1,0 +1,128 @@
+import json
+import os
+import glob
+import pprint
+import subprocess
+import sys
+
+esrp_tool = os.path.join("esrp", "tools", "EsrpClient.exe")
+
+aad_id = os.environ['AZURE_AAD_ID'].strip()
+workspace = os.environ['GITHUB_WORKSPACE'].strip()
+
+source_root_location = os.path.join(workspace, "tosign")
+destination_location = os.path.join(workspace)
+
+scalar_files = glob.glob(os.path.join(source_root_location, "scalar-linux*.deb"))
+azrepos_files = glob.glob(os.path.join(source_root_location, "scalar-azrepos-linux*.deb"))
+
+print("Found files:")
+pprint.pp(scalar_files)
+pprint.pp(azrepos_files)
+
+if len(scalar_files) < 1 or not scalar_files[0].endswith(".deb"):
+	print("Error: cannot find scalar .deb to sign")
+	exit(1)
+
+if len(azrepos_files) < 1 or not azrepos_files[0].endswith(".deb"):
+	print("Error: cannot find scalar-azrepos .deb to sign")
+	exit(1)
+
+scalar_to_sign = os.path.basename(scalar_files[0])
+azrepos_to_sign = os.path.basename(azrepos_files[0])
+
+auth_json = {
+	"Version": "1.0.0",
+	"AuthenticationType": "AAD_CERT",
+	"TenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+	"ClientId": aad_id,
+	"AuthCert": {
+		"SubjectName": f"CN={aad_id}.microsoft.com",
+		"StoreLocation": "LocalMachine",
+		"StoreName": "My",
+	},
+	"RequestSigningCert": {
+		"SubjectName": f"CN={aad_id}",
+		"StoreLocation": "LocalMachine",
+		"StoreName": "My",
+	}
+}
+
+input_json = {
+	"Version": "1.0.0",
+	"SignBatches": [
+		{
+			"SourceLocationType": "UNC",
+			"SourceRootDirectory": source_root_location,
+			"DestinationLocationType": "UNC",
+			"DestinationRootDirectory": destination_location,
+			"SignRequestFiles": [
+				{
+					"CustomerCorrelationId": "01A7F55F-6CDD-4123-B255-77E6F212CDAD",
+					"SourceLocation": scalar_to_sign,
+					"DestinationLocation": os.path.join("signed", scalar_to_sign),
+				},
+				{
+					"CustomerCorrelationId": "01A7F55F-6CDD-4123-B255-77E6F212CDAD",
+					"SourceLocation": azrepos_to_sign,
+					"DestinationLocation": os.path.join("signed", azrepos_to_sign),
+				}
+			],
+			"SigningInfo": {
+				"Operations": [
+					{
+						"KeyCode": "CP-450779-Pgp",
+						"OperationCode": "LinuxSign",
+						"Parameters": {},
+						"ToolName": "sign",
+						"ToolVersion": "1.0",
+					}
+				]
+			}
+		}
+	]
+}
+
+policy_json = {
+	"Version": "1.0.0",
+	"Intent": "production release",
+	"ContentType": "Debian package",
+}
+
+configs = [
+	("auth.json", auth_json),
+	("input.json", input_json),
+	("policy.json", policy_json),
+]
+
+for filename, data in configs:
+	with open(filename, 'w') as fp:
+		json.dump(data, fp)
+
+# Run ESRP Client
+esrp_out = "esrp_out.json"
+result = subprocess.run(
+	[esrp_tool, "sign",
+	"-a", "auth.json",
+	"-i", "input.json",
+	"-p", "policy.json",
+	"-o", esrp_out,
+	"-l", "Verbose"],
+	cwd=workspace)
+
+if result.returncode != 0:
+	print("Failed to run ESRPClient.exe")
+	sys.exit(1)
+
+if os.path.isfile(esrp_out):
+	print("ESRP output json:")
+	with open(esrp_out, 'r') as fp:
+		pprint.pp(json.load(fp))
+
+scalar_signed = os.path.join(destination_location, "signed", scalar_to_sign)
+if os.path.isfile(scalar_signed):
+	print(f"Success!\nSigned {scalar_signed}")
+
+azrepos_to_sign = os.path.join(destination_location, "signed", azrepos_to_sign)
+if os.path.isfile(azrepos_to_sign):
+	print(f"Success!\nSigned {azrepos_to_sign}")

--- a/.github/workflows/build-signed-deb.yml
+++ b/.github/workflows/build-signed-deb.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   release:
     types: [released]
+  pull_request:
+    branches: [ main ] # TODO: remove after testing
 
 jobs:
   build:

--- a/.github/workflows/build-signed-deb.yml
+++ b/.github/workflows/build-signed-deb.yml
@@ -1,0 +1,108 @@
+name: "Build Signed Debian Packages"
+
+on:
+  workflow_dispatch:
+  release:
+    types: [released]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.302
+
+    - name: Install dependencies
+      run: dotnet restore --force
+
+    - name: Build Linux packages
+      run: |
+        BRANCH=$(git branch --show-current)
+        if [ "${BRANCH:0:9}" = "releases/" ]; then
+          SCALARVERSION="${BRANCH:9}".0
+        else
+          SCALARVERSION=0.3.132.0
+        fi
+        echo $SCALARVERSION
+        dotnet publish -c Release -p:ScalarVersion=$SCALARVERSION 'Scalar.Packaging.Linux/Scalar.Packaging.Linux.csproj'
+
+      # Because the actions/upload-artifact action does not allow you to specify
+      # relative file paths we must first use a shell script to copy the
+      # artifacts to a different directory.
+    - name: Collect packages
+      shell: bash
+      run: |
+        rm -rf to_upload
+        mkdir to_upload
+        cp ../out/Scalar.Packaging.Linux/deb/Release/*.deb    to_upload
+
+    - name: Upload packages
+      uses: actions/upload-artifact@v2
+      with:
+        name: DebianUnsigned
+        path: to_upload/*
+
+  sign:
+    name: Sign
+    runs-on: windows-latest
+    needs: build
+    steps:
+    - name: setup python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    - uses: actions/checkout@v2
+
+    - name: 'Download Unsigned Packages'
+      uses: actions/download-artifact@v2
+      with:
+        name: DebianUnsigned
+        path: tosign
+
+    - uses: Azure/login@v1.1
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+    - name: 'Install ESRP Client'
+      shell: pwsh
+      env:
+        AZ_SUB: ${{ secrets.AZURE_SUBSCRIPTION }}
+      run: |
+        az storage blob download --subscription  "$env:AZ_SUB" --account-name gitcitoolstore -c tools -n microsoft.esrpclient.1.2.47.nupkg -f esrp.zip
+        Expand-Archive -Path esrp.zip -DestinationPath .\esrp
+
+    - name: Install Certificates
+      shell: pwsh
+      env:
+        AZ_SUB: ${{ secrets.AZURE_SUBSCRIPTION }}
+        AZ_VAULT: ${{ secrets.AZURE_VAULT }}
+        SSL_CERT: ${{ secrets.VAULT_SSL_CERT_NAME }}
+        ESRP_CERT: ${{ secrets.VAULT_ESRP_CERT_NAME }}
+      run: |
+        az keyvault secret download --subscription "$env:AZ_SUB" --vault-name "$env:AZ_VAULT" --name "$env:SSL_CERT" -f out.pfx
+        certutil -f -importpfx out.pfx
+        Remove-Item out.pfx
+
+        az keyvault secret download --subscription "$env:AZ_SUB" --vault-name "$env:AZ_VAULT" --name "$env:ESRP_CERT" -f out.pfx
+        certutil -f -importpfx out.pfx
+        Remove-Item out.pfx
+
+    - name: Run ESRP Client
+      shell: pwsh
+      env:
+        AZURE_AAD_ID: ${{ secrets.AZURE_AAD_ID }}
+      run: |
+        python .github/run_esrp_signing.py
+
+    - name: Upload Signed Packages
+      uses: actions/upload-artifact@v2
+      with:
+        name: DebianSigned
+        path: |
+          signed/*.deb


### PR DESCRIPTION
Port Debian package signing workflow and scripts from GCM Core.

This is a "good enough for now" state; we should revisit these scripts and clean them up, when we look to port Windows and macOS signing to this model.