### PR TITLE
Enable experimental features through `features.scalar=experimental`

### DIFF
--- a/Scalar.Common/Git/GitFeatureFlags.cs
+++ b/Scalar.Common/Git/GitFeatureFlags.cs
@@ -22,5 +22,10 @@ namespace Scalar.Common.Git
         /// * Subcommands: run, register, unregister, start, stop
         /// </summary>
         MaintenanceBuiltin = 1 << 1,
+
+        /// <summary>
+        /// Supports the builtin FS Monitor
+        /// </summary>
+        BuiltinFSMonitor = 1 << 2,
     }
 }

--- a/Scalar.Common/Git/GitProcess.cs
+++ b/Scalar.Common/Git/GitProcess.cs
@@ -148,8 +148,33 @@ namespace Scalar.Common.Git
                 return false;
             }
 
+            gitVersion.Features.UnionWith(GetAdvertisedFeatures(gitBinPath));
+
             error = null;
             return true;
+        }
+
+        public static IEnumerable<string> GetAdvertisedFeatures(string gitBinPath)
+        {
+            GitProcess gitProcess = new GitProcess(gitBinPath, null);
+            Result result = gitProcess.InvokeGitOutsideEnlistment("version --build-options");
+            string version = result.Output;
+
+            if (result.ExitCodeIsFailure)
+            {
+                yield break;
+            }
+
+            foreach (string line in result.Output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+            {
+                string prefix = "feature: ";
+                string trimmed = line.Trim();
+
+                if (trimmed.StartsWith(prefix))
+                {
+                    yield return line.Substring(prefix.Length);
+                }
+            }
         }
 
         /// <summary>

--- a/Scalar.Common/Git/GitProcess.cs
+++ b/Scalar.Common/Git/GitProcess.cs
@@ -164,10 +164,9 @@ namespace Scalar.Common.Git
             {
                 yield break;
             }
-
+            const string prefix = "feature: ";
             foreach (string line in result.Output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
             {
-                string prefix = "feature: ";
                 string trimmed = line.Trim();
 
                 if (trimmed.StartsWith(prefix))

--- a/Scalar.Common/Git/GitVersion.cs
+++ b/Scalar.Common/Git/GitVersion.cs
@@ -171,6 +171,25 @@ namespace Scalar.Common.Git
             return true;
         }
 
+        public static GitFeatureFlags GetAvailableGitFeatures(ITracer tracer)
+        {
+            // Determine what features of Git we have available to guide how we init/clone the repository
+            var gitFeatures = GitFeatureFlags.None;
+            string gitBinPath = ScalarPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
+            tracer?.RelatedInfo("Attempting to determine Git version for installation '{0}'", gitBinPath);
+            if (GitProcess.TryGetVersion(gitBinPath, out var gitVersion, out string gitVersionError))
+            {
+                tracer?.RelatedInfo("Git installation '{0}' has version '{1}", gitBinPath, gitVersion);
+                gitFeatures = gitVersion.GetFeatures();
+            }
+            else
+            {
+                tracer?.RelatedWarning("Unable to detect Git features for installation '{0}'. Failed to get Git version: '{1}", gitBinPath, gitVersionError);
+            }
+
+            return gitFeatures;
+        }
+
         public bool IsEqualTo(GitVersion other)
         {
             if (this.Platform != other.Platform)

--- a/Scalar.Common/Git/GitVersion.cs
+++ b/Scalar.Common/Git/GitVersion.cs
@@ -5,7 +5,7 @@ namespace Scalar.Common.Git
 {
     public class GitVersion
     {
-        public GitVersion(int major, int minor, int build, string platform = null, int revision = 0, int minorRevision = 0, int? rc = null)
+        public GitVersion(int major, int minor, int build, string platform = null, int revision = 0, int minorRevision = 0, int? rc = null, string extra = null)
         {
             this.Major = major;
             this.Minor = minor;
@@ -14,6 +14,7 @@ namespace Scalar.Common.Git
             this.Platform = platform;
             this.Revision = revision;
             this.MinorRevision = minorRevision;
+            this.Extra = extra;
         }
 
         public int Major { get; private set; }
@@ -23,6 +24,7 @@ namespace Scalar.Common.Git
         public string Platform { get; private set; }
         public int Revision { get; private set; }
         public int MinorRevision { get; private set; }
+        public string Extra { get; private set; }
 
         /// <summary>
         /// Determine the set of Git features that are supported in this version of Git.
@@ -41,6 +43,11 @@ namespace Scalar.Common.Git
                 this.Minor > 28 || (this.Minor == 28 && this.Revision > 0))
             {
                 flags |= GitFeatureFlags.MaintenanceBuiltin;
+            }
+
+            if (this.Extra != null && this.Extra.Equals("exp"))
+            {
+                flags |= GitFeatureFlags.BuiltinFSMonitor;
             }
 
             return flags;
@@ -88,6 +95,7 @@ namespace Scalar.Common.Git
             int major, minor, build, revision = 0, minorRevision = 0;
             int? rc = null;
             string platform = null;
+            string extra = null;
 
             if (string.IsNullOrWhiteSpace(input))
             {
@@ -155,7 +163,11 @@ namespace Scalar.Common.Git
                 minorRevision = 0;
             }
 
-            version = new GitVersion(major, minor, build, platform, revision, minorRevision, rc);
+            if (numComponents > 6) {
+                extra = parsedComponents[6];
+            }
+
+            version = new GitVersion(major, minor, build, platform, revision, minorRevision, rc, extra);
             return true;
         }
 

--- a/Scalar.Common/Git/GitVersion.cs
+++ b/Scalar.Common/Git/GitVersion.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using Scalar.Common.Tracing;
 
 namespace Scalar.Common.Git
 {
@@ -164,7 +165,7 @@ namespace Scalar.Common.Git
             }
 
             if (numComponents > 6) {
-                extra = parsedComponents[6];
+                extra = parsedComponents[6].Trim();
             }
 
             version = new GitVersion(major, minor, build, platform, revision, minorRevision, rc, extra);
@@ -219,6 +220,10 @@ namespace Scalar.Common.Git
             if (!string.IsNullOrWhiteSpace(this.Platform))
             {
                 sb.AppendFormat(".{0}.{1}.{2}", this.Platform, this.Revision, this.MinorRevision);
+            }
+
+            if (this.Extra != null) {
+                sb.Append($".{this.Extra}");
             }
 
             return sb.ToString();

--- a/Scalar.Common/Git/GitVersion.cs
+++ b/Scalar.Common/Git/GitVersion.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text;
 using Scalar.Common.Tracing;
 
@@ -16,6 +17,7 @@ namespace Scalar.Common.Git
             this.Revision = revision;
             this.MinorRevision = minorRevision;
             this.Extra = extra;
+            this.Features = new HashSet<string>();
         }
 
         public int Major { get; private set; }
@@ -26,6 +28,7 @@ namespace Scalar.Common.Git
         public int Revision { get; private set; }
         public int MinorRevision { get; private set; }
         public string Extra { get; private set; }
+        public HashSet<string> Features { get; private set; }
 
         /// <summary>
         /// Determine the set of Git features that are supported in this version of Git.
@@ -46,7 +49,7 @@ namespace Scalar.Common.Git
                 flags |= GitFeatureFlags.MaintenanceBuiltin;
             }
 
-            if (this.Extra != null && this.Extra.Equals("exp"))
+            if (this.Features.Contains("fsmonitor--daemon"))
             {
                 flags |= GitFeatureFlags.BuiltinFSMonitor;
             }
@@ -224,6 +227,16 @@ namespace Scalar.Common.Git
 
             if (this.Extra != null) {
                 sb.Append($".{this.Extra}");
+            }
+
+            if (this.Features.Count > 0)
+            {
+                sb.Append(" (");
+                foreach (string feature in this.Features)
+                {
+                    sb.Append($" {feature} ");
+                }
+                sb.Append(")");
             }
 
             return sb.ToString();

--- a/Scalar.Common/Maintenance/ConfigStep.cs
+++ b/Scalar.Common/Maintenance/ConfigStep.cs
@@ -227,7 +227,7 @@ namespace Scalar.Common.Maintenance
             GitFeatureFlags flags = GitVersion.GetAvailableGitFeatures(this.Context.Tracer);
             config.TryParseAsString(out string scalar, out error, defaultValue: "true");
 
-            if (scalar.Equals("false"))
+            if (StringComparer.OrdinalIgnoreCase.Equals(scalar, "false"))
             {
                 GitProcess.Result deleteResult = this.RunGitCommand(
                     process => process.DeleteFromLocalConfig("core.fsmonitor"),
@@ -236,7 +236,7 @@ namespace Scalar.Common.Maintenance
 
                 return deleteResult.ExitCodeIsSuccess;
             }
-            else if (scalar.Equals("experimental")
+            else if (StringComparer.OrdinalIgnoreCase.Equals(scalar, "experimental")
                      // Make sure Git supports builtin FS Monitor
                      && flags.HasFlag(GitFeatureFlags.BuiltinFSMonitor)
                      // For now, this doesn't work on Linux

--- a/Scalar.Common/Maintenance/ConfigStep.cs
+++ b/Scalar.Common/Maintenance/ConfigStep.cs
@@ -209,7 +209,52 @@ namespace Scalar.Common.Maintenance
                 return false;
             }
 
-            return this.ConfigureWatchmanIntegration(out error);
+            this.GetConfigSettings();
+
+            if (this.existingConfigSettings == null)
+            {
+                return this.ConfigureWatchmanIntegration(out error);
+            }
+
+            GitProcess.ConfigResult config = null;
+            GitProcess.Result getResult = this.RunGitCommand(
+                process => {
+                    config = process.GetFromLocalConfig("feature.scalar");
+                    return null;
+                },
+                nameof(GitProcess.GetFromLocalConfig)
+            );
+            GitFeatureFlags flags = GitVersion.GetAvailableGitFeatures(this.Context.Tracer);
+            config.TryParseAsString(out string scalar, out error, defaultValue: "true");
+
+            if (scalar.Equals("false"))
+            {
+                GitProcess.Result deleteResult = this.RunGitCommand(
+                    process => process.DeleteFromLocalConfig("core.fsmonitor"),
+                    nameof(GitProcess.DeleteFromLocalConfig)
+                );
+
+                return deleteResult.ExitCodeIsSuccess;
+            }
+            else if (scalar.Equals("experimental")
+                     // Make sure Git supports builtin FS Monitor
+                     && flags.HasFlag(GitFeatureFlags.BuiltinFSMonitor)
+                     // For now, this doesn't work on Linux
+                     && !RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                // ":internal:" is a custom value to specify the builtin
+                // FS Monitor feature.
+                GitProcess.Result setResult = this.RunGitCommand(
+                    process => process.SetInLocalConfig("core.fsmonitor", ":internal:"),
+                    nameof(GitProcess.SetInLocalConfig)
+                );
+
+                return setResult.ExitCodeIsSuccess;
+            }
+            else
+            {
+                return this.ConfigureWatchmanIntegration(out error);
+            }
         }
 
         protected override void PerformMaintenance()

--- a/Scalar.Common/Maintenance/ConfigStep.cs
+++ b/Scalar.Common/Maintenance/ConfigStep.cs
@@ -209,13 +209,6 @@ namespace Scalar.Common.Maintenance
                 return false;
             }
 
-            this.GetConfigSettings();
-
-            if (this.existingConfigSettings == null)
-            {
-                return this.ConfigureWatchmanIntegration(out error);
-            }
-
             GitProcess.ConfigResult config = null;
             GitProcess.Result getResult = this.RunGitCommand(
                 process => {
@@ -272,12 +265,6 @@ namespace Scalar.Common.Maintenance
             GitProcess.Result getConfigResult = this.RunGitCommand(
                 process => process.TryGetAllConfig(localOnly: true, configSettings: out this.existingConfigSettings),
                 nameof(GitProcess.TryGetAllConfig));
-
-            if (getConfigResult.ExitCodeIsFailure)
-            {
-                this.existingConfigSettings = null;
-                return null;
-            }
 
             return this.existingConfigSettings;
         }

--- a/Scalar.Common/Maintenance/ConfigStep.cs
+++ b/Scalar.Common/Maintenance/ConfigStep.cs
@@ -231,9 +231,7 @@ namespace Scalar.Common.Maintenance
             }
             else if (StringComparer.OrdinalIgnoreCase.Equals(scalar, "experimental")
                      // Make sure Git supports builtin FS Monitor
-                     && flags.HasFlag(GitFeatureFlags.BuiltinFSMonitor)
-                     // For now, this doesn't work on Linux
-                     && !RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                     && flags.HasFlag(GitFeatureFlags.BuiltinFSMonitor))
             {
                 // ":internal:" is a custom value to specify the builtin
                 // FS Monitor feature.

--- a/Scalar.FunctionalTests/Tools/GitHelpers.cs
+++ b/Scalar.FunctionalTests/Tools/GitHelpers.cs
@@ -94,7 +94,8 @@ namespace Scalar.FunctionalTests.Tools
         {
             return data
                     .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-                    .Where(s => !string.IsNullOrWhiteSpace(s));
+                    .Where(s => !string.IsNullOrWhiteSpace(s))
+                    .Where(s => !s.Contains("gvfs-helper error: '(curl"));
         }
 
         private static bool LinesAreEqual(string actualLine, string expectedLine)

--- a/Scalar.UnitTests/Common/GitVersionTests.cs
+++ b/Scalar.UnitTests/Common/GitVersionTests.cs
@@ -68,6 +68,36 @@ namespace Scalar.UnitTests.Common
         }
 
         [TestCase]
+        public void GetFeatureFlags_BuiltinFSMonitor()
+        {
+            var notSupportedVerisons = new List<GitVersion>
+            {
+                new GitVersion(2, 30, 0),
+                new GitVersion(2, 29, 0, "windows"),
+                new GitVersion(2, 30, 0, "vfs", 0, 0),
+            };
+
+            foreach (GitVersion version in notSupportedVerisons)
+            {
+                GitFeatureFlags gitGitFeatures = version.GetFeatures();
+                gitGitFeatures.HasFlag(GitFeatureFlags.BuiltinFSMonitor).ShouldBeFalse($"Incorrect for version {version}");
+            }
+
+            var supportedVerisons = new List<GitVersion>
+            {
+                new GitVersion(2, 28, 0, "vfs", 1, 0, extra: "exp"),
+                new GitVersion(2, 29, 0, "vfs", 0, 0, extra: "exp"),
+                new GitVersion(2, 30, 0, "vfs", 0, 0, extra: "exp"),
+            };
+
+            foreach (GitVersion version in supportedVerisons)
+            {
+                GitFeatureFlags gitGitFeatures = version.GetFeatures();
+                gitGitFeatures.HasFlag(GitFeatureFlags.BuiltinFSMonitor).ShouldBeTrue($"Incorrect for version {version}");
+            }
+        }
+
+        [TestCase]
         public void TryParseInstallerName()
         {
             this.ParseAndValidateInstallerVersion("Git-1.2.3.scalar.4.5.gb16030b-64-bit" + ScalarPlatform.Instance.Constants.InstallerExtension);

--- a/Scalar.UnitTests/Common/GitVersionTests.cs
+++ b/Scalar.UnitTests/Common/GitVersionTests.cs
@@ -70,31 +70,17 @@ namespace Scalar.UnitTests.Common
         [TestCase]
         public void GetFeatureFlags_BuiltinFSMonitor()
         {
-            var notSupportedVerisons = new List<GitVersion>
-            {
-                new GitVersion(2, 30, 0),
-                new GitVersion(2, 29, 0, "windows"),
-                new GitVersion(2, 30, 0, "vfs", 0, 0),
-            };
+            GitVersion version = new GitVersion(2, 30, 0, "vfs", 0, 0);
+            GitFeatureFlags gitFeatures = version.GetFeatures();
+            gitFeatures.HasFlag(GitFeatureFlags.BuiltinFSMonitor).ShouldBeFalse($"Incorrect for version {version}");
 
-            foreach (GitVersion version in notSupportedVerisons)
-            {
-                GitFeatureFlags gitGitFeatures = version.GetFeatures();
-                gitGitFeatures.HasFlag(GitFeatureFlags.BuiltinFSMonitor).ShouldBeFalse($"Incorrect for version {version}");
-            }
+            version.Features.Add("bogus");
+            gitFeatures = version.GetFeatures();
+            gitFeatures.HasFlag(GitFeatureFlags.BuiltinFSMonitor).ShouldBeFalse($"Incorrect for version {version}");
 
-            var supportedVerisons = new List<GitVersion>
-            {
-                new GitVersion(2, 28, 0, "vfs", 1, 0, extra: "exp"),
-                new GitVersion(2, 29, 0, "vfs", 0, 0, extra: "exp"),
-                new GitVersion(2, 30, 0, "vfs", 0, 0, extra: "exp"),
-            };
-
-            foreach (GitVersion version in supportedVerisons)
-            {
-                GitFeatureFlags gitGitFeatures = version.GetFeatures();
-                gitGitFeatures.HasFlag(GitFeatureFlags.BuiltinFSMonitor).ShouldBeTrue($"Incorrect for version {version}");
-            }
+            version.Features.Add("fsmonitor--daemon");
+            gitFeatures = version.GetFeatures();
+            gitFeatures.HasFlag(GitFeatureFlags.BuiltinFSMonitor).ShouldBeTrue($"Incorrect for version {version}");
         }
 
         [TestCase]

--- a/Scalar/CommandLine/CloneVerb.cs
+++ b/Scalar/CommandLine/CloneVerb.cs
@@ -211,7 +211,7 @@ namespace Scalar.CommandLine
                 resolvedLocalCacheRoot = Path.GetFullPath(this.LocalCacheRoot);
             }
 
-            GitFeatureFlags gitFeatures = this.GetAvailableGitFeatures(this.tracer);
+            GitFeatureFlags gitFeatures = GitVersion.GetAvailableGitFeatures(this.tracer);
 
             // Do not try GVFS authentication on SSH URLs or when we don't have Git support for the GVFS protocol
             bool isHttpsRemote = this.enlistment.RepoUrl.StartsWith("https://", StringComparison.OrdinalIgnoreCase);

--- a/Scalar/CommandLine/RunVerb.cs
+++ b/Scalar/CommandLine/RunVerb.cs
@@ -113,7 +113,7 @@ namespace Scalar.CommandLine
                         GitObjectsHttpRequestor objectRequestor = null;
                         CacheServerInfo cacheServer;
                         GitObjects gitObjects;
-                        GitFeatureFlags gitFeatures = this.GetAvailableGitFeatures(tracer);
+                        GitFeatureFlags gitFeatures = GitVersion.GetAvailableGitFeatures(tracer);
 
                         switch (this.MaintenanceTask)
                         {

--- a/Scalar/CommandLine/ScalarVerb.cs
+++ b/Scalar/CommandLine/ScalarVerb.cs
@@ -492,26 +492,6 @@ You can specify a URL, a name of a configured cache server, or the special names
             }
         }
 
