### PR TITLE
Update Git to signed Debian package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
        VFS for Git (which is less flexible). Only update that version if we rely upon a
        new command-line interface in Git or if there is a truly broken interaction.
     -->
-    <GitPackageVersion>2.20201020.1</GitPackageVersion>
+    <GitPackageVersion>2.20201109.1</GitPackageVersion>
     <MinimumGitVersion>v2.25.0.vfs.1.1</MinimumGitVersion>
 
     <WatchmanPackageUrl>https://github.com/facebook/watchman/releases/download/v2020.08.03.00/watchman-v2020.08.03.00-windows.zip</WatchmanPackageUrl>


### PR DESCRIPTION
Thanks to @kyle-rader and @mjcheetham, we have signed Linux builds for `microsoft/git`. This updates the package to [the signed version of the same Git code](https://dev.azure.com/gvfs/ci/_build/results?buildId=19227&view=results).