### PR TITLE
ScalarProcess: print stderr to result string

### DIFF
--- a/Scalar.FunctionalTests/Tools/ScalarProcess.cs
+++ b/Scalar.FunctionalTests/Tools/ScalarProcess.cs
@@ -137,6 +137,8 @@ namespace Scalar.FunctionalTests.Tools
             processInfo.WindowStyle = ProcessWindowStyle.Hidden;
             processInfo.UseShellExecute = false;
             processInfo.RedirectStandardOutput = true;
+            processInfo.RedirectStandardError = true;
+
             if (standardInput != null)
             {
                 processInfo.RedirectStandardInput = true;
@@ -161,6 +163,7 @@ namespace Scalar.FunctionalTests.Tools
                 }
 
                 string result = process.StandardOutput.ReadToEnd();
+                result += process.StandardError.ReadToEnd();
                 process.WaitForExit();
 
                 if (expectedExitCode >= SuccessExitCode)


### PR DESCRIPTION
Include stderr printouts in the 'result' string returned by 'CallScalar()'
to allow tests to parse printouts that have been changed to stderr while
upstreaming scalar.

See https://github.com/microsoft/git/pull/479#issuecomment-1161766799 for more details