### PR TITLE
Maintenance: use the correct object directory

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
        VFS for Git (which is less flexible). Only update that version if we rely upon a
        new command-line interface in Git or if there is a truly broken interaction.
     -->
-    <GitPackageVersion>2.20201209.2</GitPackageVersion>
+    <GitPackageVersion>2.20201215.2</GitPackageVersion>
     <MinimumGitVersion>v2.25.0.vfs.1.1</MinimumGitVersion>
 
     <WatchmanPackageUrl>https://github.com/facebook/watchman/releases/download/v2020.08.03.00/watchman-v2020.08.03.00-windows.zip</WatchmanPackageUrl>

--- a/Scalar.FunctionalTests/Categories.cs
+++ b/Scalar.FunctionalTests/Categories.cs
@@ -3,6 +3,7 @@ namespace Scalar.FunctionalTests
     public static class Categories
     {
         public const string GitCommands = "GitCommands";
+        public const string Maintenance = "Maintenance";
 
         public const string WindowsOnly = "WindowsOnly";
         public const string POSIXOnly = "POSIXOnly";

--- a/Scalar.FunctionalTests/Program.cs
+++ b/Scalar.FunctionalTests/Program.cs
@@ -54,6 +54,14 @@ namespace Scalar.FunctionalTests
                         new object[] { Settings.ValidateWorkingTreeMode.SparseMode },
                 };
 
+            // Run maintenance tests in both `scalar run` and `git maintenance run` modes
+            ScalarTestConfig.MaintenanceMode =
+                new object[]
+                {
+                    new object[] { Settings.MaintenanceMode.Scalar },
+                    new object[] { Settings.MaintenanceMode.Git },
+                };
+
             if (runner.HasCustomArg("--full-suite"))
             {
                 Console.WriteLine("Running the full suite of tests");

--- a/Scalar.FunctionalTests/ScalarTestConfig.cs
+++ b/Scalar.FunctionalTests/ScalarTestConfig.cs
@@ -54,6 +54,8 @@ namespace Scalar.FunctionalTests
 
         public static object[] GitRepoTestsValidateWorkTree { get; set; }
 
+        public static object[] MaintenanceMode { get; set; }
+
         public static bool TestGitOnPath { get; set; }
 
         public static string PathToGit

--- a/Scalar.FunctionalTests/Settings.cs
+++ b/Scalar.FunctionalTests/Settings.cs
@@ -13,6 +13,12 @@ namespace Scalar.FunctionalTests.Properties
             SparseMode = 2,
         }
 
+        public enum MaintenanceMode
+        {
+            Scalar = 0,
+            Git = 1,
+        }
+
         public static class Default
         {
             public static string CurrentDirectory { get; private set; }

--- a/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/CommitGraphStepTests.cs
+++ b/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/CommitGraphStepTests.cs
@@ -33,7 +33,7 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
         {
             RepositoryHelpers.DeleteTestDirectory(this.CommitGraphsRoot);
 
-            this.Enlistment.RunVerb("commit-graph");
+            this.RunCommitGraphTask();
 
             this.fileSystem
                 .FileExists(this.CommitGraphsChain)
@@ -62,10 +62,23 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
 
             this.fileSystem.CreateEmptyFile(graphLockPath);
 
-            this.Enlistment.RunVerb("commit-graph");
+            this.RunCommitGraphTask();
 
-            this.fileSystem.FileExists(graphLockPath).ShouldBeFalse(nameof(graphLockPath));
+            this.fileSystem.FileExists(graphLockPath)
+                           .ShouldEqual(this.maintenanceMode == Settings.MaintenanceMode.Git, nameof(graphLockPath));
             this.fileSystem.FileExists(this.CommitGraphsChain).ShouldBeTrue(nameof(this.CommitGraphsChain));
+        }
+
+        private void RunCommitGraphTask()
+        {
+            if (this.maintenanceMode == Settings.MaintenanceMode.Scalar)
+            {
+                this.Enlistment.RunVerb("commit-graph");
+            }
+            else if (this.maintenanceMode == Settings.MaintenanceMode.Git)
+            {
+                this.Enlistment.RunMaintenanceTask("commit-graph");
+            }
         }
     }
 }

--- a/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/CommitGraphStepTests.cs
+++ b/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/CommitGraphStepTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using Scalar.FunctionalTests.FileSystemRunners;
+using Scalar.FunctionalTests.Properties;
 using Scalar.FunctionalTests.Tools;
 using Scalar.Tests.Should;
 using System;
