### PR TITLE
CI: use more recent version of Watchman

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -115,7 +115,7 @@ jobs:
 
     - name: Install Watchman (Mac)
       if: runner.os == 'macOS' && matrix.watchman
-      run: brew install watchman
+      run: brew update && brew install watchman
 
     - name: Install Watchman (Windows)
       if: runner.os == 'Windows' && matrix.watchman

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,7 +46,7 @@
     <GitPackageVersion>2.20210114.2</GitPackageVersion>
     <MinimumGitVersion>v2.25.0.vfs.1.1</MinimumGitVersion>
 
-    <WatchmanPackageUrl>https://github.com/facebook/watchman/releases/download/v2020.08.03.00/watchman-v2020.08.03.00-windows.zip</WatchmanPackageUrl>
+    <WatchmanPackageUrl>https://github.com/facebook/watchman/releases/download/v2021.01.11.00/watchman-v2021.01.11.00-windows.zip</WatchmanPackageUrl>
     <GcmCoreOSXPackageUrl>https://github.com/microsoft/Git-Credential-Manager-Core/releases/download/v2.0.79-beta/gcmcore-osx-2.0.79.64449.pkg</GcmCoreOSXPackageUrl>
 
     <!-- Signing certificates -->


### PR DESCRIPTION
Our Watchman builds have been a bit flaky. Let's see if using a more-recent version helps.

Windows is more recent for sure. macOS might be newer with the extra `brew update` call.

Linux will require new build steps after cloning to a new tag. I haven't looked up those steps yet.