### PR TITLE
Remove unused packages that have vulnerable dependencies

### DIFF
--- a/Dependencies.props
+++ b/Dependencies.props
@@ -3,8 +3,6 @@
   <ItemGroup>
     <!-- Product dependencies -->
     <PackageReference Update="CommandLineParser"               Version="2.6.0"  />
-    <PackageReference Update="Microsoft.PowerShell.SDK"        Version="6.2.2"  />
-    <PackageReference Update="Microsoft.Windows.Compatibility" Version="2.1.1"  />
     <PackageReference Update="Newtonsoft.Json"                 Version="13.0.1" />
     <PackageReference Update="NuGet.CommandLine"               Version="5.4.0"  />
     <PackageReference Update="NuGet.Commands"                  Version="5.4.0"  />

--- a/Scalar.FunctionalTests/Scalar.FunctionalTests.csproj
+++ b/Scalar.FunctionalTests/Scalar.FunctionalTests.csproj
@@ -12,7 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="NUnitLite" />
   </ItemGroup>


### PR DESCRIPTION
We got an internal report for a vulnerability:

```
  A remote code execution vulnerability exists when parsing certain
  types of graphics files. This vulnerability only exists on systems
  running on MacOS or Linux. This CVE ID is unique from CVE-2021-26701.
```

The report also included this statement:

```
  Root dependencies for System.Drawing.Common

  Microsoft.PowerShell.SDK 6.2.2
  Microsoft.Windows.Compatibility 2.1.1
```

It turns out that we don't need these dependencies anymore, so we can remove them.