### PR TITLE
ScalarCloneFromGitHub: use 'for-tests' branch

### DIFF
--- a/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/ScalarCloneFromGithub.cs
+++ b/Scalar.FunctionalTests/Tests/MultiEnlistmentTests/ScalarCloneFromGithub.cs
@@ -25,7 +25,7 @@ namespace Scalar.FunctionalTests.Tests.MultiEnlistmentTests
         {
             ScalarFunctionalTestEnlistment enlistment = this.CreateNewEnlistment(
                                                                 url: MicrosoftScalarHttp,
-                                                                branch: "main",
+                                                                branch: "for-tests",
                                                                 fullClone: false);
 
             VerifyPartialCloneBehavior(enlistment);


### PR DESCRIPTION
The 'main' branch no longer contains the expected directories.