### PR TITLE
Remove Apple certificate install step from build YAML

### DIFF
--- a/.azure-pipelines/templates/osx/build-and-unit-test.yml
+++ b/.azure-pipelines/templates/osx/build-and-unit-test.yml
@@ -9,12 +9,6 @@ steps:
     displayName: Delete previous build outputs
     continueOnError: true
 
-  - task: InstallAppleCertificate@2
-    displayName: 'Install Apple certificate'
-    inputs:	
-      certSecureFile: '$(Apple.Certificate.FileName)'
-      certPwd: '$(Apple.Certificate.Password)'
-
   - script: Scripts/Mac/BuildScalarForMac.sh $(configuration) $(majorAndMinorVersion).$(revision)
     displayName: Build Scalar ($(configuration))
 


### PR DESCRIPTION
Remove the Apple developer certificate installation step from the CI build Azure Pipelines YAML, as it is no longer required. We no longer have any Xcode projects that would use it.