### PR TITLE
[HOTFIX] Update Git to include GCM Core update

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -43,17 +43,17 @@ jobs:
 
     - name: Setup platform (Linux)
       if: runner.os == 'Linux'
-      run: echo "::set-env name=BUILD_PLATFORM::${{ runner.os }}"
+      run: echo "BUILD_PLATFORM=${{ runner.os }}" >>$GITHUB_ENV
 
     - name: Setup platform (Mac)
       if: runner.os == 'macOS'
-      run: echo '::set-env name=BUILD_PLATFORM::Mac'
+      run: echo 'BUILD_PLATFORM=Mac' >>$GITHUB_ENV
 
     - name: Setup platform (Windows)
       if: runner.os == 'Windows'
       run: |
-        echo "::set-env name=BUILD_PLATFORM::${{ runner.os }}"
-        echo '::set-env name=BUILD_FILE_EXT::.exe'
+        echo "BUILD_PLATFORM=${{ runner.os }}" >>$env:GITHUB_ENV
+        echo 'BUILD_FILE_EXT=.exe' >>$env:GITHUB_ENV
 
     - name: Setup Git installer
       shell: bash

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -125,7 +125,7 @@ jobs:
         Copy-Item -Path 'watchman\watchman-*-windows\bin\*' -Destination 'C:\Program Files\Watchman'
         $ENV:PATH="$ENV:PATH;C:\Program Files\Watchman"
         & watchman --version
-        echo "::add-path::C:\Program Files\Watchman"
+        echo "PATH=$ENV:PATH" >>$env:GITHUB_ENV
 
     - name: Functional test
       shell: bash

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
        VFS for Git (which is less flexible). Only update that version if we rely upon a
        new command-line interface in Git or if there is a truly broken interaction.
     -->
-    <GitPackageVersion>2.20201020.1</GitPackageVersion>
+    <GitPackageVersion>2.20201209.2</GitPackageVersion>
     <MinimumGitVersion>v2.25.0.vfs.1.1</MinimumGitVersion>
 
     <WatchmanPackageUrl>https://github.com/facebook/watchman/releases/download/v2020.08.03.00/watchman-v2020.08.03.00-windows.zip</WatchmanPackageUrl>


### PR DESCRIPTION
This updates on top of the 20.10.178 release.

Requires build updates from #466.

This actually updates to a better build:

1. It has a new tag `v2.29.0.vfs.0.1`.
2. It was created after `git-for-windows/build-extra` updated with the new GCM Core package.