### PR TITLE
DiagnoseTests: make failure more helpful

### DIFF
--- a/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/DiagnoseTests.cs
+++ b/Scalar.FunctionalTests/Tests/EnlistmentPerFixture/DiagnoseTests.cs
@@ -26,7 +26,7 @@ namespace Scalar.FunctionalTests.Tests.EnlistmentPerFixture
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
                 !output.Contains(zipFilePath))
                 zipFilePath = zipFilePath.Replace('\\', '/');
-            output.Contains(zipFilePath).ShouldEqual(true);
+            output.ShouldContain(zipFilePath);
         }
     }
 }


### PR DESCRIPTION
I recently ran into [hard-to-diagnose problems](https://github.com/dscho/git/actions/runs/2297168173), thanks to a construct that fails to provide helpful information in case of a regression. This fixes that.