### PR TITLE
Upgrade to microsoft/git 2.20210322.1 (v2.31.0.vfs.0.1)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
        VFS for Git (which is less flexible). Only update that version if we rely upon a
        new command-line interface in Git or if there is a truly broken interaction.
     -->
-    <GitPackageVersion>2.20210317.1</GitPackageVersion>
+    <GitPackageVersion>2.20210322.1</GitPackageVersion>
     <MinimumGitVersion>v2.25.0.vfs.1.1</MinimumGitVersion>
 
     <WatchmanPackageUrl>https://github.com/facebook/watchman/releases/download/v2020.08.03.00/watchman-v2020.08.03.00-windows.zip</WatchmanPackageUrl>


### PR DESCRIPTION
Upgrade releases/21.03.185 to consume v2.31.0.vfs.0.1 of microsoft/git (build 2.20210322.1)