### PR TITLE
ScalarFunctionalTestEnlistment: one more advice config setting

### DIFF
--- a/Scalar.FunctionalTests/Tools/ScalarFunctionalTestEnlistment.cs
+++ b/Scalar.FunctionalTests/Tools/ScalarFunctionalTestEnlistment.cs
@@ -276,6 +276,7 @@ namespace Scalar.FunctionalTests.Tools
             GitProcess.Invoke(this.RepoRoot, "checkout " + this.Commitish);
             GitProcess.Invoke(this.RepoRoot, "branch --unset-upstream");
             GitProcess.Invoke(this.RepoRoot, "config core.abbrev 40");
+            GitProcess.Invoke(this.RepoRoot, "config advice.sparseIndexExpanded false");
             GitProcess.Invoke(this.RepoRoot, "config user.name \"Functional Test User\"");
             GitProcess.Invoke(this.RepoRoot, "config user.email \"functional@test.com\"");
         }


### PR DESCRIPTION
I missed one possible place for a repo to be created and have config set. Prepare for the new advice message by disabling it.