### PR TITLE
nuget.config: drop internal feed

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -68,7 +68,7 @@ jobs:
         dotnet new classlib -n Scalar.GitInstaller
         cd Scalar.GitInstaller
         cp ../../scalar/nuget.config .
-        dotnet add Scalar.GitInstaller.csproj package "GitFor${BUILD_PLATFORM}.GVFS.Installer" --package-directory . --version "$GIT_VERSION"
+        dotnet add Scalar.GitInstaller.csproj package "GitFor${BUILD_PLATFORM}.GVFS.Installer" --package-directory . --version "$GIT_VERSION" --source "https://pkgs.dev.azure.com/gvfs/ci/_packaging/Dependencies/nuget/v3/index.json"
 
     - name: Install Git (Linux)
       if: runner.os == 'Linux'

--- a/Dependencies.props
+++ b/Dependencies.props
@@ -8,9 +8,6 @@
     <PackageReference Update="Newtonsoft.Json"                 Version="12.0.2" />
     <PackageReference Update="NuGet.CommandLine"               Version="5.4.0"  />
     <PackageReference Update="NuGet.Commands"                  Version="5.4.0"  />
-    <PackageReference Update="GitForWindows.GVFS.Installer"    Version="$(GitPackageVersion)" />
-    <PackageReference Update="GitForMac.GVFS.Installer"        Version="$(GitPackageVersion)" />
-    <PackageReference Update="GitForLinux.GVFS.Installer"      Version="$(GitPackageVersion)" />
 
     <!-- Build-only dependencies -->
     <PackageReference Update="MicroBuild.Core"                 Version="0.2.0" PrivateAssets="all" />

--- a/Scalar.Common/Scalar.Common.csproj
+++ b/Scalar.Common/Scalar.Common.csproj
@@ -12,9 +12,6 @@
     <PackageReference Include="NuGet.Commands" />
     <PackageReference Include="Microsoft.PowerShell.SDK" />
     <PackageReference Include="Microsoft.Windows.Compatibility" />
-    <PackageReference Include="GitForWindows.GVFS.Installer" PrivateAssets="all" />
-    <PackageReference Include="GitForMac.GVFS.Installer" PrivateAssets="all" />
-    <PackageReference Include="GitForLinux.GVFS.Installer" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Scalar.Installer.Mac/Scalar.Installer.Mac.csproj
+++ b/Scalar.Installer.Mac/Scalar.Installer.Mac.csproj
@@ -16,10 +16,6 @@
     <ProjectReference Include="..\Scalar\Scalar.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="GitForMac.GVFS.Installer" />
-  </ItemGroup>
-
   <!-- Only create the installer when running on macOS -->
   <Target Name="BuildInstaller" AfterTargets="Publish" Condition="'$(OSPlatform)' == 'osx'" >
     <!-- Ensure all projects have been published with the correct runtime identifier and configuration -->

--- a/Scalar.Installer.Windows/Scalar.Installer.Windows.csproj
+++ b/Scalar.Installer.Windows/Scalar.Installer.Windows.csproj
@@ -20,7 +20,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitForWindows.GVFS.Installer" />
     <PackageReference Include="Tools.InnoSetup" />
   </ItemGroup>
 

--- a/nuget.config
+++ b/nuget.config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="Dependencies" value="https://pkgs.dev.azure.com/gvfs/ci/_packaging/Dependencies/nuget/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
We don't need this feed, and it is causing build problems during
release.