### PR TITLE
Tests: disable advice message

### DIFF
--- a/Scalar.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
+++ b/Scalar.FunctionalTests/Tests/GitCommands/GitRepoTests.cs
@@ -199,6 +199,7 @@ namespace Scalar.FunctionalTests.Tests.GitCommands
                                                                 fullClone: this.validateWorkingTree != Settings.ValidateWorkingTreeMode.SparseMode);
             GitProcess.Invoke(this.Enlistment.RepoRoot, "config core.editor true");
             GitProcess.Invoke(this.Enlistment.RepoRoot, "config advice.statusUoption false");
+            GitProcess.Invoke(this.Enlistment.RepoRoot, "config advice.sparseIndexExpanded false");
             this.ControlGitRepo = ControlGitRepo.Create(commitish);
             this.ControlGitRepo.Initialize();
 

--- a/Scalar.FunctionalTests/Tools/ControlGitRepo.cs
+++ b/Scalar.FunctionalTests/Tools/ControlGitRepo.cs
@@ -54,6 +54,7 @@ namespace Scalar.FunctionalTests.Tools
             GitProcess.Invoke(this.RootPath, "config merge.stat false");
             GitProcess.Invoke(this.RootPath, "config merge.renames false");
             GitProcess.Invoke(this.RootPath, "config advice.statusUoption false");
+            GitProcess.Invoke(this.RootPath, "config advice.sparseIndexExpanded false");
             GitProcess.Invoke(this.RootPath, "config core.abbrev 40");
             GitProcess.Invoke(this.RootPath, "config pack.useSparse true");
             GitProcess.Invoke(this.RootPath, "config reset.quiet true");


### PR DESCRIPTION
A new advice message is coming to Git and `microsoft/git` which can lead to different `stderr` in an expected way.

By configuring this advice message to be quiet, we can match the behavior across full and sparse Scalar enlistments.