### PR TITLE
SparseSetTests: Ensure no edits remain before merge

### DIFF
--- a/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/SparseSetTests.cs
+++ b/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/SparseSetTests.cs
@@ -350,6 +350,7 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
             string conflictTargetBranch = "FunctionalTests/20170206_Conflict_Target";
             GitProcess.Invoke(this.Enlistment.RepoRoot, $"checkout {conflictTargetBranch}");
             GitProcess.Invoke(this.Enlistment.RepoRoot, $"checkout {conflictSourceBranch}");
+            GitProcess.InvokeProcess(this.Enlistment.RepoRoot, $"reset --hard");
 
             ProcessResult checkoutResult = GitProcess.InvokeProcess(this.Enlistment.RepoRoot, $"merge {conflictTargetBranch}");
             checkoutResult.Output.ShouldContain("Merge conflict");


### PR DESCRIPTION
Something strange happens with the MergeChangesOutOfTheConeWithConflict
when run in sequence with the other tests in this class. Some edited
files from previous tests cause confusion when running 'git merge'.

For some reason, this is causing a behavior change with the
sparse-index, but it seems that either behavior would be acceptable
here.

Another thing we could do is remove the `ShouldContain("Merge conflict")`
line and the test passes that way, too. This seems like a more robust
solution.

This will resolve the last failing test in microsoft/git#388 for Linux and macOS.

There is one more strange error happening on Windows. Will investigate.