### PR TITLE
Sparse index experimental Git version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
        VFS for Git (which is less flexible). Only update that version if we rely upon a
        new command-line interface in Git or if there is a truly broken interaction.
     -->
-    <GitPackageVersion>2.20210505.2</GitPackageVersion>
+    <GitPackageVersion>2.20210603.9-pr</GitPackageVersion>
     <MinimumGitVersion>v2.25.0.vfs.1.1</MinimumGitVersion>
 
     <WatchmanPackageUrl>https://github.com/facebook/watchman/releases/download/v2020.08.03.00/watchman-v2020.08.03.00-windows.zip</WatchmanPackageUrl>

--- a/Scalar.Common/Maintenance/ConfigStep.cs
+++ b/Scalar.Common/Maintenance/ConfigStep.cs
@@ -113,6 +113,7 @@ namespace Scalar.Common.Maintenance
                 { "credential.validate", "false" },
                 { "gc.auto", "0" },
                 { "gui.gcwarning", "false" },
+                { "index.sparse", "true" },
                 { "index.threads", "true" },
                 { "index.version", "4" },
                 { "merge.stat", "false" },

--- a/Scalar.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
+++ b/Scalar.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
@@ -1010,7 +1010,7 @@ namespace Scalar.FunctionalTests.Tests.GitCommands
         [TestCase]
         public void UseAlias()
         {
-            this.ValidateGitCommand("config --local alias.potato status");
+            this.ValidateGitCommand("config --local alias.potato \"status --porcelain=v2\"");
             this.ValidateGitCommand("potato");
         }
 

--- a/Scalar.FunctionalTests/Tools/GitHelpers.cs
+++ b/Scalar.FunctionalTests/Tools/GitHelpers.cs
@@ -61,6 +61,11 @@ namespace Scalar.FunctionalTests.Tools
             string command,
             params object[] args)
         {
+            bool isStatus = command.StartsWith("status");
+            // Avoid sparse-checkout percentage in "status" calls.
+            if (isStatus) {
+                command = command + " --porcelain=v2";
+            }
             command = string.Format(command, args);
             string controlRepoRoot = controlGitRepo.RootPath;
             string scalarRepoRoot = enlistment.RepoRoot;
@@ -77,7 +82,7 @@ namespace Scalar.FunctionalTests.Tools
             LinesShouldMatch(command + " Errors Lines", expectedResult.Errors, actualResult.Errors);
             LinesShouldMatch(command + " Output Lines", expectedResult.Output, actualResult.Output);
 
-            if (command != "status")
+            if (!isStatus)
             {
                 ValidateGitCommand(enlistment, controlGitRepo, "status");
             }


### PR DESCRIPTION
The sparse-index feature will make interacting with sparse-checkouts much faster. The feature is still in the works, so start testing the pull requests that are merging into `vfs-2.31.1-exp` in `microsoft/git`.

The Git version is from this PR: microsoft/git#361