### PR TITLE
GitCommandsTests: use 'git add --sparse'

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ ubuntu-20.04, windows-2019, macos-10.15]
         features: [ignored]
 
     env:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,7 +43,7 @@
        VFS for Git (which is less flexible). Only update that version if we rely upon a
        new command-line interface in Git or if there is a truly broken interaction.
     -->
-    <GitPackageVersion>2.20210618.1-pr</GitPackageVersion>
+    <GitPackageVersion>2.20211031.5-pr</GitPackageVersion>
     <MinimumGitVersion>v2.25.0.vfs.1.1</MinimumGitVersion>
 
     <WatchmanPackageUrl>https://github.com/facebook/watchman/releases/download/v2020.08.03.00/watchman-v2020.08.03.00-windows.zip</WatchmanPackageUrl>

--- a/Scalar.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
+++ b/Scalar.FunctionalTests/Tests/GitCommands/GitCommandsTests.cs
@@ -480,7 +480,7 @@ namespace Scalar.FunctionalTests.Tests.GitCommands
             Path.Combine(scalarFolderPath, filename).ShouldBeAFile(this.FileSystem).WithContents(testFileContents);
 
             this.ValidateGitCommand("status");
-            this.ValidateGitCommand("add .");
+            this.ValidateGitCommand("add --sparse .");
             this.RunGitCommand("commit -m \"Change for MoveFolderFromOutsideRepoToInsideRepoAndAdd\"");
             this.ValidateGitCommand("checkout " + this.ControlGitRepo.Commitish);
         }


### PR DESCRIPTION
See microsoft/git#460 for a failing test due to changes to how `git add` works upstream.