@@ -7,17 +8,20 @@ using System.IO;
 
 namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
 {
-    [TestFixture]
+    [TestFixtureSource(typeof(TestsWithEnlistmentPerFixture), nameof(TestsWithEnlistmentPerFixture.MaintenanceMode))]
+    [Category(Categories.Maintenance)]
     public class CommitGraphStepTests : TestsWithEnlistmentPerFixture
     {
         private FileSystemRunner fileSystem;
+        private Settings.MaintenanceMode maintenanceMode;
 
         // Set forcePerRepoObjectCache to true to avoid any of the tests inadvertently corrupting
         // the cache
-        public CommitGraphStepTests()
+        public CommitGraphStepTests(Settings.MaintenanceMode maintenanceMode)
             : base(forcePerRepoObjectCache: true, fullClone: false)
         {
             this.fileSystem = new SystemIORunner();
+            this.maintenanceMode = maintenanceMode;
         }
 
         private string GitObjectRoot => ScalarHelpers.GetObjectsRootFromGitConfig(this.Enlistment.RepoRoot);

--- a/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/FetchStepTests.cs
+++ b/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/FetchStepTests.cs
@@ -1,31 +1,34 @@
 using NUnit.Framework;
 using Scalar.FunctionalTests.FileSystemRunners;
+using Scalar.FunctionalTests.Properties;
 using Scalar.FunctionalTests.Should;
 using Scalar.FunctionalTests.Tools;
 using Scalar.Tests.Should;
-using System;
 using System.IO;
 using System.Linq;
 
 namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
 {
-    [TestFixture]
+    [TestFixtureSource(typeof(TestsWithEnlistmentPerFixture), nameof(TestsWithEnlistmentPerFixture.MaintenanceMode))]
+    [Category(Categories.Maintenance)]
     [NonParallelizable]
     public class FetchStepTests : TestsWithEnlistmentPerFixture
     {
         private const string FetchCommitsAndTreesLock = "fetch-commits-trees.lock";
 
         private FileSystemRunner fileSystem;
+        private Settings.MaintenanceMode maintenanceMode;
 
-        public FetchStepTests()
+        public FetchStepTests(Settings.MaintenanceMode maintenanceMode)
         {
             this.fileSystem = new SystemIORunner();
+            this.maintenanceMode = maintenanceMode;
         }
 
         [TestCase]
         public void FetchStepReleasesFetchLockFile()
         {
-            this.Enlistment.RunVerb("fetch");
+            this.RunFetchTask();
             string fetchCommitsLockFile = Path.Combine(
                 ScalarHelpers.GetObjectsRootFromGitConfig(this.Enlistment.RepoRoot),
                 "pack",
@@ -40,7 +43,7 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
                 .Count()
                 .ShouldEqual(1, "Incorrect number of .keep files in pack directory");
 
-            this.Enlistment.RunVerb("fetch");
+            this.RunFetchTask();
 
             // Using FileShare.None ensures we test on both Windows, where WindowsFileBasedLock uses
             // FileShare.Read to open the lock file, and on Mac/Linux, where the .NET Core libraries
@@ -49,6 +52,18 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
             // have failed to release its lock.
             FileStream stream = new FileStream(fetchCommitsLockFile, FileMode.OpenOrCreate, FileAccess.Read, FileShare.None);
             stream.Dispose();
+        }
+
+        private void RunFetchTask()
+        {
+            if (this.maintenanceMode == Settings.MaintenanceMode.Scalar)
+            {
+                this.Enlistment.RunVerb("fetch");
+            }
+            else if (this.maintenanceMode == Settings.MaintenanceMode.Git)
+            {
+                this.Enlistment.RunMaintenanceTask("prefetch");
+            }
         }
     }
 }

--- a/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/LooseObjectStepTests.cs
+++ b/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/LooseObjectStepTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using Scalar.FunctionalTests.FileSystemRunners;
+using Scalar.FunctionalTests.Properties;
 using Scalar.FunctionalTests.Tools;
 using Scalar.Tests.Should;
 using System.Collections.Generic;
@@ -9,18 +10,21 @@ using System.Text.RegularExpressions;
 
 namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
 {
-    [TestFixture]
+    [TestFixtureSource(typeof(TestsWithEnlistmentPerFixture), nameof(TestsWithEnlistmentPerFixture.MaintenanceMode))]
+    [Category(Categories.Maintenance)]
     public class LooseObjectStepTests : TestsWithEnlistmentPerFixture
     {
         private const string TempPackFolder = "tempPacks";
         private FileSystemRunner fileSystem;
+        private Settings.MaintenanceMode maintenanceMode;
 
         // Set forcePerRepoObjectCache to true to avoid any of the tests inadvertently corrupting
         // the cache
-        public LooseObjectStepTests()
+        public LooseObjectStepTests(Settings.MaintenanceMode maintenanceMode)
             : base(forcePerRepoObjectCache: true, skipFetchCommitsAndTreesDuringClone: false, fullClone: false)
         {
             this.fileSystem = new SystemIORunner();
+            this.maintenanceMode = maintenanceMode;
         }
 
         private string GitObjectRoot => ScalarHelpers.GetObjectsRootFromGitConfig(this.Enlistment.RepoRoot);

--- a/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/PackfileMaintenanceStepTests.cs
+++ b/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/PackfileMaintenanceStepTests.cs
@@ -1,26 +1,29 @@
 using NUnit.Framework;
 using Scalar.FunctionalTests.FileSystemRunners;
+using Scalar.FunctionalTests.Properties;
 using Scalar.FunctionalTests.Tools;
 using Scalar.Tests.Should;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 
 namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
 {
-    [TestFixture]
+    [TestFixtureSource(typeof(TestsWithEnlistmentPerFixture), nameof(TestsWithEnlistmentPerFixture.MaintenanceMode))]
+    [Category(Categories.Maintenance)]
     public class PackfileMaintenanceStepTests : TestsWithEnlistmentPerFixture
     {
         private const long BatchSizeForNoRepack = 1024 * 1024 * 1024L;
         private FileSystemRunner fileSystem;
+        private Settings.MaintenanceMode maintenanceMode;
 
         // Set forcePerRepoObjectCache to true to avoid any of the tests inadvertently corrupting
         // the cache
-        public PackfileMaintenanceStepTests()
+        public PackfileMaintenanceStepTests(Settings.MaintenanceMode maintenanceMode)
             : base(forcePerRepoObjectCache: true)
         {
             this.fileSystem = new SystemIORunner();
+            this.maintenanceMode = maintenanceMode;
         }
 
         private string GitObjectRoot => ScalarHelpers.GetObjectsRootFromGitConfig(this.Enlistment.RepoRoot);

--- a/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/TestsWithEnlistmentPerFixture.cs
+++ b/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/TestsWithEnlistmentPerFixture.cs
@@ -17,6 +17,14 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
             this.fullClone = fullClone;
         }
 
+        public static object[] MaintenanceMode
+        {
+            get
+            {
+                return ScalarTestConfig.MaintenanceMode;
+            }
+        }
+
         public ScalarFunctionalTestEnlistment Enlistment
         {
             get; private set;

--- a/Scalar.FunctionalTests/Tools/ScalarFunctionalTestEnlistment.cs
+++ b/Scalar.FunctionalTests/Tools/ScalarFunctionalTestEnlistment.cs
@@ -193,6 +193,11 @@ namespace Scalar.FunctionalTests.Tools
             return this.scalarProcess.RunVerb(task, batchSize, failOnError, asService);
         }
 
+        public string RunMaintenanceTask(string task, string config = null)
+        {
+            return GitProcess.Invoke(this.RepoRoot, $"{config}maintenance run --task={task}");
+        }
+
         public void Unregister()
         {
             this.scalarProcess.Unregister(this.EnlistmentRoot);


### PR DESCRIPTION
In #458, we dropped the `Scalar.Service` application from the macOS platform and depended entirely on `git maintenance start` to initialize background maintenance. This had two issues:

1. The `cron`-based background maintenance does not sufficiently create a user environment for GCM Core to store credentials. This causes it to start loading pop-ups on the hour every hour for the `prefetch` task. This item is handled upstream as `ds/maintenance-part-4`, which creates platform-specific maintenance abilities, including macOS integration with `launchd`/`launchctl`.
2. The maintenance jobs don't look at the shared object cache! While we were depending on `git maintenance run --task=<task>` inside `scalar run <job>`, I forgot that `scalar run` sets `GIT_OBJECT_DIRECTORY` so something inside of `git maintenance run` needs to do the same. This is being answered by microsoft/git#301.

As for Scalar, the only thing we need to do is consume this new version of Git and test that `git maintenance run` does the same thing as `scalar run`. Hold it to the same standards.

Review commit-by-commit to avoid being overwhelmed with scaffolding for the multi-mode test classes.