### PR TITLE
[HOTFIX] ConfigStep: commitGraph.generationVersion=1

### DIFF
--- a/Scalar.Common/Maintenance/ConfigStep.cs
+++ b/Scalar.Common/Maintenance/ConfigStep.cs
@@ -154,6 +154,7 @@ namespace Scalar.Common.Maintenance
             Dictionary<string, string> optionalSettings = new Dictionary<string, string>
             {
                 { "status.aheadbehind", "false" },
+                { "commitGraph.generationVersion", "1" },
                 { "core.autocrlf", "false" },
                 { "core.safecrlf", "false" },
                 { "core.repositoryFormatVersion", "1" },


### PR DESCRIPTION
The generation number v2 is better for algorithmic reasons, but it is
backwards-compatible with version 1 and in doing so requires reading
more data from disk. That extra data load causes a performance
degradation in the typical case.

Let's avoid that for now, until a non-backwards-compatible version is
ready that avoids this performance problem.

> This didn't quite make it in before the release branch was created.