### PR TITLE
Adding git-client alias to troubleshooting docs

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -30,7 +30,7 @@ files for that repository. This includes:
   and the names and sizes of pack-files.
 
 As the `diagnose` command completes, it provides the path of the resulting
-zip file. This zip can be sent to the support team for investigation.
+zip file. This zip can be sent to [the support team](mailto:git-client@github.com) for investigation.
 
 Modifying Configuration Values
 ------------------------------


### PR DESCRIPTION
Discussed with @derrickstolee and agreed this change is beneficial pending @prplr's approval, as it will give users a destination to which to send `scalar diagnose` logs.