-        protected GitFeatureFlags GetAvailableGitFeatures(ITracer tracer)
-        {
-            // Determine what features of Git we have available to guide how we init/clone the repository
-            var gitFeatures = GitFeatureFlags.None;
-            string gitBinPath = ScalarPlatform.Instance.GitInstallation.GetInstalledGitBinPath();
-            tracer.RelatedInfo("Attempting to determine Git version for installation '{0}'", gitBinPath);
-            if (GitProcess.TryGetVersion(gitBinPath, out var gitVersion, out string gitVersionError))
-            {
-                tracer.RelatedInfo("Git installation '{0}' has version '{1}", gitBinPath, gitVersion);
-                gitFeatures = gitVersion.GetFeatures();
-            }
-            else
-            {
-                tracer.RelatedWarning("Unable to detect Git features for installation '{0}'. Failed to get Git version: '{1}", gitBinPath, gitVersionError);
-                this.Output.WriteLine("Warning: unable to detect Git features: {0}", gitVersionError);
-            }
-
-            return gitFeatures;
-        }
-
         private string GetAlternatesPath(ScalarEnlistment enlistment)
         {
             return Path.Combine(enlistment.WorkingDirectoryRoot, ScalarConstants.DotGit.Objects.Info.Alternates);


### PR DESCRIPTION
This expands the `GitVersion` parser to include an `Extra` string. This will contain anything after `2.X.Y.vfs.Z.W`. For instance, the tag `v2.30.0.vfs.0.0.exp` contains the builtin FS Monitor feature (see microsoft/git#289).

To enable experimental features, we check the new `feature.scalar` config setting. This has a few modes:

1. `feature.scalar=false` implies we want to disable optional features like FS Monitor.
2. `feature.scalar=true` or unset implies we want to use our default values, like using Watchman for FS Monitor.
3. `feature.scalar=experimental` means we should use available experimental features like FS Monitor. In the future, this could also include early versions of sparse-index.

After using `git config` to set the appropriate `feature.scalar` value locally, users can run `scalar run config` to re-initialize features according to this recommendation. These instructions will be part of the experimental release documentation when we are closer to making that available.

This is appropriate for full releases, as it will do nothing new if users don't have the experimental Git release as well.