### PR TITLE
GitVersion: enable maintenance flag for v2.31.0+

### DIFF
--- a/Scalar.Common/Git/GitVersion.cs
+++ b/Scalar.Common/Git/GitVersion.cs
@@ -43,8 +43,10 @@ namespace Scalar.Common.Git
                 flags |= GitFeatureFlags.GvfsProtocol;
             }
 
-            if ((flags & GitFeatureFlags.GvfsProtocol) != 0 &&
-                this.Minor > 28 || (this.Minor == 28 && this.Revision > 0))
+            // Background maintenance was generally available in v2.31.0.
+            if (this.Minor > 30 ||
+                ((flags & GitFeatureFlags.GvfsProtocol) != 0 &&
+                 this.Minor > 28 || (this.Minor == 28 && this.Revision > 0)))
             {
                 flags |= GitFeatureFlags.MaintenanceBuiltin;
             }

--- a/Scalar.UnitTests/Common/GitVersionTests.cs
+++ b/Scalar.UnitTests/Common/GitVersionTests.cs
@@ -42,6 +42,7 @@ namespace Scalar.UnitTests.Common
                 new GitVersion(2, 28, 0, "windows"),
                 new GitVersion(2, 28, 1, "windows"),
                 new GitVersion(2, 29, 0, "windows"),
+                new GitVersion(2, 30, 0),
                 new GitVersion(2, 27, 0, "vfs", 1, 1),
                 new GitVersion(2, 28, 0, "vfs", 0, 0),
                 new GitVersion(2, 28, 0, "vfs", 0, 1),
@@ -58,6 +59,8 @@ namespace Scalar.UnitTests.Common
                 new GitVersion(2, 28, 0, "vfs", 1, 0),
                 new GitVersion(2, 29, 0, "vfs", 0, 0),
                 new GitVersion(2, 30, 0, "vfs", 0, 0),
+                new GitVersion(2, 31, 0),
+                new GitVersion(2, 31, 1),
             };
 
             foreach (GitVersion version in supportedVerisons)


### PR DESCRIPTION
Resolves #501.

The feature flag was originally introduced in cd0e476870c204c5e1452493bccf83c29c3a2562 (#398) but at that time we didn't know if the core Git client was ready, so we didn't enable it for versions of Git that did not include the `.vfs.` platform.

Fix this since background maintenance is now available on all platforms on v2.31.0 and later.