### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/homebrew-release.yml
+++ b/.github/workflows/homebrew-release.yml
@@ -10,7 +10,7 @@ jobs:
     - id: version
       name: Compute version number
       run: |
-        echo "::set-output name=result::$(echo $GITHUB_REF | sed -e "s/^refs\/tags\/v//")"
+        echo "result=$(echo $GITHUB_REF | sed -e "s/^refs\/tags\/v//")" >> $GITHUB_OUTPUT
     - id: hash
       name: Compute release asset hash
       uses: mjcheetham/asset-hash@v1


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

Resolve #530 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find .github/workflows -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```
