### PR TITLE
Update Git to include GCM Core update

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
        VFS for Git (which is less flexible). Only update that version if we rely upon a
        new command-line interface in Git or if there is a truly broken interaction.
     -->
-    <GitPackageVersion>2.20201109.1</GitPackageVersion>
+    <GitPackageVersion>2.20201209.2</GitPackageVersion>
     <MinimumGitVersion>v2.25.0.vfs.1.1</MinimumGitVersion>
 
     <WatchmanPackageUrl>https://github.com/facebook/watchman/releases/download/v2020.08.03.00/watchman-v2020.08.03.00-windows.zip</WatchmanPackageUrl>


### PR DESCRIPTION
This actually updates to a better build:

1. It has a new tag `v2.29.0.vfs.0.1`.
2. It was created after `git-for-windows/build-extra` updated with the new GCM Core package.