### PR TITLE
Update Git to a version that retries fetches

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
        VFS for Git (which is less flexible). Only update that version if we rely upon a
        new command-line interface in Git or if there is a truly broken interaction.
     -->
-    <GitPackageVersion>2.20210610.2</GitPackageVersion>
+    <GitPackageVersion>2.20210618.1-pr</GitPackageVersion>
     <MinimumGitVersion>v2.25.0.vfs.1.1</MinimumGitVersion>
 
     <WatchmanPackageUrl>https://github.com/facebook/watchman/releases/download/v2020.08.03.00/watchman-v2020.08.03.00-windows.zip</WatchmanPackageUrl>


### PR DESCRIPTION
This uses a `-pr` build, but we can relax that now that we are not shipping from this repository any more.

This version specifically includes microsoft/git#378 which retries fetches. This will unblock changes such as #513 which are failing with this rather frequent flakiness.