### PR TITLE
Enable Trace2 logging of functional tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -43,17 +43,22 @@ jobs:
 
     - name: Setup platform (Linux)
       if: runner.os == 'Linux'
-      run: echo "BUILD_PLATFORM=${{ runner.os }}" >>$GITHUB_ENV
+      run: |
+        echo "BUILD_PLATFORM=${{ runner.os }}" >>$GITHUB_ENV
+        echo "TRACE2_BASENAME=Trace2.${{ github.run_id }}__${{ github.run_number }}__${{ matrix.os }}__${{ matrix.watchman }}" >>$GITHUB_ENV
 
     - name: Setup platform (Mac)
       if: runner.os == 'macOS'
-      run: echo 'BUILD_PLATFORM=Mac' >>$GITHUB_ENV
+      run: |
+        echo 'BUILD_PLATFORM=Mac' >>$GITHUB_ENV
+        echo "TRACE2_BASENAME=Trace2.${{ github.run_id }}__${{ github.run_number }}__${{ matrix.os }}__${{ matrix.watchman }}" >>$GITHUB_ENV
 
     - name: Setup platform (Windows)
       if: runner.os == 'Windows'
       run: |
         echo "BUILD_PLATFORM=${{ runner.os }}" >>$env:GITHUB_ENV
         echo 'BUILD_FILE_EXT=.exe' >>$env:GITHUB_ENV
+        echo "TRACE2_BASENAME=Trace2.${{ github.run_id }}__${{ github.run_number }}__${{ matrix.os }}__${{ matrix.watchman }}" >>$env:GITHUB_ENV
 
     - name: Setup Git installer
       shell: bash
@@ -127,9 +132,37 @@ jobs:
         & watchman --version
         echo "PATH=$ENV:PATH" >>$env:GITHUB_ENV
 
-    - name: Functional test
+    - id: functional_test
+      name: Functional test
       shell: bash
       run: |
+        export GIT_TRACE2_EVENT="$PWD/$TRACE2_BASENAME/Event"
+        export GIT_TRACE2_PERF="$PWD/$TRACE2_BASENAME/Perf"
+        export GIT_TRACE2_EVENT_BRIEF=true
+        export GIT_TRACE2_PERF_BRIEF=true
+        mkdir -p "$TRACE2_BASENAME"
+        mkdir -p "$TRACE2_BASENAME/Event"
+        mkdir -p "$TRACE2_BASENAME/Perf"
+        git version --build-options
         cd ../out
         PATH="$PWD/Scalar/$BUILD_FRAGMENT:$PWD/Scalar.Service/$BUILD_FRAGMENT:$PATH"
         Scalar.FunctionalTests/$BUILD_FRAGMENT/Scalar.FunctionalTests$BUILD_FILE_EXT --test-scalar-on-path --full-suite
+
+    - id: trace2_zip_unix
+      if: runner.os != 'Windows' && ( success() || failure() ) && ( steps.functional_test.conclusion == 'success' || steps.functional_test.conclusion == 'failure' )
+      name: Zip Trace2 Logs (Unix)
+      shell: bash
+      run: zip -q -r $TRACE2_BASENAME.zip $TRACE2_BASENAME/
+
+    - id: trace2_zip_windows
+      if: runner.os == 'Windows' && ( success() || failure() ) && ( steps.functional_test.conclusion == 'success' || steps.functional_test.conclusion == 'failure' )
+      name: Zip Trace2 Logs (Windows)
+      run: Compress-Archive -DestinationPath ${{ env.TRACE2_BASENAME }}.zip -Path ${{ env.TRACE2_BASENAME }}
+
+    - name: Archive Trace2 Logs
+      if: ( success() || failure() ) && ( steps.trace2_zip_unix.conclusion == 'success' || steps.trace2_zip_windows.conclusion == 'success' )
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ env.TRACE2_BASENAME }}.zip
+        path: ${{ env.TRACE2_BASENAME }}.zip
+        retention-days: 3

--- a/Scalar.Common/Git/GitProcess.cs
+++ b/Scalar.Common/Git/GitProcess.cs
@@ -703,6 +703,25 @@ namespace Scalar.Common.Git
             // List of environment variables: https://git-scm.com/book/gr/v2/Git-Internals-Environment-Variables
             foreach (string key in processInfo.EnvironmentVariables.Keys.Cast<string>().ToList())
             {
+                if (key.StartsWith("GIT_TRACE2", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Allow Trace2 values to pass thru as is.  Technically, a Trace2 target
+                    // (such as GIT_TRACE2_EVENT, GIT_TRACE2_PERF, or GIT_TRACE2) can be set
+                    // to stderr just like traditional tracing, but these targets can be enabled
+                    // via global or system config settings, so this filtering is not sufficient.
+                    //
+                    // Simply checking for an absolute pathname is not sufficient because Trace2
+                    // allows targets to be set to integer, booleans and Unix domain socket values.
+                    // Only values "1", "2", and "true" (for target keys) cause output to go to
+                    // stderr.
+                    //
+                    // Additionally, there are other non-target Trace2 values that are useful to
+                    // preserve, such as GIT_TRACE2_PERF_BRIEF and GIT_TRACE2_CONFIG_PARAMS.
+                    //
+                    // TODO For now, just let them thru as is.
+                    continue;
+                }
+
                 // If GIT_TRACE is set to a fully-rooted path, then Git sends the trace
                 // output to that path instead of stdout (GIT_TRACE=1) or stderr (GIT_TRACE=2).
                 if (key.StartsWith("GIT_TRACE", StringComparison.OrdinalIgnoreCase))

--- a/Scalar.Installer.Mac/InstallScalar.template.sh
+++ b/Scalar.Installer.Mac/InstallScalar.template.sh
@@ -109,10 +109,18 @@ if [ $INSTALL_WATCHMAN -eq 1 ]; then
     echo "=============================="
     echo "Installing watchman as: $CURRENT_USER"
 
+    # Remove any 2to3 binary or symlink that would prevent watchman's python3
+    # dependency from being linked correctly.
+    if [ -e /usr/local/bin/2to3 ]; then
+        sudo rm /usr/local/bin/2to3
+    fi
+
     sudo chown -R $CURRENT_USER /usr/local/Cellar
+    sudo chown -R $CURRENT_USER /usr/local/Homebrew
+    sudo chown -R $CURRENT_USER /usr/local/var/homebrew
     sudo -u $CURRENT_USER brew update
     sudo -u $CURRENT_USER brew unlink python@2 || echo "Python 2 was not installed"
-    sudo -u $CURRENT_USER brew install watchman
+    sudo -u $CURRENT_USER brew install --force watchman
 else
     echo ""
     echo "=============================="


### PR DESCRIPTION
Enable Trace2 logging in Git for the functional test suite.
Then zip up the logs and store in as a single artifact.

